### PR TITLE
feat(workflows): add shared spectral linting

### DIFF
--- a/.github/workflows/lint-common.yml
+++ b/.github/workflows/lint-common.yml
@@ -100,6 +100,12 @@ jobs:
           repository: ${{ steps.decode_context.outputs.source-owner }}/${{ steps.decode_context.outputs.source-repo }}
           token: ${{ steps.get_source_token.outputs.token }}
 
+      - name: Set up Node.js
+        if: ${{ inputs.linter-name == 'spectral' }}
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "22"
+
       - name: Set up Python
         if: ${{ inputs.linter-name == 'yamllint' || inputs.linter-name == 'zizmor' }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -125,6 +131,9 @@ jobs:
               lower_path = path.lower()
               if linter_name in {"actionlint", "ghalint", "zizmor"}:
                   if lower_path.startswith(".github/workflows/") and lower_path.endswith((".yaml", ".yml")):
+                      print(path)
+              elif linter_name == "spectral":
+                  if lower_path.endswith((".json", ".yaml", ".yml")):
                       print(path)
               elif linter_name == "yamllint":
                   if lower_path.endswith((".yaml", ".yml")):
@@ -158,6 +167,9 @@ jobs:
               tar -xzf "$RUNNER_TEMP/$asset" -C "$RUNNER_TEMP/bin"
               chmod +x "$RUNNER_TEMP/bin/ghalint"
               echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+              ;;
+            spectral)
+              npm install --global @stoplight/spectral-cli
               ;;
             yamllint)
               python -m pip install --upgrade pip yamllint
@@ -212,6 +224,28 @@ jobs:
             done
           }
 
+          resolve_spectral_ruleset() {
+            local default_ruleset="$RUNNER_TEMP/default-spectral-ruleset.yaml"
+            local config_path
+
+            for config_path in \
+              .spectral.yml \
+              .spectral.yaml \
+              .spectral.json \
+              .spectral.js
+            do
+              if [ -f "$config_path" ]; then
+                printf '%s\n' "$config_path"
+                return 0
+              fi
+            done
+
+            printf '%s\n' \
+              'extends:' \
+              '  - spectral:oas' > "$default_ruleset"
+            printf '%s\n' "$default_ruleset"
+          }
+
           case "$LINTER_NAME" in
           actionlint)
             ./actionlint "${files[@]}" > "$RUNNER_TEMP/linter-output.txt" 2>&1
@@ -226,6 +260,15 @@ jobs:
               cd "$temp_repo" || exit 1
               GHALINT_LOG_COLOR=never ghalint run
             ) > "$RUNNER_TEMP/linter-output.txt" 2>&1
+            ;;
+          spectral)
+            spectral_ruleset="$(resolve_spectral_ruleset)"
+            spectral lint \
+              --format text \
+              --ignore-unknown-format \
+              --quiet \
+              --ruleset "$spectral_ruleset" \
+              "${files[@]}" > "$RUNNER_TEMP/linter-output.txt" 2>&1
             ;;
           yamllint)
             yamllint_config=""
@@ -302,6 +345,14 @@ jobs:
                   "no_files": "No matching GitHub Actions workflow files were selected for `ghalint`.",
                   "success": "✅ No issues found in {count} changed GitHub Actions workflow file(s).",
                   "failure": "❌ Issues found in {count} changed GitHub Actions workflow file(s).",
+              },
+              "spectral": {
+                  "details_fallback": "spectral did not produce diagnostic output before the job failed.",
+                  "heading": "### spectral",
+                  "infra_failure": "❌ The `spectral` workflow failed before producing a detailed report. See the workflow logs.",
+                  "no_files": "No matching YAML or JSON files were selected for `spectral`.",
+                  "success": "✅ No issues found in {count} changed YAML or JSON file(s).",
+                  "failure": "❌ Issues found in {count} changed YAML or JSON file(s).",
               },
               "yamllint": {
                   "details_fallback": "yamllint did not produce diagnostic output before the job failed.",

--- a/.github/workflows/lint-spectral.yml
+++ b/.github/workflows/lint-spectral.yml
@@ -1,0 +1,27 @@
+name: Spectral
+
+on:
+  workflow_call:
+    outputs:
+      comment_body_base64:
+        description: Base64-encoded markdown section for spectral
+        value: ${{ jobs.spectral.outputs.comment_body_base64 }}
+      conclusion:
+        description: success or failure
+        value: ${{ jobs.spectral.outputs.conclusion }}
+    secrets:
+      CHECKER_APP_ID:
+        required: true
+      CHECKER_PRIVATE_KEY:
+        required: true
+
+permissions: {}
+
+jobs:
+  spectral:
+    uses: ./.github/workflows/lint-common.yml
+    secrets:
+      CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
+      CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
+    with:
+      linter-name: spectral

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -21,6 +21,7 @@ jobs:
       actionlint-selected: ${{ steps.collect.outputs.actionlint-selected }}
       ghalint-selected: ${{ steps.collect.outputs.ghalint-selected }}
       pull-request-number: ${{ steps.collect.outputs.pull-request-number }}
+      spectral-selected: ${{ steps.collect.outputs.spectral-selected }}
       selected-linters-json: ${{ steps.collect.outputs.selected-linters-json }}
       skip-reason: ${{ steps.collect.outputs.skip-reason }}
       yamllint-selected: ${{ steps.collect.outputs.yamllint-selected }}
@@ -35,6 +36,10 @@ jobs:
           {
             "name": "ghalint",
             "patterns": ["^\\.github\\/workflows\\/.+\\.(?:yaml|yml)$"]
+          },
+          {
+            "name": "spectral",
+            "patterns": ["\\.(?:json|yaml|yml)$"]
           },
           {
             "name": "yamllint",
@@ -162,6 +167,7 @@ jobs:
               core.setOutput("actionlint-selected", "false");
               core.setOutput("ghalint-selected", "false");
               core.setOutput("pull-request-number", String(pullNumber));
+              core.setOutput("spectral-selected", "false");
               core.setOutput("selected-linters-json", JSON.stringify([]));
               core.setOutput("skip-reason", skipReason);
               core.setOutput("yamllint-selected", "false");
@@ -246,6 +252,10 @@ jobs:
             core.setOutput(
               "ghalint-selected",
               String(selectedLinters.includes("ghalint")),
+            );
+            core.setOutput(
+              "spectral-selected",
+              String(selectedLinters.includes("spectral")),
             );
             core.setOutput(
               "yamllint-selected",
@@ -428,6 +438,16 @@ jobs:
       CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
       CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
 
+  spectral:
+    needs:
+      - detect-targets
+      - notify-processing-started
+    if: ${{ needs.detect-targets.outputs.spectral-selected == 'true' }}
+    uses: ./.github/workflows/lint-spectral.yml
+    secrets:
+      CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
+      CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
+
   yamllint:
     needs:
       - detect-targets
@@ -454,6 +474,7 @@ jobs:
       - notify-processing-started
       - actionlint
       - ghalint
+      - spectral
       - yamllint
       - zizmor
     if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' }}
@@ -554,6 +575,9 @@ jobs:
           GHALINT_COMMENT_BODY_BASE64: ${{ needs.ghalint.outputs.comment_body_base64 }}
           GHALINT_CONCLUSION: ${{ needs.ghalint.outputs.conclusion }}
           GHALINT_JOB_RESULT: ${{ needs.ghalint.result }}
+          SPECTRAL_COMMENT_BODY_BASE64: ${{ needs.spectral.outputs.comment_body_base64 }}
+          SPECTRAL_CONCLUSION: ${{ needs.spectral.outputs.conclusion }}
+          SPECTRAL_JOB_RESULT: ${{ needs.spectral.result }}
           SELECTED_LINTERS_JSON: ${{ needs.detect-targets.outputs.selected-linters-json }}
           YAMLLINT_COMMENT_BODY_BASE64: ${{ needs.yamllint.outputs.comment_body_base64 }}
           YAMLLINT_CONCLUSION: ${{ needs.yamllint.outputs.conclusion }}
@@ -581,6 +605,11 @@ jobs:
                   "comment_body_base64": os.environ.get("GHALINT_COMMENT_BODY_BASE64", ""),
                   "conclusion": os.environ.get("GHALINT_CONCLUSION", ""),
                   "job_result": os.environ.get("GHALINT_JOB_RESULT", ""),
+              },
+              "spectral": {
+                  "comment_body_base64": os.environ.get("SPECTRAL_COMMENT_BODY_BASE64", ""),
+                  "conclusion": os.environ.get("SPECTRAL_CONCLUSION", ""),
+                  "job_result": os.environ.get("SPECTRAL_JOB_RESULT", ""),
               },
               "yamllint": {
                   "comment_body_base64": os.environ.get("YAMLLINT_COMMENT_BODY_BASE64", ""),

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -10,11 +10,11 @@ rules:
     ignore:
       - lint-common.yml:89
       - lint-common.yml:92
-      - repository-dispatch.yml:87
-      - repository-dispatch.yml:90
-      - repository-dispatch.yml:339
-      - repository-dispatch.yml:342
-      - repository-dispatch.yml:532
-      - repository-dispatch.yml:535
-      - repository-dispatch.yml:542
-      - repository-dispatch.yml:545
+      - repository-dispatch.yml:92
+      - repository-dispatch.yml:95
+      - repository-dispatch.yml:349
+      - repository-dispatch.yml:352
+      - repository-dispatch.yml:553
+      - repository-dispatch.yml:556
+      - repository-dispatch.yml:563
+      - repository-dispatch.yml:566

--- a/worker/README.md
+++ b/worker/README.md
@@ -130,6 +130,7 @@ Worker は self-webhook を落として二重起動を防ぎます。
 |--------|---------------------|
 | `actionlint` | `.github/actionlint.yaml` / `.yml` を自動で読みます。 |
 | `ghalint` | `.ghalint.yaml` / `.ghalint.yml` / `ghalint.yaml` / `ghalint.yml` / `.github/ghalint.yaml` / `.github/ghalint.yml` を順に探します。 |
+| `spectral` | `.spectral.yml` / `.spectral.yaml` / `.spectral.json` / `.spectral.js` を読みます。未配置時は `spectral:oas` を使い、unknown format は無視します。 |
 | `yamllint` | `.yamllint` 系 3 形式を順に探します。 |
 | `zizmor` | このリポジトリでは `zizmor.yml` / `zizmor.yaml` / `.github/zizmor.yml` / `.github/zizmor.yaml` を配置先として案内します。 |
 


### PR DESCRIPTION
## Summary
- add `spectral` as a shared reusable linter through `lint-common.yml` and `repository-dispatch.yml`
- resolve target repository `.spectral.*` rulesets or fall back to a temporary `spectral:oas` ruleset with unknown formats ignored
- document Spectral config behavior in `worker/README.md`

## Validation
- focused workflow validation: `actionlint` on changed workflows
- focused workflow validation: `ghalint run`
- focused workflow validation: `spectral lint` with a temporary fallback `.spectral.yml`
- `git diff --check`

## Notes
- attempted `cd worker && npm ci && npm run check`, but local dependency installation stalled in this environment; hosted CI remains the authoritative worker validation