### PR TITLE
feat(workflows): add shared ghalint linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,12 @@ permissions:
 jobs:
   validate-worker:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6

--- a/.github/workflows/lint-common.yml
+++ b/.github/workflows/lint-common.yml
@@ -24,6 +24,7 @@ permissions: {}
 jobs:
   run-linter:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       comment_body_base64: ${{ steps.publish_outputs.outputs.comment_body_base64 }}
       conclusion: ${{ steps.publish_outputs.outputs.conclusion }}
@@ -87,6 +88,7 @@ jobs:
         with:
           app-id: ${{ secrets.CHECKER_APP_ID }}
           owner: ${{ steps.decode_context.outputs.source-owner }}
+          permission-contents: read
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_context.outputs.source-repo }}
 
@@ -121,14 +123,11 @@ jobs:
 
           for path in files:
               lower_path = path.lower()
-              if linter_name == "actionlint":
+              if linter_name in {"actionlint", "ghalint", "zizmor"}:
                   if lower_path.startswith(".github/workflows/") and lower_path.endswith((".yaml", ".yml")):
                       print(path)
               elif linter_name == "yamllint":
                   if lower_path.endswith((".yaml", ".yml")):
-                      print(path)
-              elif linter_name == "zizmor":
-                  if lower_path.startswith(".github/workflows/") and lower_path.endswith((".yaml", ".yml")):
                       print(path)
               else:
                   raise SystemExit(f"unsupported linter: {linter_name}")
@@ -148,6 +147,17 @@ jobs:
               curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash \
                 -o "$RUNNER_TEMP/download-actionlint.bash"
               bash "$RUNNER_TEMP/download-actionlint.bash" latest
+              ;;
+            ghalint)
+              release_url="$(curl -fsSL -o /dev/null -w '%{url_effective}' https://github.com/suzuki-shunsuke/ghalint/releases/latest)"
+              version="$(basename "$release_url")"
+              version_number="$(printf '%s' "$version" | sed 's/^v//')"
+              asset="ghalint_${version_number}_linux_amd64.tar.gz"
+              mkdir -p "$RUNNER_TEMP/bin"
+              curl -fsSL "https://github.com/suzuki-shunsuke/ghalint/releases/download/$version/$asset" -o "$RUNNER_TEMP/$asset"
+              tar -xzf "$RUNNER_TEMP/$asset" -C "$RUNNER_TEMP/bin"
+              chmod +x "$RUNNER_TEMP/bin/ghalint"
+              echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
               ;;
             yamllint)
               python -m pip install --upgrade pip yamllint
@@ -170,9 +180,52 @@ jobs:
           set +e
           mapfile -t files < "$RUNNER_TEMP/selected-files.txt"
 
+          copy_selected_files_to_root() {
+            local target_root=$1
+            shift
+
+            for file in "$@"; do
+              local destination="$target_root/$file"
+              mkdir -p "$(dirname "$destination")"
+              cp "$file" "$destination"
+            done
+          }
+
+          copy_ghalint_config() {
+            local target_root=$1
+            local config_path
+
+            for config_path in \
+              .ghalint.yaml \
+              .ghalint.yml \
+              ghalint.yaml \
+              ghalint.yml \
+              .github/ghalint.yaml \
+              .github/ghalint.yml
+            do
+              if [ -f "$config_path" ]; then
+                local destination="$target_root/$config_path"
+                mkdir -p "$(dirname "$destination")"
+                cp "$config_path" "$destination"
+                return 0
+              fi
+            done
+          }
+
           case "$LINTER_NAME" in
           actionlint)
             ./actionlint "${files[@]}" > "$RUNNER_TEMP/linter-output.txt" 2>&1
+            ;;
+          ghalint)
+            temp_repo="$RUNNER_TEMP/ghalint-repo"
+            rm -rf "$temp_repo"
+            mkdir -p "$temp_repo"
+            copy_selected_files_to_root "$temp_repo" "${files[@]}"
+            copy_ghalint_config "$temp_repo"
+            (
+              cd "$temp_repo" || exit 1
+              GHALINT_LOG_COLOR=never ghalint run
+            ) > "$RUNNER_TEMP/linter-output.txt" 2>&1
             ;;
           yamllint)
             yamllint_config=""
@@ -239,6 +292,14 @@ jobs:
                   "heading": "### actionlint",
                   "infra_failure": "❌ The `actionlint` workflow failed before producing a detailed report. See the workflow logs.",
                   "no_files": "No matching workflow files were selected for `actionlint`.",
+                  "success": "✅ No issues found in {count} changed GitHub Actions workflow file(s).",
+                  "failure": "❌ Issues found in {count} changed GitHub Actions workflow file(s).",
+              },
+              "ghalint": {
+                  "details_fallback": "ghalint did not produce diagnostic output before the job failed.",
+                  "heading": "### ghalint",
+                  "infra_failure": "❌ The `ghalint` workflow failed before producing a detailed report. See the workflow logs.",
+                  "no_files": "No matching GitHub Actions workflow files were selected for `ghalint`.",
                   "success": "✅ No issues found in {count} changed GitHub Actions workflow file(s).",
                   "failure": "❌ Issues found in {count} changed GitHub Actions workflow file(s).",
               },

--- a/.github/workflows/lint-ghalint.yml
+++ b/.github/workflows/lint-ghalint.yml
@@ -1,0 +1,27 @@
+name: Ghalint
+
+on:
+  workflow_call:
+    outputs:
+      comment_body_base64:
+        description: Base64-encoded markdown section for ghalint
+        value: ${{ jobs.ghalint.outputs.comment_body_base64 }}
+      conclusion:
+        description: success or failure
+        value: ${{ jobs.ghalint.outputs.conclusion }}
+    secrets:
+      CHECKER_APP_ID:
+        required: true
+      CHECKER_PRIVATE_KEY:
+        required: true
+
+permissions: {}
+
+jobs:
+  ghalint:
+    uses: ./.github/workflows/lint-common.yml
+    secrets:
+      CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
+      CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
+    with:
+      linter-name: ghalint

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -16,8 +16,10 @@ permissions: {}
 jobs:
   detect-targets:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       actionlint-selected: ${{ steps.collect.outputs.actionlint-selected }}
+      ghalint-selected: ${{ steps.collect.outputs.ghalint-selected }}
       pull-request-number: ${{ steps.collect.outputs.pull-request-number }}
       selected-linters-json: ${{ steps.collect.outputs.selected-linters-json }}
       skip-reason: ${{ steps.collect.outputs.skip-reason }}
@@ -28,6 +30,10 @@ jobs:
         [
           {
             "name": "actionlint",
+            "patterns": ["^\\.github\\/workflows\\/.+\\.(?:yaml|yml)$"]
+          },
+          {
+            "name": "ghalint",
             "patterns": ["^\\.github\\/workflows\\/.+\\.(?:yaml|yml)$"]
           },
           {
@@ -80,6 +86,7 @@ jobs:
         with:
           app-id: ${{ secrets.CHECKER_APP_ID }}
           owner: ${{ env.PR_REPOSITORY_OWNER }}
+          permission-pull-requests: read
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ env.PR_REPOSITORY_NAME }}
 
@@ -153,6 +160,7 @@ jobs:
 
               writeContext(contextValues);
               core.setOutput("actionlint-selected", "false");
+              core.setOutput("ghalint-selected", "false");
               core.setOutput("pull-request-number", String(pullNumber));
               core.setOutput("selected-linters-json", JSON.stringify([]));
               core.setOutput("skip-reason", skipReason);
@@ -236,6 +244,10 @@ jobs:
             core.setOutput("selected-linters-json", JSON.stringify(selectedLinters));
             core.setOutput("skip-reason", "");
             core.setOutput(
+              "ghalint-selected",
+              String(selectedLinters.includes("ghalint")),
+            );
+            core.setOutput(
               "yamllint-selected",
               String(selectedLinters.includes("yamllint")),
             );
@@ -263,6 +275,7 @@ jobs:
     needs: detect-targets
     if: ${{ needs.detect-targets.outputs.selected-linters-json != '[]' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Download dispatch context artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -325,6 +338,7 @@ jobs:
         with:
           app-id: ${{ secrets.CHECKER_APP_ID }}
           owner: ${{ steps.decode_source_context.outputs.source-owner }}
+          permission-checks: write
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_source_context.outputs.source-repo }}
 
@@ -404,6 +418,16 @@ jobs:
       CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
       CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
 
+  ghalint:
+    needs:
+      - detect-targets
+      - notify-processing-started
+    if: ${{ needs.detect-targets.outputs.ghalint-selected == 'true' }}
+    uses: ./.github/workflows/lint-ghalint.yml
+    secrets:
+      CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
+      CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
+
   yamllint:
     needs:
       - detect-targets
@@ -429,10 +453,12 @@ jobs:
       - detect-targets
       - notify-processing-started
       - actionlint
+      - ghalint
       - yamllint
       - zizmor
     if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Download dispatch context artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -505,6 +531,7 @@ jobs:
         with:
           app-id: ${{ secrets.CHECKER_APP_ID }}
           owner: ${{ steps.decode_repository_context.outputs.pr-owner }}
+          permission-issues: write
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_repository_context.outputs.pr-repo }}
 
@@ -514,6 +541,7 @@ jobs:
         with:
           app-id: ${{ secrets.CHECKER_APP_ID }}
           owner: ${{ steps.decode_repository_context.outputs.source-owner }}
+          permission-checks: write
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_repository_context.outputs.source-repo }}
 
@@ -523,6 +551,9 @@ jobs:
           ACTIONLINT_COMMENT_BODY_BASE64: ${{ needs.actionlint.outputs.comment_body_base64 }}
           ACTIONLINT_CONCLUSION: ${{ needs.actionlint.outputs.conclusion }}
           ACTIONLINT_JOB_RESULT: ${{ needs.actionlint.result }}
+          GHALINT_COMMENT_BODY_BASE64: ${{ needs.ghalint.outputs.comment_body_base64 }}
+          GHALINT_CONCLUSION: ${{ needs.ghalint.outputs.conclusion }}
+          GHALINT_JOB_RESULT: ${{ needs.ghalint.result }}
           SELECTED_LINTERS_JSON: ${{ needs.detect-targets.outputs.selected-linters-json }}
           YAMLLINT_COMMENT_BODY_BASE64: ${{ needs.yamllint.outputs.comment_body_base64 }}
           YAMLLINT_CONCLUSION: ${{ needs.yamllint.outputs.conclusion }}
@@ -545,6 +576,11 @@ jobs:
                   "comment_body_base64": os.environ.get("ACTIONLINT_COMMENT_BODY_BASE64", ""),
                   "conclusion": os.environ.get("ACTIONLINT_CONCLUSION", ""),
                   "job_result": os.environ.get("ACTIONLINT_JOB_RESULT", ""),
+              },
+              "ghalint": {
+                  "comment_body_base64": os.environ.get("GHALINT_COMMENT_BODY_BASE64", ""),
+                  "conclusion": os.environ.get("GHALINT_CONCLUSION", ""),
+                  "job_result": os.environ.get("GHALINT_JOB_RESULT", ""),
               },
               "yamllint": {
                   "comment_body_base64": os.environ.get("YAMLLINT_COMMENT_BODY_BASE64", ""),
@@ -756,6 +792,7 @@ jobs:
     needs: detect-targets
     if: ${{ needs.detect-targets.outputs.selected-linters-json == '[]' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Report skipped lint execution
         env:

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -531,7 +531,7 @@ jobs:
         with:
           app-id: ${{ secrets.CHECKER_APP_ID }}
           owner: ${{ steps.decode_repository_context.outputs.pr-owner }}
-          permission-issues: write
+          permission-pull-requests: write
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_repository_context.outputs.pr-repo }}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -8,13 +8,13 @@ rules:
         - CHECKER_APP_ID
         - CHECKER_PRIVATE_KEY
     ignore:
-      - lint-common.yml:88
-      - lint-common.yml:90
-      - repository-dispatch.yml:81
-      - repository-dispatch.yml:83
-      - repository-dispatch.yml:326
-      - repository-dispatch.yml:328
-      - repository-dispatch.yml:506
-      - repository-dispatch.yml:508
-      - repository-dispatch.yml:515
-      - repository-dispatch.yml:517
+      - lint-common.yml:89
+      - lint-common.yml:92
+      - repository-dispatch.yml:87
+      - repository-dispatch.yml:90
+      - repository-dispatch.yml:339
+      - repository-dispatch.yml:342
+      - repository-dispatch.yml:532
+      - repository-dispatch.yml:535
+      - repository-dispatch.yml:542
+      - repository-dispatch.yml:545

--- a/worker/README.md
+++ b/worker/README.md
@@ -129,6 +129,7 @@ Worker は self-webhook を落として二重起動を防ぎます。
 | linter | 設定ファイル / 挙動 |
 |--------|---------------------|
 | `actionlint` | `.github/actionlint.yaml` / `.yml` を自動で読みます。 |
+| `ghalint` | `.ghalint.yaml` / `.ghalint.yml` / `ghalint.yaml` / `ghalint.yml` / `.github/ghalint.yaml` / `.github/ghalint.yml` を順に探します。 |
 | `yamllint` | `.yamllint` 系 3 形式を順に探します。 |
 | `zizmor` | このリポジトリでは `zizmor.yml` / `zizmor.yaml` / `.github/zizmor.yml` / `.github/zizmor.yaml` を配置先として案内します。 |
 


### PR DESCRIPTION
## Summary
- add `ghalint` as a shared workflow linter through `lint-common.yml` and `repository-dispatch.yml`
- add a dedicated `lint-ghalint.yml` reusable wrapper and document supported `ghalint` config paths
- tighten directly coupled workflow settings so this repository stays compatible with `ghalint` checks

## Validation
- `./actionlint .github/workflows/ci.yml .github/workflows/lint-common.yml .github/workflows/lint-ghalint.yml .github/workflows/repository-dispatch.yml`
- `ghalint run`
- `git diff --check`
- critical code review agent