### PR TITLE
fix(workflows): grant reusable checkout permission

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -396,6 +396,8 @@ jobs:
       - detect-targets
       - notify-processing-started
     if: ${{ needs.detect-targets.outputs.actionlint-selected == 'true' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/lint-common.yml
     with:
       linter-name: actionlint
@@ -408,6 +410,8 @@ jobs:
       - detect-targets
       - notify-processing-started
     if: ${{ needs.detect-targets.outputs.ghalint-selected == 'true' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/lint-common.yml
     with:
       linter-name: ghalint
@@ -420,6 +424,8 @@ jobs:
       - detect-targets
       - notify-processing-started
     if: ${{ needs.detect-targets.outputs.spectral-selected == 'true' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/lint-common.yml
     with:
       linter-name: spectral
@@ -432,6 +438,8 @@ jobs:
       - detect-targets
       - notify-processing-started
     if: ${{ needs.detect-targets.outputs.yamllint-selected == 'true' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/lint-common.yml
     with:
       linter-name: yamllint
@@ -444,6 +452,8 @@ jobs:
       - detect-targets
       - notify-processing-started
     if: ${{ needs.detect-targets.outputs.zizmor-selected == 'true' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/lint-common.yml
     with:
       linter-name: zizmor

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -14,7 +14,7 @@ rules:
       - repository-dispatch.yml:115
       - repository-dispatch.yml:358
       - repository-dispatch.yml:361
-      - repository-dispatch.yml:517
-      - repository-dispatch.yml:520
       - repository-dispatch.yml:527
       - repository-dispatch.yml:530
+      - repository-dispatch.yml:537
+      - repository-dispatch.yml:540


### PR DESCRIPTION
## Summary
- add `permissions.contents: read` to each reusable workflow caller job in `repository-dispatch.yml`
- keep top-level `permissions: {}` and preserve App-token usage only for cross-repository reads and write operations
- refresh `zizmor` line ignores after the workflow line shift

## Validation
- `actionlint .github/workflows/*.yml`
- `git diff --check`

## Problem
- after merge, GitHub rejected `repository-dispatch.yml` because the reusable caller jobs allowed `contents: none` while `lint-common.yml` now requests `contents: read` for its self-checkout job