### PR TITLE
fix: use app tokens for PR reporting

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -253,8 +253,6 @@ jobs:
     needs: detect-targets
     if: ${{ needs.detect-targets.outputs.selected-linters-json != '[]' }}
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
     steps:
       - name: Download dispatch context artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -288,8 +286,6 @@ jobs:
         id: decode_source_context
         env:
           CONTEXT_PATH: ${{ runner.temp }}/detect-targets-context/detect-targets-context.json
-          CURRENT_REPO: ${{ github.event.repository.name }}
-          CURRENT_OWNER: ${{ github.repository_owner }}
         run: |
           python3 - <<'PY'
           import json
@@ -297,18 +293,12 @@ jobs:
           from pathlib import Path
 
           context = json.loads(Path(os.environ["CONTEXT_PATH"]).read_text(encoding="utf-8"))
-          current_owner = os.environ["CURRENT_OWNER"]
-          current_repo = os.environ["CURRENT_REPO"]
           source_owner = context["source_owner"]
           source_repo = context["source_repo"]
           values = {
               "processing-check-external-id": context["processing_check_external_id"],
               "processing-check-name": context["processing_check_name"],
               "source-head-sha": context["source_head_sha"],
-              "source-is-current-repo": str(
-                  source_owner.lower() == current_owner.lower()
-                  and source_repo.lower() == current_repo.lower()
-              ).lower(),
               "source-owner": source_owner,
               "source-repo": source_repo,
           }
@@ -321,7 +311,6 @@ jobs:
 
       - name: Get source repository checker token
         id: get_source_token
-        if: ${{ steps.decode_source_context.outputs.source-is-current-repo != 'true' }}
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ secrets.CHECKER_APP_ID }}
@@ -339,7 +328,7 @@ jobs:
           SOURCE_OWNER: ${{ steps.decode_source_context.outputs.source-owner }}
           SOURCE_REPO: ${{ steps.decode_source_context.outputs.source-repo }}
         with:
-          github-token: ${{ steps.decode_source_context.outputs.source-is-current-repo == 'true' && github.token || steps.get_source_token.outputs.token }}
+          github-token: ${{ steps.get_source_token.outputs.token }}
           script: |
             const owner = process.env.SOURCE_OWNER;
             const repo = process.env.SOURCE_REPO;
@@ -419,10 +408,6 @@ jobs:
       - yamllint
     if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' }}
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      issues: write
-      pull-requests: write
     steps:
       - name: Download dispatch context artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -462,8 +447,6 @@ jobs:
         id: decode_repository_context
         env:
           CONTEXT_PATH: ${{ runner.temp }}/detect-targets-context/detect-targets-context.json
-          CURRENT_REPO: ${{ github.event.repository.name }}
-          CURRENT_OWNER: ${{ github.repository_owner }}
         run: |
           python3 - <<'PY'
           import json
@@ -471,26 +454,16 @@ jobs:
           from pathlib import Path
 
           context = json.loads(Path(os.environ["CONTEXT_PATH"]).read_text(encoding="utf-8"))
-          current_owner = os.environ["CURRENT_OWNER"]
-          current_repo = os.environ["CURRENT_REPO"]
           pr_owner = context["pr_owner"]
           pr_repo = context["pr_repo"]
           source_owner = context["source_owner"]
           source_repo = context["source_repo"]
           values = {
-              "pr-is-current-repo": str(
-                  pr_owner.lower() == current_owner.lower()
-                  and pr_repo.lower() == current_repo.lower()
-              ).lower(),
               "pr-owner": pr_owner,
               "pr-repo": pr_repo,
               "processing-check-external-id": context["processing_check_external_id"],
               "processing-check-name": context["processing_check_name"],
               "source-head-sha": context["source_head_sha"],
-              "source-is-current-repo": str(
-                  source_owner.lower() == current_owner.lower()
-                  and source_repo.lower() == current_repo.lower()
-              ).lower(),
               "source-owner": source_owner,
               "source-repo": source_repo,
           }
@@ -503,7 +476,6 @@ jobs:
 
       - name: Get PR repository checker token
         id: get_pr_token
-        if: ${{ steps.decode_repository_context.outputs.pr-is-current-repo != 'true' }}
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ secrets.CHECKER_APP_ID }}
@@ -513,7 +485,6 @@ jobs:
 
       - name: Get source repository checker token
         id: get_source_token
-        if: ${{ steps.decode_repository_context.outputs.source-is-current-repo != 'true' }}
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ secrets.CHECKER_APP_ID }}
@@ -629,7 +600,7 @@ jobs:
           PR_OWNER: ${{ steps.decode_repository_context.outputs.pr-owner }}
           PR_REPO: ${{ steps.decode_repository_context.outputs.pr-repo }}
         with:
-          github-token: ${{ steps.decode_repository_context.outputs.pr-is-current-repo == 'true' && github.token || steps.get_pr_token.outputs.token }}
+          github-token: ${{ steps.get_pr_token.outputs.token }}
           script: |
             const fs = require("node:fs");
 
@@ -685,7 +656,7 @@ jobs:
           SOURCE_OWNER: ${{ steps.decode_repository_context.outputs.source-owner }}
           SOURCE_REPO: ${{ steps.decode_repository_context.outputs.source-repo }}
         with:
-          github-token: ${{ steps.decode_repository_context.outputs.source-is-current-repo == 'true' && github.token || steps.get_source_token.outputs.token }}
+          github-token: ${{ steps.get_source_token.outputs.token }}
           script: |
             const owner = process.env.SOURCE_OWNER;
             const repo = process.env.SOURCE_REPO;

--- a/worker/README.md
+++ b/worker/README.md
@@ -20,18 +20,17 @@ Worker はこの App の credentials を使って、このリポジトリへ `re
 ### `linter-service-checker`
 
 - 利用場所: `.github/workflows/repository-dispatch.yml`
-- Install 先: 各利用リポジトリ
+- Install 先: 各利用リポジトリ（このリポジトリ自身を含む）
 - Webhook: Cloudflare Worker
   - `Pull request`
   - `Check run`
 - 権限:
   - `Checks: write`
   - `Contents: read`
-  - `Issues: write`
-  - `Pull requests: read`
+  - `Pull requests: write`
   - `Metadata: read`
 
-Cloudflare Worker はこの App の webhook secret で署名検証を行います。`repository_dispatch.yml` ではこの App の credentials を使って、PR metadata の取得、対象ソース repository の checkout、集約 PR comment の更新、共通 processing check run の更新を行います。
+Cloudflare Worker はこの App の webhook secret で署名検証を行います。`repository_dispatch.yml` ではこの App の credentials を使って、PR metadata の取得、対象ソース repository の checkout、集約 PR comment の更新、共通 processing check run の更新を行います。workflow 側の `permissions` は `{}` のままにし、GitHub への書き込みは checker App token を使います。
 
 ## 役割
 
@@ -106,7 +105,7 @@ wrangler secret put GITHUB_DISPATCH_REPO
 - `CHECKER_APP_ID`
 - `CHECKER_PRIVATE_KEY`
 
-`repository_dispatch` 経由では workflow は `client_payload.repository.owner.login` と `client_payload.repository.name` を使って PR repository 用 token を取得し、PR details から head/source repository を解決します。このリポジトリ自身の `pull_request` event でも同じ workflow を直接実行でき、その場合は `github.event` から同等の情報を解決します。Worker は dispatch 先と同じ repository から来た webhook を送信せず、このリポジトリの PR が `pull_request` trigger と `repository_dispatch` trigger の両方で二重実行されることを避けます。
+`repository_dispatch` 経由では workflow は `client_payload.repository.owner.login` と `client_payload.repository.name` を使って PR repository 用 token を取得し、PR details から head/source repository を解決します。このリポジトリ自身の `pull_request` event でも同じ workflow を直接実行でき、その場合も checker App がこのリポジトリに install されている前提で同じ token 解決を行います。Worker は dispatch 先と同じ repository から来た webhook を送信せず、このリポジトリの PR が `pull_request` trigger と `repository_dispatch` trigger の両方で二重実行されることを避けます。
 
 また `repository_dispatch.yml` は declarative な linter 定義から changed files を評価し、共通の in-progress check run を作成してから reusable linter workflow を並列実行します。個別 workflow は lint 実行結果だけを返し、最終的な PR comment の upsert と processing check run の success/failure 更新は `repository_dispatch.yml` 側で一括して行います。このリポジトリの PR では `pull_request` trigger、外部リポジトリでは Worker からの `repository_dispatch` trigger を使います。private repository を前提に、workflow logs には repository 名や changed file 一覧、lint diagnostics を極力出さず、詳細は PR comment に寄せます。
 


### PR DESCRIPTION
## Summary
- use the checker GitHub App token for same-repository and external PR comment updates
- use checker App tokens for same-repository processing check-run updates and keep workflow permissions at `{}`
- document the checker App installation and permission requirements for direct `pull_request` runs

## Testing
- `actionlint .github/workflows/repository-dispatch.yml`
- `git diff --check`
