### PR TITLE
feat(workflows): add shared linters

### DIFF
--- a/.github/workflows/lint-action-shellcheck.yml
+++ b/.github/workflows/lint-action-shellcheck.yml
@@ -1,14 +1,14 @@
-name: Yamllint
+name: Action Shellcheck
 
 on:
   workflow_call:
     outputs:
       comment_body_base64:
-        description: Base64-encoded markdown section for yamllint
-        value: ${{ jobs.yamllint.outputs.comment_body_base64 }}
+        description: Base64-encoded markdown section for action-shellcheck
+        value: ${{ jobs.action_shellcheck.outputs.comment_body_base64 }}
       conclusion:
         description: success or failure
-        value: ${{ jobs.yamllint.outputs.conclusion }}
+        value: ${{ jobs.action_shellcheck.outputs.conclusion }}
     secrets:
       CHECKER_APP_ID:
         required: true
@@ -18,10 +18,10 @@ on:
 permissions: {}
 
 jobs:
-  yamllint:
+  action_shellcheck:
     uses: ./.github/workflows/lint-common.yml
     secrets:
       CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
       CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
     with:
-      linter-name: yamllint
+      linter-name: action-shellcheck

--- a/.github/workflows/lint-actionlint.yml
+++ b/.github/workflows/lint-actionlint.yml
@@ -20,6 +20,8 @@ permissions: {}
 jobs:
   actionlint:
     uses: ./.github/workflows/lint-common.yml
-    secrets: inherit
+    secrets:
+      CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
+      CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
     with:
       linter-name: actionlint

--- a/.github/workflows/lint-biome.yml
+++ b/.github/workflows/lint-biome.yml
@@ -1,14 +1,14 @@
-name: Yamllint
+name: Biome
 
 on:
   workflow_call:
     outputs:
       comment_body_base64:
-        description: Base64-encoded markdown section for yamllint
-        value: ${{ jobs.yamllint.outputs.comment_body_base64 }}
+        description: Base64-encoded markdown section for biome
+        value: ${{ jobs.biome.outputs.comment_body_base64 }}
       conclusion:
         description: success or failure
-        value: ${{ jobs.yamllint.outputs.conclusion }}
+        value: ${{ jobs.biome.outputs.conclusion }}
     secrets:
       CHECKER_APP_ID:
         required: true
@@ -18,10 +18,10 @@ on:
 permissions: {}
 
 jobs:
-  yamllint:
+  biome:
     uses: ./.github/workflows/lint-common.yml
     secrets:
       CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
       CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
     with:
-      linter-name: yamllint
+      linter-name: biome

--- a/.github/workflows/lint-common.yml
+++ b/.github/workflows/lint-common.yml
@@ -23,6 +23,7 @@ permissions: {}
 
 jobs:
   run-linter:
+    environment: checker-app
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:

--- a/.github/workflows/lint-common.yml
+++ b/.github/workflows/lint-common.yml
@@ -23,7 +23,6 @@ permissions: {}
 
 jobs:
   run-linter:
-    environment: checker-app
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:

--- a/.github/workflows/lint-common.yml
+++ b/.github/workflows/lint-common.yml
@@ -24,6 +24,7 @@ permissions: {}
 jobs:
   run-linter:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       comment_body_base64: ${{ steps.publish_outputs.outputs.comment_body_base64 }}
       conclusion: ${{ steps.publish_outputs.outputs.conclusion }}
@@ -87,6 +88,7 @@ jobs:
         with:
           app-id: ${{ secrets.CHECKER_APP_ID }}
           owner: ${{ steps.decode_context.outputs.source-owner }}
+          permission-contents: read
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_context.outputs.source-repo }}
 
@@ -98,8 +100,14 @@ jobs:
           repository: ${{ steps.decode_context.outputs.source-owner }}/${{ steps.decode_context.outputs.source-repo }}
           token: ${{ steps.get_source_token.outputs.token }}
 
+      - name: Set up Node.js
+        if: ${{ inputs.linter-name == 'biome' || inputs.linter-name == 'spectral' || inputs.linter-name == 'taplo' }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "24"
+
       - name: Set up Python
-        if: ${{ inputs.linter-name == 'yamllint' }}
+        if: ${{ inputs.linter-name == 'yamllint' || inputs.linter-name == 'zizmor' }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.x"
@@ -121,8 +129,20 @@ jobs:
 
           for path in files:
               lower_path = path.lower()
-              if linter_name == "actionlint":
+              if linter_name in {"actionlint", "ghalint", "zizmor"}:
                   if lower_path.startswith(".github/workflows/") and lower_path.endswith((".yaml", ".yml")):
+                      print(path)
+              elif linter_name == "action-shellcheck":
+                  if lower_path.endswith((".bash", ".sh")):
+                      print(path)
+              elif linter_name == "biome":
+                  if lower_path.endswith((".cjs", ".cts", ".js", ".json", ".jsonc", ".jsx", ".mjs", ".mts", ".ts", ".tsx")):
+                      print(path)
+              elif linter_name == "spectral":
+                  if lower_path.endswith((".json", ".yaml", ".yml")):
+                      print(path)
+              elif linter_name == "taplo":
+                  if lower_path.endswith(".toml"):
                       print(path)
               elif linter_name == "yamllint":
                   if lower_path.endswith((".yaml", ".yml")):
@@ -138,6 +158,7 @@ jobs:
         id: install_tool
         if: ${{ steps.select_files.outputs.count != '0' }}
         env:
+          GH_TOKEN: ${{ github.token }}
           LINTER_NAME: ${{ inputs.linter-name }}
         run: |
           case "$LINTER_NAME" in
@@ -146,8 +167,40 @@ jobs:
                 -o "$RUNNER_TEMP/download-actionlint.bash"
               bash "$RUNNER_TEMP/download-actionlint.bash" latest
               ;;
+            action-shellcheck)
+              if command -v shellcheck >/dev/null 2>&1; then
+                shellcheck --version
+              else
+                sudo apt-get update
+                sudo apt-get install -y shellcheck
+              fi
+              ;;
+            biome)
+              npm install --no-audit --no-fund --prefix "$RUNNER_TEMP/npm-tools" @biomejs/biome
+              echo "$RUNNER_TEMP/npm-tools/node_modules/.bin" >> "$GITHUB_PATH"
+              ;;
+            ghalint)
+              version=$(gh release view --repo suzuki-shunsuke/ghalint --json tagName --jq .tagName)
+              asset="ghalint_${version#v}_linux_amd64.tar.gz"
+              mkdir -p "$RUNNER_TEMP/bin"
+              gh release download "$version" --repo suzuki-shunsuke/ghalint --pattern "$asset" --dir "$RUNNER_TEMP"
+              tar -xzf "$RUNNER_TEMP/$asset" -C "$RUNNER_TEMP/bin"
+              chmod +x "$RUNNER_TEMP/bin/ghalint"
+              echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+              ;;
+            spectral)
+              npm install --no-audit --no-fund --prefix "$RUNNER_TEMP/npm-tools" @stoplight/spectral-cli
+              echo "$RUNNER_TEMP/npm-tools/node_modules/.bin" >> "$GITHUB_PATH"
+              ;;
+            taplo)
+              npm install --no-audit --no-fund --prefix "$RUNNER_TEMP/npm-tools" @taplo/cli
+              echo "$RUNNER_TEMP/npm-tools/node_modules/.bin" >> "$GITHUB_PATH"
+              ;;
             yamllint)
               python -m pip install --upgrade pip yamllint
+              ;;
+            zizmor)
+              python -m pip install --upgrade pip zizmor
               ;;
             *)
               echo "unsupported linter: $LINTER_NAME" >&2
@@ -164,9 +217,76 @@ jobs:
           set +e
           mapfile -t files < "$RUNNER_TEMP/selected-files.txt"
 
+          copy_selected_files_to_root() {
+            local target_root=$1
+            shift
+
+            for file in "$@"; do
+              local destination="$target_root/$file"
+              mkdir -p "$(dirname "$destination")"
+              cp "$file" "$destination"
+            done
+          }
+
+          copy_ghalint_config() {
+            local target_root=$1
+            local config_path
+
+            for config_path in \
+              .ghalint.yaml \
+              .ghalint.yml \
+              ghalint.yaml \
+              ghalint.yml \
+              .github/ghalint.yaml \
+              .github/ghalint.yml
+            do
+              if [ -f "$config_path" ]; then
+                local destination="$target_root/$config_path"
+                mkdir -p "$(dirname "$destination")"
+                cp "$config_path" "$destination"
+                return 0
+              fi
+            done
+          }
+
           case "$LINTER_NAME" in
           actionlint)
             ./actionlint "${files[@]}" > "$RUNNER_TEMP/linter-output.txt" 2>&1
+            ;;
+          action-shellcheck)
+            shellcheck --external-sources --format=gcc "${files[@]}" > "$RUNNER_TEMP/linter-output.txt" 2>&1
+            ;;
+          biome)
+            biome lint --colors=off --files-ignore-unknown=true "${files[@]}" > "$RUNNER_TEMP/linter-output.txt" 2>&1
+            ;;
+          ghalint)
+            temp_repo="$RUNNER_TEMP/ghalint-repo"
+            rm -rf "$temp_repo"
+            mkdir -p "$temp_repo"
+            copy_selected_files_to_root "$temp_repo" "${files[@]}"
+            copy_ghalint_config "$temp_repo"
+            (
+              cd "$temp_repo"
+              GHALINT_LOG_COLOR=never ghalint run
+            ) > "$RUNNER_TEMP/linter-output.txt" 2>&1
+            ;;
+          spectral)
+            spectral_args=(lint --fail-severity warn --ignore-unknown-format)
+            if [ ! -f .spectral.yaml ] && [ ! -f .spectral.yml ] && [ ! -f .spectral.json ] && [ ! -f .spectral.js ]; then
+              cat > "$RUNNER_TEMP/default-spectral.yaml" <<'EOF'
+          extends:
+            - spectral:oas
+            - spectral:asyncapi
+          EOF
+              spectral_args+=(--ruleset "$RUNNER_TEMP/default-spectral.yaml")
+            fi
+            spectral "${spectral_args[@]}" "${files[@]}" > "$RUNNER_TEMP/linter-output.txt" 2>&1
+            ;;
+          taplo)
+            {
+              taplo --colors never lint "${files[@]}" &&
+              taplo --colors never format --check "${files[@]}"
+            } > "$RUNNER_TEMP/linter-output.txt" 2>&1
             ;;
           yamllint)
             cat > "$RUNNER_TEMP/yamllint.yaml" <<'EOF'
@@ -179,6 +299,9 @@ jobs:
               check-keys: false
           EOF
             yamllint -c "$RUNNER_TEMP/yamllint.yaml" "${files[@]}" > "$RUNNER_TEMP/linter-output.txt" 2>&1
+            ;;
+          zizmor)
+            zizmor --offline --color=never --format=plain "${files[@]}" > "$RUNNER_TEMP/linter-output.txt" 2>&1
             ;;
           *)
             echo "unsupported linter: $LINTER_NAME" >&2
@@ -223,6 +346,46 @@ jobs:
                   "success": "✅ No issues found in {count} changed GitHub Actions workflow file(s).",
                   "failure": "❌ Issues found in {count} changed GitHub Actions workflow file(s).",
               },
+              "action-shellcheck": {
+                  "details_fallback": "action-shellcheck did not produce diagnostic output before the job failed.",
+                  "heading": "### action-shellcheck",
+                  "infra_failure": "❌ The `action-shellcheck` workflow failed before producing a detailed report. See the workflow logs.",
+                  "no_files": "No matching shell script files were selected for `action-shellcheck`.",
+                  "success": "✅ No issues found in {count} changed shell script file(s).",
+                  "failure": "❌ Issues found in {count} changed shell script file(s).",
+              },
+              "biome": {
+                  "details_fallback": "Biome did not produce diagnostic output before the job failed.",
+                  "heading": "### biome",
+                  "infra_failure": "❌ The `biome` workflow failed before producing a detailed report. See the workflow logs.",
+                  "no_files": "No matching JavaScript, TypeScript, or JSON files were selected for `biome`.",
+                  "success": "✅ No issues found in {count} changed JavaScript, TypeScript, or JSON file(s).",
+                  "failure": "❌ Issues found in {count} changed JavaScript, TypeScript, or JSON file(s).",
+              },
+              "ghalint": {
+                  "details_fallback": "ghalint did not produce diagnostic output before the job failed.",
+                  "heading": "### ghalint",
+                  "infra_failure": "❌ The `ghalint` workflow failed before producing a detailed report. See the workflow logs.",
+                  "no_files": "No matching GitHub Actions workflow files were selected for `ghalint`.",
+                  "success": "✅ No issues found in {count} changed GitHub Actions workflow file(s).",
+                  "failure": "❌ Issues found in {count} changed GitHub Actions workflow file(s).",
+              },
+              "spectral": {
+                  "details_fallback": "spectral did not produce diagnostic output before the job failed.",
+                  "heading": "### spectral",
+                  "infra_failure": "❌ The `spectral` workflow failed before producing a detailed report. See the workflow logs.",
+                  "no_files": "No matching YAML or JSON files were selected for `spectral`.",
+                  "success": "✅ No issues found in {count} changed YAML or JSON file(s) checked by `spectral`.",
+                  "failure": "❌ Issues found in {count} changed YAML or JSON file(s) checked by `spectral`.",
+              },
+              "taplo": {
+                  "details_fallback": "Taplo did not produce diagnostic output before the job failed.",
+                  "heading": "### taplo",
+                  "infra_failure": "❌ The `taplo` workflow failed before producing a detailed report. See the workflow logs.",
+                  "no_files": "No matching TOML files were selected for `taplo`.",
+                  "success": "✅ No issues found in {count} changed TOML file(s).",
+                  "failure": "❌ Issues found in {count} changed TOML file(s).",
+              },
               "yamllint": {
                   "details_fallback": "yamllint did not produce diagnostic output before the job failed.",
                   "heading": "### yamllint",
@@ -230,6 +393,14 @@ jobs:
                   "no_files": "No matching YAML files were selected for `yamllint`.",
                   "success": "✅ No issues found in {count} changed YAML file(s).",
                   "failure": "❌ Issues found in {count} changed YAML file(s).",
+              },
+              "zizmor": {
+                  "details_fallback": "zizmor did not produce diagnostic output before the job failed.",
+                  "heading": "### zizmor",
+                  "infra_failure": "❌ The `zizmor` workflow failed before producing a detailed report. See the workflow logs.",
+                  "no_files": "No matching GitHub Actions workflow files were selected for `zizmor`.",
+                  "success": "✅ No issues found in {count} changed GitHub Actions workflow file(s).",
+                  "failure": "❌ Issues found in {count} changed GitHub Actions workflow file(s).",
               },
           }
 

--- a/.github/workflows/lint-ghalint.yml
+++ b/.github/workflows/lint-ghalint.yml
@@ -1,14 +1,14 @@
-name: Yamllint
+name: Ghalint
 
 on:
   workflow_call:
     outputs:
       comment_body_base64:
-        description: Base64-encoded markdown section for yamllint
-        value: ${{ jobs.yamllint.outputs.comment_body_base64 }}
+        description: Base64-encoded markdown section for ghalint
+        value: ${{ jobs.ghalint.outputs.comment_body_base64 }}
       conclusion:
         description: success or failure
-        value: ${{ jobs.yamllint.outputs.conclusion }}
+        value: ${{ jobs.ghalint.outputs.conclusion }}
     secrets:
       CHECKER_APP_ID:
         required: true
@@ -18,10 +18,10 @@ on:
 permissions: {}
 
 jobs:
-  yamllint:
+  ghalint:
     uses: ./.github/workflows/lint-common.yml
     secrets:
       CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
       CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
     with:
-      linter-name: yamllint
+      linter-name: ghalint

--- a/.github/workflows/lint-spectral.yml
+++ b/.github/workflows/lint-spectral.yml
@@ -1,14 +1,14 @@
-name: Yamllint
+name: Spectral
 
 on:
   workflow_call:
     outputs:
       comment_body_base64:
-        description: Base64-encoded markdown section for yamllint
-        value: ${{ jobs.yamllint.outputs.comment_body_base64 }}
+        description: Base64-encoded markdown section for spectral
+        value: ${{ jobs.spectral.outputs.comment_body_base64 }}
       conclusion:
         description: success or failure
-        value: ${{ jobs.yamllint.outputs.conclusion }}
+        value: ${{ jobs.spectral.outputs.conclusion }}
     secrets:
       CHECKER_APP_ID:
         required: true
@@ -18,10 +18,10 @@ on:
 permissions: {}
 
 jobs:
-  yamllint:
+  spectral:
     uses: ./.github/workflows/lint-common.yml
     secrets:
       CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
       CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
     with:
-      linter-name: yamllint
+      linter-name: spectral

--- a/.github/workflows/lint-taplo.yml
+++ b/.github/workflows/lint-taplo.yml
@@ -1,14 +1,14 @@
-name: Yamllint
+name: Taplo
 
 on:
   workflow_call:
     outputs:
       comment_body_base64:
-        description: Base64-encoded markdown section for yamllint
-        value: ${{ jobs.yamllint.outputs.comment_body_base64 }}
+        description: Base64-encoded markdown section for taplo
+        value: ${{ jobs.taplo.outputs.comment_body_base64 }}
       conclusion:
         description: success or failure
-        value: ${{ jobs.yamllint.outputs.conclusion }}
+        value: ${{ jobs.taplo.outputs.conclusion }}
     secrets:
       CHECKER_APP_ID:
         required: true
@@ -18,10 +18,10 @@ on:
 permissions: {}
 
 jobs:
-  yamllint:
+  taplo:
     uses: ./.github/workflows/lint-common.yml
     secrets:
       CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
       CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
     with:
-      linter-name: yamllint
+      linter-name: taplo

--- a/.github/workflows/lint-zizmor.yml
+++ b/.github/workflows/lint-zizmor.yml
@@ -1,14 +1,14 @@
-name: Yamllint
+name: Zizmor
 
 on:
   workflow_call:
     outputs:
       comment_body_base64:
-        description: Base64-encoded markdown section for yamllint
-        value: ${{ jobs.yamllint.outputs.comment_body_base64 }}
+        description: Base64-encoded markdown section for zizmor
+        value: ${{ jobs.zizmor.outputs.comment_body_base64 }}
       conclusion:
         description: success or failure
-        value: ${{ jobs.yamllint.outputs.conclusion }}
+        value: ${{ jobs.zizmor.outputs.conclusion }}
     secrets:
       CHECKER_APP_ID:
         required: true
@@ -18,10 +18,10 @@ on:
 permissions: {}
 
 jobs:
-  yamllint:
+  zizmor:
     uses: ./.github/workflows/lint-common.yml
     secrets:
       CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
       CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
     with:
-      linter-name: yamllint
+      linter-name: zizmor

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -594,7 +594,6 @@ jobs:
 
       - name: Get PR repository checker token
         id: get_pr_token
-        if: ${{ steps.decode_repository_context.outputs.pr-is-current-repo != 'true' }}
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ secrets.CHECKER_APP_ID }}
@@ -602,6 +601,42 @@ jobs:
           permission-issues: write
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_repository_context.outputs.pr-repo }}
+
+      - name: Delete legacy workflow-authored PR comments
+        if: ${{ steps.decode_repository_context.outputs.pr-is-current-repo == 'true' }}
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          COMMENT_MARKER: '<!-- linter-service:results -->'
+          PR_NUMBER: ${{ needs.detect-targets.outputs.pull-request-number }}
+          PR_OWNER: ${{ steps.decode_repository_context.outputs.pr-owner }}
+          PR_REPO: ${{ steps.decode_repository_context.outputs.pr-repo }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const marker = process.env.COMMENT_MARKER;
+            const owner = process.env.PR_OWNER;
+            const repo = process.env.PR_REPO;
+            const issueNumber = Number(process.env.PR_NUMBER);
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            const legacyComments = comments.filter((comment) =>
+              comment.body?.includes(marker) &&
+              comment.user?.login === "github-actions[bot]",
+            );
+
+            for (const comment of legacyComments) {
+              await github.rest.issues.deleteComment({
+                owner,
+                repo,
+                comment_id: comment.id,
+              });
+            }
 
       - name: Get source repository checker token
         id: get_source_token
@@ -707,7 +742,7 @@ jobs:
           PR_OWNER: ${{ steps.decode_repository_context.outputs.pr-owner }}
           PR_REPO: ${{ steps.decode_repository_context.outputs.pr-repo }}
         with:
-          github-token: ${{ steps.decode_repository_context.outputs.pr-is-current-repo == 'true' && github.token || steps.get_pr_token.outputs.token }}
+          github-token: ${{ steps.get_pr_token.outputs.token }}
           script: |
             const fs = require("node:fs");
 

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -603,42 +603,6 @@ jobs:
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_repository_context.outputs.pr-repo }}
 
-      - name: Delete legacy workflow-authored PR comments
-        if: ${{ steps.decode_repository_context.outputs.pr-is-current-repo == 'true' }}
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        env:
-          COMMENT_MARKER: '<!-- linter-service:results -->'
-          PR_NUMBER: ${{ needs.detect-targets.outputs.pull-request-number }}
-          PR_OWNER: ${{ steps.decode_repository_context.outputs.pr-owner }}
-          PR_REPO: ${{ steps.decode_repository_context.outputs.pr-repo }}
-        with:
-          github-token: ${{ github.token }}
-          script: |
-            const marker = process.env.COMMENT_MARKER;
-            const owner = process.env.PR_OWNER;
-            const repo = process.env.PR_REPO;
-            const issueNumber = Number(process.env.PR_NUMBER);
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number: issueNumber,
-              per_page: 100,
-            });
-
-            const legacyComments = comments.filter((comment) =>
-              comment.body?.includes(marker) &&
-              comment.user?.login === "github-actions[bot]",
-            );
-
-            for (const comment of legacyComments) {
-              await github.rest.issues.deleteComment({
-                owner,
-                repo,
-                comment_id: comment.id,
-              });
-            }
-
       - name: Get source repository checker token
         id: get_source_token
         if: ${{ steps.decode_repository_context.outputs.source-is-current-repo != 'true' }}
@@ -739,6 +703,7 @@ jobs:
         env:
           COMMENT_FILE: ${{ runner.temp }}/combined-linter-comment.md
           COMMENT_MARKER: '<!-- linter-service:results -->'
+          PREFER_APP_AUTHORED_COMMENT: ${{ steps.get_pr_token.outcome == 'success' && 'true' || 'false' }}
           PR_NUMBER: ${{ needs.detect-targets.outputs.pull-request-number }}
           PR_OWNER: ${{ steps.decode_repository_context.outputs.pr-owner }}
           PR_REPO: ${{ steps.decode_repository_context.outputs.pr-repo }}
@@ -761,9 +726,13 @@ jobs:
                   "",
                 ].join("\n");
             const marker = process.env.COMMENT_MARKER;
+            const preferAppAuthoredComment =
+              process.env.PREFER_APP_AUTHORED_COMMENT === "true";
             const owner = process.env.PR_OWNER;
             const repo = process.env.PR_REPO;
             const issueNumber = Number(process.env.PR_NUMBER);
+            const isWorkflowAuthoredComment = (comment) =>
+              comment.user?.login === "github-actions[bot]";
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner,
@@ -772,7 +741,12 @@ jobs:
               per_page: 100,
             });
 
-            const existing = comments.find((comment) => comment.body?.includes(marker));
+            const matchingComments = comments.filter((comment) =>
+              comment.body?.includes(marker),
+            );
+            const existing = preferAppAuthoredComment
+              ? matchingComments.find((comment) => !isWorkflowAuthoredComment(comment))
+              : matchingComments.find((comment) => isWorkflowAuthoredComment(comment));
 
             if (existing) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -16,12 +16,11 @@ permissions: {}
 jobs:
   detect-targets:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
-      actionlint-selected: ${{ steps.collect.outputs.actionlint-selected }}
       pull-request-number: ${{ steps.collect.outputs.pull-request-number }}
       selected-linters-json: ${{ steps.collect.outputs.selected-linters-json }}
       skip-reason: ${{ steps.collect.outputs.skip-reason }}
-      yamllint-selected: ${{ steps.collect.outputs.yamllint-selected }}
     env:
       LINTER_DEFINITIONS_JSON: >-
         [
@@ -30,8 +29,32 @@ jobs:
             "patterns": ["^\\.github\\/workflows\\/.+\\.(?:yaml|yml)$"]
           },
           {
+            "name": "action-shellcheck",
+            "patterns": ["\\.(?:bash|sh)$"]
+          },
+          {
+            "name": "biome",
+            "patterns": ["\\.(?:cjs|cts|js|json|jsonc|jsx|mjs|mts|ts|tsx)$"]
+          },
+          {
+            "name": "ghalint",
+            "patterns": ["^\\.github\\/workflows\\/.+\\.(?:yaml|yml)$"]
+          },
+          {
+            "name": "spectral",
+            "patterns": ["\\.(?:json|yaml|yml)$"]
+          },
+          {
+            "name": "taplo",
+            "patterns": ["\\.toml$"]
+          },
+          {
             "name": "yamllint",
             "patterns": ["\\.(?:yaml|yml)$"]
+          },
+          {
+            "name": "zizmor",
+            "patterns": ["^\\.github\\/workflows\\/.+\\.(?:yaml|yml)$"]
           }
         ]
       PR_REPOSITORY_NAME: ${{ github.event_name == 'pull_request' && github.event.repository.name || github.event.client_payload.repository.name }}
@@ -75,6 +98,8 @@ jobs:
         with:
           app-id: ${{ secrets.CHECKER_APP_ID }}
           owner: ${{ env.PR_REPOSITORY_OWNER }}
+          permission-contents: read
+          permission-pull-requests: read
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ env.PR_REPOSITORY_NAME }}
 
@@ -147,11 +172,9 @@ jobs:
               }
 
               writeContext(contextValues);
-              core.setOutput("actionlint-selected", "false");
               core.setOutput("pull-request-number", String(pullNumber));
               core.setOutput("selected-linters-json", JSON.stringify([]));
               core.setOutput("skip-reason", skipReason);
-              core.setOutput("yamllint-selected", "false");
               return;
             }
 
@@ -222,17 +245,9 @@ jobs:
               source_owner: sourceOwner,
               source_repo: sourceRepo,
             });
-            core.setOutput(
-              "actionlint-selected",
-              String(selectedLinters.includes("actionlint")),
-            );
             core.setOutput("pull-request-number", String(pullNumber));
             core.setOutput("selected-linters-json", JSON.stringify(selectedLinters));
             core.setOutput("skip-reason", "");
-            core.setOutput(
-              "yamllint-selected",
-              String(selectedLinters.includes("yamllint")),
-            );
 
       - name: Report routing status
         env:
@@ -253,6 +268,7 @@ jobs:
     needs: detect-targets
     if: ${{ needs.detect-targets.outputs.selected-linters-json != '[]' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       checks: write
     steps:
@@ -326,6 +342,7 @@ jobs:
         with:
           app-id: ${{ secrets.CHECKER_APP_ID }}
           owner: ${{ steps.decode_source_context.outputs.source-owner }}
+          permission-checks: write
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_source_context.outputs.source-repo }}
 
@@ -399,26 +416,97 @@ jobs:
     needs:
       - detect-targets
       - notify-processing-started
-    if: ${{ needs.detect-targets.outputs.actionlint-selected == 'true' }}
+    if: ${{ contains(fromJSON(needs.detect-targets.outputs.selected-linters-json), 'actionlint') }}
     uses: ./.github/workflows/lint-actionlint.yml
-    secrets: inherit
+    secrets:
+      CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
+      CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
+
+  action_shellcheck:
+    needs:
+      - detect-targets
+      - notify-processing-started
+    if: ${{ contains(fromJSON(needs.detect-targets.outputs.selected-linters-json), 'action-shellcheck') }}
+    uses: ./.github/workflows/lint-action-shellcheck.yml
+    secrets:
+      CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
+      CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
+
+  biome:
+    needs:
+      - detect-targets
+      - notify-processing-started
+    if: ${{ contains(fromJSON(needs.detect-targets.outputs.selected-linters-json), 'biome') }}
+    uses: ./.github/workflows/lint-biome.yml
+    secrets:
+      CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
+      CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
+
+  ghalint:
+    needs:
+      - detect-targets
+      - notify-processing-started
+    if: ${{ contains(fromJSON(needs.detect-targets.outputs.selected-linters-json), 'ghalint') }}
+    uses: ./.github/workflows/lint-ghalint.yml
+    secrets:
+      CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
+      CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
+
+  spectral:
+    needs:
+      - detect-targets
+      - notify-processing-started
+    if: ${{ contains(fromJSON(needs.detect-targets.outputs.selected-linters-json), 'spectral') }}
+    uses: ./.github/workflows/lint-spectral.yml
+    secrets:
+      CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
+      CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
+
+  taplo:
+    needs:
+      - detect-targets
+      - notify-processing-started
+    if: ${{ contains(fromJSON(needs.detect-targets.outputs.selected-linters-json), 'taplo') }}
+    uses: ./.github/workflows/lint-taplo.yml
+    secrets:
+      CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
+      CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
 
   yamllint:
     needs:
       - detect-targets
       - notify-processing-started
-    if: ${{ needs.detect-targets.outputs.yamllint-selected == 'true' }}
+    if: ${{ contains(fromJSON(needs.detect-targets.outputs.selected-linters-json), 'yamllint') }}
     uses: ./.github/workflows/lint-yamllint.yml
-    secrets: inherit
+    secrets:
+      CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
+      CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
+
+  zizmor:
+    needs:
+      - detect-targets
+      - notify-processing-started
+    if: ${{ contains(fromJSON(needs.detect-targets.outputs.selected-linters-json), 'zizmor') }}
+    uses: ./.github/workflows/lint-zizmor.yml
+    secrets:
+      CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
+      CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
 
   publish-results:
     needs:
       - detect-targets
       - notify-processing-started
       - actionlint
+      - action_shellcheck
+      - biome
+      - ghalint
+      - spectral
+      - taplo
       - yamllint
+      - zizmor
     if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       checks: write
       issues: write
@@ -508,6 +596,7 @@ jobs:
         with:
           app-id: ${{ secrets.CHECKER_APP_ID }}
           owner: ${{ steps.decode_repository_context.outputs.pr-owner }}
+          permission-issues: write
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_repository_context.outputs.pr-repo }}
 
@@ -518,19 +607,15 @@ jobs:
         with:
           app-id: ${{ secrets.CHECKER_APP_ID }}
           owner: ${{ steps.decode_repository_context.outputs.source-owner }}
+          permission-checks: write
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_repository_context.outputs.source-repo }}
 
       - name: Prepare combined report
         id: prepare_report
         env:
-          ACTIONLINT_COMMENT_BODY_BASE64: ${{ needs.actionlint.outputs.comment_body_base64 }}
-          ACTIONLINT_CONCLUSION: ${{ needs.actionlint.outputs.conclusion }}
-          ACTIONLINT_JOB_RESULT: ${{ needs.actionlint.result }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
           SELECTED_LINTERS_JSON: ${{ needs.detect-targets.outputs.selected-linters-json }}
-          YAMLLINT_COMMENT_BODY_BASE64: ${{ needs.yamllint.outputs.comment_body_base64 }}
-          YAMLLINT_CONCLUSION: ${{ needs.yamllint.outputs.conclusion }}
-          YAMLLINT_JOB_RESULT: ${{ needs.yamllint.result }}
         run: |
           python3 - <<'PY'
           import base64
@@ -538,31 +623,23 @@ jobs:
           import os
           from pathlib import Path
 
+          needs_payload = json.loads(os.environ["NEEDS_JSON"])
           selected_linters = json.loads(os.environ["SELECTED_LINTERS_JSON"])
           runner_temp = Path(os.environ["RUNNER_TEMP"])
           comment_path = runner_temp / "combined-linter-comment.md"
-          env_map = {
-              "actionlint": {
-                  "comment_body_base64": os.environ.get("ACTIONLINT_COMMENT_BODY_BASE64", ""),
-                  "conclusion": os.environ.get("ACTIONLINT_CONCLUSION", ""),
-                  "job_result": os.environ.get("ACTIONLINT_JOB_RESULT", ""),
-              },
-              "yamllint": {
-                  "comment_body_base64": os.environ.get("YAMLLINT_COMMENT_BODY_BASE64", ""),
-                  "conclusion": os.environ.get("YAMLLINT_CONCLUSION", ""),
-                  "job_result": os.environ.get("YAMLLINT_JOB_RESULT", ""),
-              },
+          job_id_map = {
+              "action-shellcheck": "action_shellcheck",
           }
 
           sections = []
-          passed = 0
           failed = 0
 
           for linter_name in selected_linters:
-              linter_env = env_map.get(linter_name, {})
-              encoded_body = linter_env.get("comment_body_base64", "")
-              job_result = linter_env.get("job_result", "")
-              conclusion = linter_env.get("conclusion", "")
+              linter_job = needs_payload.get(job_id_map.get(linter_name, linter_name), {})
+              linter_outputs = linter_job.get("outputs", {})
+              encoded_body = linter_outputs.get("comment_body_base64", "")
+              job_result = linter_job.get("result", "")
+              conclusion = linter_outputs.get("conclusion", "")
 
               if encoded_body:
                   section = base64.b64decode(encoded_body).decode("utf-8").strip()
@@ -582,9 +659,7 @@ jobs:
 
               is_success = job_result not in {"failure", "cancelled"} and conclusion == "success"
 
-              if is_success:
-                  passed += 1
-              else:
+              if not is_success:
                   failed += 1
 
               if section:
@@ -752,6 +827,7 @@ jobs:
     needs: detect-targets
     if: ${{ needs.detect-targets.outputs.selected-linters-json == '[]' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Report skipped lint execution
         env:

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -15,7 +15,6 @@ permissions: {}
 
 jobs:
   detect-targets:
-    environment: checker-app
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -268,7 +267,6 @@ jobs:
   notify-processing-started:
     needs: detect-targets
     if: ${{ needs.detect-targets.outputs.selected-linters-json != '[]' }}
-    environment: checker-app
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -507,7 +505,6 @@ jobs:
       - yamllint
       - zizmor
     if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' }}
-    environment: checker-app
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -604,11 +604,7 @@ jobs:
           repositories: ${{ steps.decode_repository_context.outputs.pr-repo }}
 
       - name: Delete legacy workflow-authored PR comments
-        if: >-
-          ${{
-            steps.decode_repository_context.outputs.pr-is-current-repo == 'true' &&
-            steps.get_pr_token.outcome == 'success'
-          }}
+        if: ${{ steps.decode_repository_context.outputs.pr-is-current-repo == 'true' }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           COMMENT_MARKER: '<!-- linter-service:results -->'

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -599,7 +599,7 @@ jobs:
         with:
           app-id: ${{ secrets.CHECKER_APP_ID }}
           owner: ${{ steps.decode_repository_context.outputs.pr-owner }}
-          permission-issues: write
+          permission-pull-requests: write
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_repository_context.outputs.pr-repo }}
 

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -15,6 +15,7 @@ permissions: {}
 
 jobs:
   detect-targets:
+    environment: checker-app
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -267,6 +268,7 @@ jobs:
   notify-processing-started:
     needs: detect-targets
     if: ${{ needs.detect-targets.outputs.selected-linters-json != '[]' }}
+    environment: checker-app
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -505,6 +507,7 @@ jobs:
       - yamllint
       - zizmor
     if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' }}
+    environment: checker-app
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -594,6 +594,7 @@ jobs:
 
       - name: Get PR repository checker token
         id: get_pr_token
+        continue-on-error: ${{ steps.decode_repository_context.outputs.pr-is-current-repo == 'true' }}
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ secrets.CHECKER_APP_ID }}
@@ -603,7 +604,11 @@ jobs:
           repositories: ${{ steps.decode_repository_context.outputs.pr-repo }}
 
       - name: Delete legacy workflow-authored PR comments
-        if: ${{ steps.decode_repository_context.outputs.pr-is-current-repo == 'true' }}
+        if: >-
+          ${{
+            steps.decode_repository_context.outputs.pr-is-current-repo == 'true' &&
+            steps.get_pr_token.outcome == 'success'
+          }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           COMMENT_MARKER: '<!-- linter-service:results -->'
@@ -742,7 +747,11 @@ jobs:
           PR_OWNER: ${{ steps.decode_repository_context.outputs.pr-owner }}
           PR_REPO: ${{ steps.decode_repository_context.outputs.pr-repo }}
         with:
-          github-token: ${{ steps.get_pr_token.outputs.token }}
+          github-token: >-
+            ${{
+              steps.get_pr_token.outcome == 'success' && steps.get_pr_token.outputs.token ||
+              (steps.decode_repository_context.outputs.pr-is-current-repo == 'true' && github.token || '')
+            }}
           script: |
             const fs = require("node:fs");
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  secrets-outside-env:
+    ignore:
+      - lint-common.yml
+      - repository-dispatch.yml

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## 主な場所
 
-- `.github/workflows/repository-dispatch.yml`: `repository_dispatch` とこのリポジトリ自身の `pull_request` を受けて changed files から対象 linter を選ぶ router workflow
+- `.github/workflows/repository-dispatch.yml`: `repository_dispatch` とこのリポジトリ自身の `pull_request` を受けて changed files から対象 linter（`actionlint` / `action-shellcheck` / `biome` / `ghalint` / `spectral` / `taplo` / `yamllint` / `zizmor`）を選ぶ router workflow
 - `.github/workflows/lint-*.yml`: linter ごとの reusable workflow
 - `.github/workflows/ci.yml`: `worker/` 配下の型検査とテスト
 - `worker/`: GitHub App Webhook を受けて `repository_dispatch` を送る Cloudflare Worker

--- a/worker/README.md
+++ b/worker/README.md
@@ -105,7 +105,7 @@ wrangler secret put GITHUB_DISPATCH_REPO
 - `CHECKER_APP_ID`
 - `CHECKER_PRIVATE_KEY`
 
-これらの secrets を使う jobs は `checker-app` environment に関連付けています。必要に応じて GitHub 側でも同名 environment を作成し、protection rules や environment secrets に移行してください。
+これらは repository secrets として参照します。shared linter service では source / PR repository 向けの短命な installation token を都度発行する構成のため、GitHub Actions の environment は使いません。`secrets-outside-env` については `.github/zizmor.yml` で `lint-common.yml` と `repository-dispatch.yml` に限定して抑制しています。
 
 `repository_dispatch` 経由では workflow は `client_payload.repository.owner.login` と `client_payload.repository.name` を使って PR repository 用 token を取得し、PR details から head/source repository を解決します。このリポジトリ自身の `pull_request` event でも同じ workflow を直接実行でき、その場合は `github.event` から同等の情報を解決します。Worker は dispatch 先と同じ repository から来た webhook を送信せず、このリポジトリの PR が `pull_request` trigger と `repository_dispatch` trigger の両方で二重実行されることを避けます。
 

--- a/worker/README.md
+++ b/worker/README.md
@@ -108,7 +108,7 @@ wrangler secret put GITHUB_DISPATCH_REPO
 
 `repository_dispatch` 経由では workflow は `client_payload.repository.owner.login` と `client_payload.repository.name` を使って PR repository 用 token を取得し、PR details から head/source repository を解決します。このリポジトリ自身の `pull_request` event でも同じ workflow を直接実行でき、その場合は `github.event` から同等の情報を解決します。Worker は dispatch 先と同じ repository から来た webhook を送信せず、このリポジトリの PR が `pull_request` trigger と `repository_dispatch` trigger の両方で二重実行されることを避けます。
 
-また `repository_dispatch.yml` は declarative な linter 定義から changed files を評価し、共通の in-progress check run を作成してから reusable linter workflow を並列実行します。個別 workflow は lint 実行結果だけを返し、最終的な PR comment の upsert と processing check run の success/failure 更新は `repository_dispatch.yml` 側で一括して行います。このリポジトリの PR では `pull_request` trigger、外部リポジトリでは Worker からの `repository_dispatch` trigger を使います。private repository を前提に、workflow logs には repository 名や changed file 一覧、lint diagnostics を極力出さず、詳細は PR comment に寄せます。
+また `repository_dispatch.yml` は declarative な linter 定義から changed files を評価し、共通の in-progress check run を作成してから reusable linter workflow を並列実行します。現在の共通 linter は `actionlint`、`action-shellcheck`、`biome`、`ghalint`、`spectral`、`taplo`、`yamllint`、`zizmor` です。個別 workflow は lint 実行結果だけを返し、最終的な PR comment の upsert と processing check run の success/failure 更新は `repository_dispatch.yml` 側で一括して行います。このリポジトリの PR では `pull_request` trigger、外部リポジトリでは Worker からの `repository_dispatch` trigger を使います。private repository を前提に、workflow logs には repository 名や changed file 一覧、lint diagnostics を極力出さず、詳細は PR comment に寄せます。`spectral` は source repository に `.spectral.*` がない場合、OpenAPI / AsyncAPI 向けのデフォルト ruleset を使います。
 
 ## `repository_dispatch` payload
 

--- a/worker/README.md
+++ b/worker/README.md
@@ -106,6 +106,8 @@ wrangler secret put GITHUB_DISPATCH_REPO
 - `CHECKER_APP_ID`
 - `CHECKER_PRIVATE_KEY`
 
+これらの secrets を使う jobs は `checker-app` environment に関連付けています。必要に応じて GitHub 側でも同名 environment を作成し、protection rules や environment secrets に移行してください。
+
 `repository_dispatch` 経由では workflow は `client_payload.repository.owner.login` と `client_payload.repository.name` を使って PR repository 用 token を取得し、PR details から head/source repository を解決します。このリポジトリ自身の `pull_request` event でも同じ workflow を直接実行でき、その場合は `github.event` から同等の情報を解決します。Worker は dispatch 先と同じ repository から来た webhook を送信せず、このリポジトリの PR が `pull_request` trigger と `repository_dispatch` trigger の両方で二重実行されることを避けます。
 
 また `repository_dispatch.yml` は declarative な linter 定義から changed files を評価し、共通の in-progress check run を作成してから reusable linter workflow を並列実行します。現在の共通 linter は `actionlint`、`action-shellcheck`、`biome`、`ghalint`、`spectral`、`taplo`、`yamllint`、`zizmor` です。個別 workflow は lint 実行結果だけを返し、最終的な PR comment の upsert と processing check run の success/failure 更新は `repository_dispatch.yml` 側で一括して行います。このリポジトリの PR では `pull_request` trigger、外部リポジトリでは Worker からの `repository_dispatch` trigger を使います。private repository を前提に、workflow logs には repository 名や changed file 一覧、lint diagnostics を極力出さず、詳細は PR comment に寄せます。`spectral` は source repository に `.spectral.*` がない場合、OpenAPI / AsyncAPI 向けのデフォルト ruleset を使います。

--- a/worker/README.md
+++ b/worker/README.md
@@ -27,8 +27,7 @@ Worker はこの App の credentials を使って、このリポジトリへ `re
 - 権限:
   - `Checks: write`
   - `Contents: read`
-  - `Issues: write`
-  - `Pull requests: read`
+  - `Pull requests: write`
   - `Metadata: read`
 
 Cloudflare Worker はこの App の webhook secret で署名検証を行います。`repository_dispatch.yml` ではこの App の credentials を使って、PR metadata の取得、対象ソース repository の checkout、集約 PR comment の更新、共通 processing check run の更新を行います。


### PR DESCRIPTION
## Summary
- add shared workflow wrappers and router wiring for biome, taplo, spectral, zizmor, ghalint, and action-shellcheck
- extend the reusable lint workflow with on-demand tool install, file selection, explicit secret passing, pinned action SHAs, and aggregated reporting
- update repo docs to mention the expanded supported linter set
- rebase onto the latest `main` to resolve the PR conflict

## Validation
- `cd worker && npm run check`
- `actionlint /workspace/.github/workflows/*.yml`
- `ghalint run` on a temp repo containing the changed workflow files
- `podman run ... docker.io/cytopia/yamllint -c <repo-equivalent-config> <changed-workflow-files>`
- `git diff --check`