### PR TITLE
refactor(workflows): make linter dispatch data-driven

### DIFF
--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -1,0 +1,49 @@
+{
+  "linters": [
+    {
+      "name": "actionlint",
+      "heading": "### actionlint",
+      "no_files": "No matching workflow files were selected for `actionlint`.",
+      "success": "✅ No issues found in {count} changed GitHub Actions workflow file(s).",
+      "failure": "❌ Issues found in {count} changed GitHub Actions workflow file(s).",
+      "infra_failure": "❌ The `actionlint` workflow failed before producing a detailed report. See the workflow logs.",
+      "details_fallback": "actionlint did not produce diagnostic output before the job failed."
+    },
+    {
+      "name": "ghalint",
+      "heading": "### ghalint",
+      "no_files": "No matching GitHub Actions workflow files were selected for `ghalint`.",
+      "success": "✅ No issues found in {count} changed GitHub Actions workflow file(s).",
+      "failure": "❌ Issues found in {count} changed GitHub Actions workflow file(s).",
+      "infra_failure": "❌ The `ghalint` workflow failed before producing a detailed report. See the workflow logs.",
+      "details_fallback": "ghalint did not produce diagnostic output before the job failed."
+    },
+    {
+      "name": "spectral",
+      "heading": "### spectral",
+      "no_files": "No matching YAML or JSON files were selected for `spectral`.",
+      "success": "✅ No issues found in {count} changed YAML or JSON file(s).",
+      "failure": "❌ Issues found in {count} changed YAML or JSON file(s).",
+      "infra_failure": "❌ The `spectral` workflow failed before producing a detailed report. See the workflow logs.",
+      "details_fallback": "spectral did not produce diagnostic output before the job failed."
+    },
+    {
+      "name": "yamllint",
+      "heading": "### yamllint",
+      "no_files": "No matching YAML files were selected for `yamllint`.",
+      "success": "✅ No issues found in {count} changed YAML file(s).",
+      "failure": "❌ Issues found in {count} changed YAML file(s).",
+      "infra_failure": "❌ The `yamllint` workflow failed before producing a detailed report. See the workflow logs.",
+      "details_fallback": "yamllint did not produce diagnostic output before the job failed."
+    },
+    {
+      "name": "zizmor",
+      "heading": "### zizmor",
+      "no_files": "No matching workflow files were selected for `zizmor`.",
+      "success": "✅ No security issues found in {count} changed GitHub Actions workflow file(s).",
+      "failure": "❌ Security issues found in {count} changed GitHub Actions workflow file(s).",
+      "infra_failure": "❌ The `zizmor` workflow failed before producing a detailed report. See the workflow logs.",
+      "details_fallback": "zizmor did not produce diagnostic output before the job failed."
+    }
+  ]
+}

--- a/.github/scripts/secure-artifact.sh
+++ b/.github/scripts/secure-artifact.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "openssl is required" >&2
+  exit 1
+fi
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 {encrypt|decrypt} <input> <output>" >&2
+  exit 1
+fi
+
+mode=$1
+input_path=$2
+output_path=$3
+
+: "${ARTIFACT_PASSPHRASE:?ARTIFACT_PASSPHRASE is required}"
+
+mkdir -p "$(dirname "$output_path")"
+
+case "$mode" in
+  encrypt)
+    openssl enc -aes-256-cbc -pbkdf2 -md sha256 -salt \
+      -in "$input_path" \
+      -out "$output_path" \
+      -pass env:ARTIFACT_PASSPHRASE
+    ;;
+  decrypt)
+    openssl enc -d -aes-256-cbc -pbkdf2 -md sha256 \
+      -in "$input_path" \
+      -out "$output_path" \
+      -pass env:ARTIFACT_PASSPHRASE
+    ;;
+  *)
+    echo "usage: $0 {encrypt|decrypt} <input> <output>" >&2
+    exit 1
+    ;;
+esac

--- a/.github/workflows/lint-common.yml
+++ b/.github/workflows/lint-common.yml
@@ -39,15 +39,6 @@ jobs:
           persist-credentials: false
           ref: ${{ github.sha }}
 
-      - name: Derive summary artifact passphrase
-        if: ${{ always() }}
-        env:
-          CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
-        run: |
-          passphrase="$(node -e 'const crypto = require(\"node:crypto\"); process.stdout.write(crypto.createHmac(\"sha256\", process.env.CHECKER_PRIVATE_KEY).update(process.env.GITHUB_RUN_ID).digest(\"hex\"));')"
-          echo "::add-mask::$passphrase"
-          echo "ARTIFACT_PASSPHRASE=$passphrase" >> "$GITHUB_ENV"
-
       - name: Mask repository metadata
         env:
           CONTEXT_PATH: ${{ runner.temp }}/detect-targets-context/detect-targets-context.json
@@ -248,10 +239,19 @@ jobs:
                       "conclusion": conclusion,
                       "linter_name": linter_name,
                   }
-              ),
-              encoding="utf-8",
+            ),
+            encoding="utf-8",
           )
           PY
+
+      - name: Derive summary artifact passphrase
+        if: ${{ always() }}
+        env:
+          CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
+        run: |
+          passphrase="$(node -e 'const crypto = require("node:crypto"); process.stdout.write(crypto.createHmac("sha256", process.env.CHECKER_PRIVATE_KEY).update(process.env.GITHUB_RUN_ID).digest("hex"));')"
+          echo "::add-mask::$passphrase"
+          echo "ARTIFACT_PASSPHRASE=$passphrase" >> "$GITHUB_ENV"
 
       - name: Encrypt linter summary artifact
         id: encrypt_summary

--- a/.github/workflows/lint-common.yml
+++ b/.github/workflows/lint-common.yml
@@ -6,17 +6,12 @@ on:
       linter-name:
         required: true
         type: string
-    outputs:
-      comment_body_base64:
-        description: Base64-encoded markdown section for this linter
-        value: ${{ jobs.run-linter.outputs.comment_body_base64 }}
-      conclusion:
-        description: success or failure
-        value: ${{ jobs.run-linter.outputs.conclusion }}
     secrets:
       CHECKER_APP_ID:
         required: true
       CHECKER_PRIVATE_KEY:
+        required: true
+      SUMMARY_ARTIFACT_PASSPHRASE:
         required: true
 
 permissions: {}
@@ -27,9 +22,6 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    outputs:
-      comment_body_base64: ${{ steps.prepare_report.outputs.comment_body_base64 }}
-      conclusion: ${{ steps.prepare_report.outputs.conclusion }}
     env:
       LINTER_NAME: ${{ inputs.linter-name }}
       LINTER_CONFIG_PATH: ${{ github.workspace }}/linter-service/.github/scripts/linters/config.json
@@ -48,6 +40,13 @@ jobs:
           path: linter-service
           persist-credentials: false
           ref: ${{ github.sha }}
+
+      - name: Mask summary artifact passphrase
+        if: ${{ always() }}
+        env:
+          ARTIFACT_PASSPHRASE: ${{ secrets.SUMMARY_ARTIFACT_PASSPHRASE }}
+        run: |
+          echo "::add-mask::$ARTIFACT_PASSPHRASE"
 
       - name: Mask repository metadata
         env:
@@ -173,7 +172,6 @@ jobs:
           SELECT_FILES_OUTCOME: ${{ steps.select_files.outcome }}
         run: |
           python3 - <<'PY'
-          import base64
           import json
           import os
           from pathlib import Path
@@ -243,7 +241,6 @@ jobs:
 
           comment_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
           body = comment_path.read_text(encoding="utf-8")
-          encoded_body = base64.b64encode(body.encode("utf-8")).decode("ascii")
           summary_path.write_text(
               json.dumps(
                   {
@@ -254,18 +251,27 @@ jobs:
               ),
               encoding="utf-8",
           )
-
-          output_path = Path(os.environ["GITHUB_OUTPUT"])
-          with output_path.open("a", encoding="utf-8") as fh:
-              fh.write(f"comment_body_base64={encoded_body}\n")
-              fh.write(f"conclusion={conclusion}\n")
           PY
+
+      - name: Encrypt linter summary artifact
+        id: encrypt_summary
+        if: ${{ always() }}
+        env:
+          ARTIFACT_PASSPHRASE: ${{ secrets.SUMMARY_ARTIFACT_PASSPHRASE }}
+        run: |
+          input_path="$RUNNER_TEMP/linter-summary-$LINTER_NAME.json"
+          output_path="$RUNNER_TEMP/linter-summary-$LINTER_NAME.json.enc"
+          bash "$LINTER_SERVICE_PATH/.github/scripts/secure-artifact.sh" \
+            encrypt \
+            "$input_path" \
+            "$output_path"
+          rm -f "$input_path"
 
       - name: Upload linter summary artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: linter-summary-${{ inputs.linter-name }}
-          path: ${{ runner.temp }}/linter-summary-${{ inputs.linter-name }}.json
+          path: ${{ runner.temp }}/linter-summary-${{ inputs.linter-name }}.json.enc
           if-no-files-found: warn
           retention-days: 1

--- a/.github/workflows/lint-common.yml
+++ b/.github/workflows/lint-common.yml
@@ -11,8 +11,6 @@ on:
         required: true
       CHECKER_PRIVATE_KEY:
         required: true
-      SUMMARY_ARTIFACT_PASSPHRASE:
-        required: true
 
 permissions: {}
 
@@ -41,12 +39,14 @@ jobs:
           persist-credentials: false
           ref: ${{ github.sha }}
 
-      - name: Mask summary artifact passphrase
+      - name: Derive summary artifact passphrase
         if: ${{ always() }}
         env:
-          ARTIFACT_PASSPHRASE: ${{ secrets.SUMMARY_ARTIFACT_PASSPHRASE }}
+          CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
         run: |
-          echo "::add-mask::$ARTIFACT_PASSPHRASE"
+          passphrase="$(node -e 'const crypto = require(\"node:crypto\"); process.stdout.write(crypto.createHmac(\"sha256\", process.env.CHECKER_PRIVATE_KEY).update(process.env.GITHUB_RUN_ID).digest(\"hex\"));')"
+          echo "::add-mask::$passphrase"
+          echo "ARTIFACT_PASSPHRASE=$passphrase" >> "$GITHUB_ENV"
 
       - name: Mask repository metadata
         env:
@@ -256,8 +256,6 @@ jobs:
       - name: Encrypt linter summary artifact
         id: encrypt_summary
         if: ${{ always() }}
-        env:
-          ARTIFACT_PASSPHRASE: ${{ secrets.SUMMARY_ARTIFACT_PASSPHRASE }}
         run: |
           input_path="$RUNNER_TEMP/linter-summary-$LINTER_NAME.json"
           output_path="$RUNNER_TEMP/linter-summary-$LINTER_NAME.json.enc"

--- a/.github/workflows/lint-common.yml
+++ b/.github/workflows/lint-common.yml
@@ -32,6 +32,7 @@ jobs:
       conclusion: ${{ steps.prepare_report.outputs.conclusion }}
     env:
       LINTER_NAME: ${{ inputs.linter-name }}
+      LINTER_CONFIG_PATH: ${{ github.workspace }}/linter-service/.github/scripts/linters/config.json
       LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
       SOURCE_REPOSITORY_PATH: ${{ github.workspace }}/source-repo
     steps:
@@ -186,48 +187,17 @@ jobs:
           result_path = Path(os.environ["RESULT_PATH"])
           runner_temp = Path(os.environ["RUNNER_TEMP"])
           comment_path = runner_temp / "linter-comment.md"
+          summary_path = runner_temp / f"linter-summary-{linter_name}.json"
+          config_path = Path(os.environ["LINTER_CONFIG_PATH"])
 
+          config_data = json.loads(config_path.read_text(encoding="utf-8"))
+          linters = config_data.get("linters", [])
+          if not isinstance(linters, list):
+              raise SystemExit("linter config must include a linters array")
           config = {
-              "actionlint": {
-                  "details_fallback": "actionlint did not produce diagnostic output before the job failed.",
-                  "heading": "### actionlint",
-                  "infra_failure": "❌ The `actionlint` workflow failed before producing a detailed report. See the workflow logs.",
-                  "no_files": "No matching workflow files were selected for `actionlint`.",
-                  "success": "✅ No issues found in {count} changed GitHub Actions workflow file(s).",
-                  "failure": "❌ Issues found in {count} changed GitHub Actions workflow file(s).",
-              },
-              "ghalint": {
-                  "details_fallback": "ghalint did not produce diagnostic output before the job failed.",
-                  "heading": "### ghalint",
-                  "infra_failure": "❌ The `ghalint` workflow failed before producing a detailed report. See the workflow logs.",
-                  "no_files": "No matching GitHub Actions workflow files were selected for `ghalint`.",
-                  "success": "✅ No issues found in {count} changed GitHub Actions workflow file(s).",
-                  "failure": "❌ Issues found in {count} changed GitHub Actions workflow file(s).",
-              },
-              "spectral": {
-                  "details_fallback": "spectral did not produce diagnostic output before the job failed.",
-                  "heading": "### spectral",
-                  "infra_failure": "❌ The `spectral` workflow failed before producing a detailed report. See the workflow logs.",
-                  "no_files": "No matching YAML or JSON files were selected for `spectral`.",
-                  "success": "✅ No issues found in {count} changed YAML or JSON file(s).",
-                  "failure": "❌ Issues found in {count} changed YAML or JSON file(s).",
-              },
-              "yamllint": {
-                  "details_fallback": "yamllint did not produce diagnostic output before the job failed.",
-                  "heading": "### yamllint",
-                  "infra_failure": "❌ The `yamllint` workflow failed before producing a detailed report. See the workflow logs.",
-                  "no_files": "No matching YAML files were selected for `yamllint`.",
-                  "success": "✅ No issues found in {count} changed YAML file(s).",
-                  "failure": "❌ Issues found in {count} changed YAML file(s).",
-              },
-              "zizmor": {
-                  "details_fallback": "zizmor did not produce diagnostic output before the job failed.",
-                  "heading": "### zizmor",
-                  "infra_failure": "❌ The `zizmor` workflow failed before producing a detailed report. See the workflow logs.",
-                  "no_files": "No matching workflow files were selected for `zizmor`.",
-                  "success": "✅ No security issues found in {count} changed GitHub Actions workflow file(s).",
-                  "failure": "❌ Security issues found in {count} changed GitHub Actions workflow file(s).",
-              },
+              item["name"]: item
+              for item in linters
+              if isinstance(item, dict) and isinstance(item.get("name"), str)
           }
 
           if linter_name not in config:
@@ -274,9 +244,28 @@ jobs:
           comment_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
           body = comment_path.read_text(encoding="utf-8")
           encoded_body = base64.b64encode(body.encode("utf-8")).decode("ascii")
+          summary_path.write_text(
+              json.dumps(
+                  {
+                      "comment_body": body,
+                      "conclusion": conclusion,
+                      "linter_name": linter_name,
+                  }
+              ),
+              encoding="utf-8",
+          )
 
           output_path = Path(os.environ["GITHUB_OUTPUT"])
           with output_path.open("a", encoding="utf-8") as fh:
               fh.write(f"comment_body_base64={encoded_body}\n")
               fh.write(f"conclusion={conclusion}\n")
           PY
+
+      - name: Upload linter summary artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: linter-summary-${{ inputs.linter-name }}
+          path: ${{ runner.temp }}/linter-summary-${{ inputs.linter-name }}.json
+          if-no-files-found: warn
+          retention-days: 1

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -423,15 +423,6 @@ jobs:
           merge-multiple: true
           path: ${{ runner.temp }}/linter-summaries
 
-      - name: Derive summary artifact passphrase
-        if: ${{ always() }}
-        env:
-          CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
-        run: |
-          passphrase="$(node -e 'const crypto = require(\"node:crypto\"); process.stdout.write(crypto.createHmac(\"sha256\", process.env.CHECKER_PRIVATE_KEY).update(process.env.GITHUB_RUN_ID).digest(\"hex\"));')"
-          echo "::add-mask::$passphrase"
-          echo "ARTIFACT_PASSPHRASE=$passphrase" >> "$GITHUB_ENV"
-
       - name: Mask repository metadata
         env:
           CONTEXT_PATH: ${{ runner.temp }}/detect-targets-context/detect-targets-context.json
@@ -482,6 +473,15 @@ jobs:
           permission-checks: write
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_repository_context.outputs.source-repo }}
+
+      - name: Derive summary artifact passphrase
+        if: ${{ always() }}
+        env:
+          CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
+        run: |
+          passphrase="$(node -e 'const crypto = require("node:crypto"); process.stdout.write(crypto.createHmac("sha256", process.env.CHECKER_PRIVATE_KEY).update(process.env.GITHUB_RUN_ID).digest("hex"));')"
+          echo "::add-mask::$passphrase"
+          echo "ARTIFACT_PASSPHRASE=$passphrase" >> "$GITHUB_ENV"
 
       - name: Decrypt linter summary artifacts
         id: decrypt_summaries

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -23,6 +23,7 @@ jobs:
       pull-request-number: ${{ steps.collect.outputs.pull-request-number }}
       selected-linters-json: ${{ steps.collect.outputs.selected-linters-json }}
       skip-reason: ${{ steps.collect.outputs.skip-reason }}
+      summary-artifact-passphrase: ${{ steps.generate_summary_artifact_passphrase.outputs.summary-artifact-passphrase }}
     env:
       PR_REPOSITORY_NAME: ${{ github.event_name == 'pull_request' && github.event.repository.name || github.event.client_payload.repository.name }}
       PR_REPOSITORY_OWNER: ${{ github.event_name == 'pull_request' && github.event.repository.owner.login || github.event.client_payload.repository.owner.login }}
@@ -65,6 +66,13 @@ jobs:
           path: linter-service
           persist-credentials: false
           ref: ${{ github.sha }}
+
+      - name: Generate summary artifact passphrase
+        id: generate_summary_artifact_passphrase
+        run: |
+          passphrase="$(node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("hex"))')"
+          echo "summary-artifact-passphrase=$passphrase" >> "$GITHUB_OUTPUT"
+          echo "::add-mask::$passphrase"
 
       - name: Build linter definitions
         id: build_linter_definitions
@@ -389,6 +397,7 @@ jobs:
     secrets:
       CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
       CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
+      SUMMARY_ARTIFACT_PASSPHRASE: ${{ needs.detect-targets.outputs.summary-artifact-passphrase }}
 
   publish-results:
     needs:
@@ -422,6 +431,13 @@ jobs:
           pattern: linter-summary-*
           merge-multiple: true
           path: ${{ runner.temp }}/linter-summaries
+
+      - name: Mask summary artifact passphrase
+        if: ${{ always() }}
+        env:
+          ARTIFACT_PASSPHRASE: ${{ needs.detect-targets.outputs.summary-artifact-passphrase }}
+        run: |
+          echo "::add-mask::$ARTIFACT_PASSPHRASE"
 
       - name: Mask repository metadata
         env:
@@ -474,10 +490,40 @@ jobs:
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_repository_context.outputs.source-repo }}
 
+      - name: Decrypt linter summary artifacts
+        id: decrypt_summaries
+        if: ${{ always() }}
+        env:
+          ARTIFACT_PASSPHRASE: ${{ needs.detect-targets.outputs.summary-artifact-passphrase }}
+          LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
+        run: |
+          shopt -s nullglob
+          failures=0
+          mkdir -p "$RUNNER_TEMP/linter-summaries-decrypted"
+          encrypted_files=("$RUNNER_TEMP"/linter-summaries/*.enc)
+          if [ "${#encrypted_files[@]}" -eq 0 ]; then
+            exit 0
+          fi
+
+          for encrypted_path in "${encrypted_files[@]}"; do
+            decrypted_path="$RUNNER_TEMP/linter-summaries-decrypted/$(basename "${encrypted_path%.enc}")"
+            if ! bash "$LINTER_SERVICE_PATH/.github/scripts/secure-artifact.sh" \
+              decrypt \
+              "$encrypted_path" \
+              "$decrypted_path"; then
+              echo "::warning::Failed to decrypt $(basename "$encrypted_path")"
+              failures=1
+            fi
+          done
+
+          exit "$failures"
+
       - name: Prepare combined report
         id: prepare_report
+        if: ${{ always() }}
         env:
-          LINTER_SUMMARY_PATH: ${{ runner.temp }}/linter-summaries
+          DECRYPT_SUMMARIES_OUTCOME: ${{ steps.decrypt_summaries.outcome }}
+          LINTER_SUMMARY_PATH: ${{ runner.temp }}/linter-summaries-decrypted
           SELECTED_LINTERS_JSON: ${{ needs.detect-targets.outputs.selected-linters-json }}
         run: |
           python3 - <<'PY'
@@ -486,6 +532,7 @@ jobs:
           from pathlib import Path
 
           selected_linters = json.loads(os.environ["SELECTED_LINTERS_JSON"])
+          decrypt_outcome = os.environ.get("DECRYPT_SUMMARIES_OUTCOME", "")
           runner_temp = Path(os.environ["RUNNER_TEMP"])
           comment_path = runner_temp / "combined-linter-comment.md"
           summary_root = Path(os.environ["LINTER_SUMMARY_PATH"])
@@ -509,10 +556,16 @@ jobs:
               conclusion = str(summary.get("conclusion") or "")
 
               if not section:
-                  section = (
-                      f"### {linter_name}\n\n"
-                      f"❌ The `{linter_name}` workflow failed before producing a detailed report. See the workflow logs."
-                  )
+                  if decrypt_outcome == "failure":
+                      section = (
+                          f"### {linter_name}\n\n"
+                          f"❌ The encrypted `{linter_name}` summary could not be decrypted. See the workflow logs."
+                      )
+                  else:
+                      section = (
+                          f"### {linter_name}\n\n"
+                          f"❌ The `{linter_name}` workflow failed before producing a detailed report. See the workflow logs."
+                      )
 
               if conclusion != "success":
                   failed += 1
@@ -521,9 +574,11 @@ jobs:
                   sections.append(section)
 
           total = len(selected_linters)
-          overall_conclusion = "success" if failed == 0 else "failure"
+          overall_conclusion = "success" if failed == 0 and decrypt_outcome != "failure" else "failure"
 
-          if overall_conclusion == "success":
+          if decrypt_outcome == "failure":
+              overall_summary = "One or more encrypted linter summaries could not be read. See the workflow logs."
+          elif overall_conclusion == "success":
               overall_summary = f"All {total} selected linter(s) completed successfully."
           else:
               overall_summary = f"{failed} of {total} selected linter(s) reported issues or failed."

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -20,14 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
-      actionlint-selected: ${{ steps.collect.outputs.actionlint-selected }}
-      ghalint-selected: ${{ steps.collect.outputs.ghalint-selected }}
       pull-request-number: ${{ steps.collect.outputs.pull-request-number }}
-      spectral-selected: ${{ steps.collect.outputs.spectral-selected }}
       selected-linters-json: ${{ steps.collect.outputs.selected-linters-json }}
       skip-reason: ${{ steps.collect.outputs.skip-reason }}
-      yamllint-selected: ${{ steps.collect.outputs.yamllint-selected }}
-      zizmor-selected: ${{ steps.collect.outputs.zizmor-selected }}
     env:
       PR_REPOSITORY_NAME: ${{ github.event_name == 'pull_request' && github.event.repository.name || github.event.client_payload.repository.name }}
       PR_REPOSITORY_OWNER: ${{ github.event_name == 'pull_request' && github.event.repository.owner.login || github.event.client_payload.repository.owner.login }}
@@ -74,6 +69,7 @@ jobs:
       - name: Build linter definitions
         id: build_linter_definitions
         env:
+          LINTER_CONFIG_PATH: ${{ github.workspace }}/linter-service/.github/scripts/linters/config.json
           LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
         run: |
           python3 - <<'PY'
@@ -82,11 +78,20 @@ jobs:
           import subprocess
           from pathlib import Path
 
-          linter_names = ["actionlint", "ghalint", "spectral", "yamllint", "zizmor"]
+          config_path = Path(os.environ["LINTER_CONFIG_PATH"])
+          config_data = json.loads(config_path.read_text(encoding="utf-8"))
+          linters = config_data.get("linters", [])
           script_root = Path(os.environ["LINTER_SERVICE_PATH"]) / ".github" / "scripts" / "linters"
           definitions = []
 
-          for linter_name in linter_names:
+          if not isinstance(linters, list):
+              raise SystemExit("linter config must include a linters array")
+
+          for item in linters:
+              if not isinstance(item, dict) or not isinstance(item.get("name"), str):
+                  raise SystemExit("each linter config entry must include a name")
+
+              linter_name = item["name"]
               script_path = script_root / f"{linter_name}.sh"
               result = subprocess.run(
                   ["bash", str(script_path), "patterns"],
@@ -186,14 +191,9 @@ jobs:
               };
 
               writeContext(contextValues);
-              core.setOutput("actionlint-selected", "false");
-              core.setOutput("ghalint-selected", "false");
               core.setOutput("pull-request-number", String(pullNumber));
-              core.setOutput("spectral-selected", "false");
               core.setOutput("selected-linters-json", JSON.stringify([]));
               core.setOutput("skip-reason", skipReason);
-              core.setOutput("yamllint-selected", "false");
-              core.setOutput("zizmor-selected", "false");
               return;
             }
 
@@ -264,29 +264,9 @@ jobs:
               source_owner: sourceOwner,
               source_repo: sourceRepo,
             });
-            core.setOutput(
-              "actionlint-selected",
-              String(selectedLinters.includes("actionlint")),
-            );
             core.setOutput("pull-request-number", String(pullNumber));
             core.setOutput("selected-linters-json", JSON.stringify(selectedLinters));
             core.setOutput("skip-reason", "");
-            core.setOutput(
-              "ghalint-selected",
-              String(selectedLinters.includes("ghalint")),
-            );
-            core.setOutput(
-              "spectral-selected",
-              String(selectedLinters.includes("spectral")),
-            );
-            core.setOutput(
-              "yamllint-selected",
-              String(selectedLinters.includes("yamllint")),
-            );
-            core.setOutput(
-              "zizmor-selected",
-              String(selectedLinters.includes("zizmor")),
-            );
 
       - name: Report routing status
         env:
@@ -391,72 +371,21 @@ jobs:
             );
             await upsertCheckRun({ github, env: process.env });
 
-  actionlint:
+  run-linters:
+    name: ${{ matrix.linter }}
     needs:
       - detect-targets
       - notify-processing-started
-    if: ${{ needs.detect-targets.outputs.actionlint-selected == 'true' }}
+    if: ${{ needs.detect-targets.outputs.selected-linters-json != '[]' }}
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        linter: ${{ fromJSON(needs.detect-targets.outputs.selected-linters-json) }}
     uses: ./.github/workflows/lint-common.yml
     with:
-      linter-name: actionlint
-    secrets:
-      CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
-      CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
-
-  ghalint:
-    needs:
-      - detect-targets
-      - notify-processing-started
-    if: ${{ needs.detect-targets.outputs.ghalint-selected == 'true' }}
-    permissions:
-      contents: read
-    uses: ./.github/workflows/lint-common.yml
-    with:
-      linter-name: ghalint
-    secrets:
-      CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
-      CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
-
-  spectral:
-    needs:
-      - detect-targets
-      - notify-processing-started
-    if: ${{ needs.detect-targets.outputs.spectral-selected == 'true' }}
-    permissions:
-      contents: read
-    uses: ./.github/workflows/lint-common.yml
-    with:
-      linter-name: spectral
-    secrets:
-      CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
-      CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
-
-  yamllint:
-    needs:
-      - detect-targets
-      - notify-processing-started
-    if: ${{ needs.detect-targets.outputs.yamllint-selected == 'true' }}
-    permissions:
-      contents: read
-    uses: ./.github/workflows/lint-common.yml
-    with:
-      linter-name: yamllint
-    secrets:
-      CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
-      CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
-
-  zizmor:
-    needs:
-      - detect-targets
-      - notify-processing-started
-    if: ${{ needs.detect-targets.outputs.zizmor-selected == 'true' }}
-    permissions:
-      contents: read
-    uses: ./.github/workflows/lint-common.yml
-    with:
-      linter-name: zizmor
+      linter-name: ${{ matrix.linter }}
     secrets:
       CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
       CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
@@ -465,11 +394,7 @@ jobs:
     needs:
       - detect-targets
       - notify-processing-started
-      - actionlint
-      - ghalint
-      - spectral
-      - yamllint
-      - zizmor
+      - run-linters
     if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' }}
     permissions:
       contents: read
@@ -488,6 +413,15 @@ jobs:
           path: linter-service
           persist-credentials: false
           ref: ${{ github.sha }}
+
+      - name: Download linter summary artifacts
+        if: ${{ always() }}
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: linter-summary-*
+          merge-multiple: true
+          path: ${{ runner.temp }}/linter-summaries
 
       - name: Mask repository metadata
         env:
@@ -543,25 +477,10 @@ jobs:
       - name: Prepare combined report
         id: prepare_report
         env:
-          ACTIONLINT_COMMENT_BODY_BASE64: ${{ needs.actionlint.outputs.comment_body_base64 }}
-          ACTIONLINT_CONCLUSION: ${{ needs.actionlint.outputs.conclusion }}
-          ACTIONLINT_JOB_RESULT: ${{ needs.actionlint.result }}
-          GHALINT_COMMENT_BODY_BASE64: ${{ needs.ghalint.outputs.comment_body_base64 }}
-          GHALINT_CONCLUSION: ${{ needs.ghalint.outputs.conclusion }}
-          GHALINT_JOB_RESULT: ${{ needs.ghalint.result }}
-          SPECTRAL_COMMENT_BODY_BASE64: ${{ needs.spectral.outputs.comment_body_base64 }}
-          SPECTRAL_CONCLUSION: ${{ needs.spectral.outputs.conclusion }}
-          SPECTRAL_JOB_RESULT: ${{ needs.spectral.result }}
+          LINTER_SUMMARY_PATH: ${{ runner.temp }}/linter-summaries
           SELECTED_LINTERS_JSON: ${{ needs.detect-targets.outputs.selected-linters-json }}
-          YAMLLINT_COMMENT_BODY_BASE64: ${{ needs.yamllint.outputs.comment_body_base64 }}
-          YAMLLINT_CONCLUSION: ${{ needs.yamllint.outputs.conclusion }}
-          YAMLLINT_JOB_RESULT: ${{ needs.yamllint.result }}
-          ZIZMOR_COMMENT_BODY_BASE64: ${{ needs.zizmor.outputs.comment_body_base64 }}
-          ZIZMOR_CONCLUSION: ${{ needs.zizmor.outputs.conclusion }}
-          ZIZMOR_JOB_RESULT: ${{ needs.zizmor.result }}
         run: |
           python3 - <<'PY'
-          import base64
           import json
           import os
           from pathlib import Path
@@ -569,65 +488,33 @@ jobs:
           selected_linters = json.loads(os.environ["SELECTED_LINTERS_JSON"])
           runner_temp = Path(os.environ["RUNNER_TEMP"])
           comment_path = runner_temp / "combined-linter-comment.md"
-          env_map = {
-              "actionlint": {
-                  "comment_body_base64": os.environ.get("ACTIONLINT_COMMENT_BODY_BASE64", ""),
-                  "conclusion": os.environ.get("ACTIONLINT_CONCLUSION", ""),
-                  "job_result": os.environ.get("ACTIONLINT_JOB_RESULT", ""),
-              },
-              "ghalint": {
-                  "comment_body_base64": os.environ.get("GHALINT_COMMENT_BODY_BASE64", ""),
-                  "conclusion": os.environ.get("GHALINT_CONCLUSION", ""),
-                  "job_result": os.environ.get("GHALINT_JOB_RESULT", ""),
-              },
-              "spectral": {
-                  "comment_body_base64": os.environ.get("SPECTRAL_COMMENT_BODY_BASE64", ""),
-                  "conclusion": os.environ.get("SPECTRAL_CONCLUSION", ""),
-                  "job_result": os.environ.get("SPECTRAL_JOB_RESULT", ""),
-              },
-              "yamllint": {
-                  "comment_body_base64": os.environ.get("YAMLLINT_COMMENT_BODY_BASE64", ""),
-                  "conclusion": os.environ.get("YAMLLINT_CONCLUSION", ""),
-                  "job_result": os.environ.get("YAMLLINT_JOB_RESULT", ""),
-              },
-              "zizmor": {
-                  "comment_body_base64": os.environ.get("ZIZMOR_COMMENT_BODY_BASE64", ""),
-                  "conclusion": os.environ.get("ZIZMOR_CONCLUSION", ""),
-                  "job_result": os.environ.get("ZIZMOR_JOB_RESULT", ""),
-              },
-          }
+          summary_root = Path(os.environ["LINTER_SUMMARY_PATH"])
+          summaries = {}
+          for summary_path in sorted(summary_root.glob("linter-summary-*.json")):
+              try:
+                  summary = json.loads(summary_path.read_text(encoding="utf-8"))
+              except json.JSONDecodeError:
+                  continue
+
+              linter_name = summary.get("linter_name")
+              if isinstance(linter_name, str):
+                  summaries[linter_name] = summary
 
           sections = []
-          passed = 0
           failed = 0
 
           for linter_name in selected_linters:
-              linter_env = env_map.get(linter_name, {})
-              encoded_body = linter_env.get("comment_body_base64", "")
-              job_result = linter_env.get("job_result", "")
-              conclusion = linter_env.get("conclusion", "")
+              summary = summaries.get(linter_name, {})
+              section = str(summary.get("comment_body") or "").strip()
+              conclusion = str(summary.get("conclusion") or "")
 
-              if encoded_body:
-                  section = base64.b64decode(encoded_body).decode("utf-8").strip()
-              else:
-                  section = ""
-
-              if job_result == "failure" and not section:
+              if not section:
                   section = (
                       f"### {linter_name}\n\n"
                       f"❌ The `{linter_name}` workflow failed before producing a detailed report. See the workflow logs."
                   )
-              elif job_result == "cancelled" and not section:
-                  section = (
-                      f"### {linter_name}\n\n"
-                      f"❌ The `{linter_name}` workflow was cancelled before producing a detailed report."
-                  )
 
-              is_success = job_result not in {"failure", "cancelled"} and conclusion == "success"
-
-              if is_success:
-                  passed += 1
-              else:
+              if conclusion != "success":
                   failed += 1
 
               if section:

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -23,7 +23,6 @@ jobs:
       pull-request-number: ${{ steps.collect.outputs.pull-request-number }}
       selected-linters-json: ${{ steps.collect.outputs.selected-linters-json }}
       skip-reason: ${{ steps.collect.outputs.skip-reason }}
-      summary-artifact-passphrase: ${{ steps.generate_summary_artifact_passphrase.outputs.summary-artifact-passphrase }}
     env:
       PR_REPOSITORY_NAME: ${{ github.event_name == 'pull_request' && github.event.repository.name || github.event.client_payload.repository.name }}
       PR_REPOSITORY_OWNER: ${{ github.event_name == 'pull_request' && github.event.repository.owner.login || github.event.client_payload.repository.owner.login }}
@@ -66,13 +65,6 @@ jobs:
           path: linter-service
           persist-credentials: false
           ref: ${{ github.sha }}
-
-      - name: Generate summary artifact passphrase
-        id: generate_summary_artifact_passphrase
-        run: |
-          passphrase="$(node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("hex"))')"
-          echo "summary-artifact-passphrase=$passphrase" >> "$GITHUB_OUTPUT"
-          echo "::add-mask::$passphrase"
 
       - name: Build linter definitions
         id: build_linter_definitions
@@ -397,7 +389,6 @@ jobs:
     secrets:
       CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
       CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
-      SUMMARY_ARTIFACT_PASSPHRASE: ${{ needs.detect-targets.outputs.summary-artifact-passphrase }}
 
   publish-results:
     needs:
@@ -432,12 +423,14 @@ jobs:
           merge-multiple: true
           path: ${{ runner.temp }}/linter-summaries
 
-      - name: Mask summary artifact passphrase
+      - name: Derive summary artifact passphrase
         if: ${{ always() }}
         env:
-          ARTIFACT_PASSPHRASE: ${{ needs.detect-targets.outputs.summary-artifact-passphrase }}
+          CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
         run: |
-          echo "::add-mask::$ARTIFACT_PASSPHRASE"
+          passphrase="$(node -e 'const crypto = require(\"node:crypto\"); process.stdout.write(crypto.createHmac(\"sha256\", process.env.CHECKER_PRIVATE_KEY).update(process.env.GITHUB_RUN_ID).digest(\"hex\"));')"
+          echo "::add-mask::$passphrase"
+          echo "ARTIFACT_PASSPHRASE=$passphrase" >> "$GITHUB_ENV"
 
       - name: Mask repository metadata
         env:
@@ -494,7 +487,6 @@ jobs:
         id: decrypt_summaries
         if: ${{ always() }}
         env:
-          ARTIFACT_PASSPHRASE: ${{ needs.detect-targets.outputs.summary-artifact-passphrase }}
           LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
         run: |
           shopt -s nullglob

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -10,13 +10,15 @@ rules:
     ignore:
       - lint-common.yml:69
       - lint-common.yml:72
-      - repository-dispatch.yml:125
-      - repository-dispatch.yml:128
-      - repository-dispatch.yml:346
-      - repository-dispatch.yml:349
-      - repository-dispatch.yml:398
-      - repository-dispatch.yml:399
+      - lint-common.yml:250
+      - repository-dispatch.yml:117
+      - repository-dispatch.yml:120
+      - repository-dispatch.yml:338
+      - repository-dispatch.yml:341
+      - repository-dispatch.yml:390
+      - repository-dispatch.yml:391
       - repository-dispatch.yml:461
       - repository-dispatch.yml:464
       - repository-dispatch.yml:471
       - repository-dispatch.yml:474
+      - repository-dispatch.yml:480

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -8,15 +8,15 @@ rules:
         - CHECKER_APP_ID
         - CHECKER_PRIVATE_KEY
     ignore:
-      - lint-common.yml:78
-      - lint-common.yml:81
+      - lint-common.yml:69
+      - lint-common.yml:72
       - repository-dispatch.yml:125
       - repository-dispatch.yml:128
       - repository-dispatch.yml:346
       - repository-dispatch.yml:349
       - repository-dispatch.yml:398
       - repository-dispatch.yml:399
-      - repository-dispatch.yml:470
-      - repository-dispatch.yml:473
-      - repository-dispatch.yml:480
-      - repository-dispatch.yml:483
+      - repository-dispatch.yml:461
+      - repository-dispatch.yml:464
+      - repository-dispatch.yml:471
+      - repository-dispatch.yml:474

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -8,15 +8,15 @@ rules:
         - CHECKER_APP_ID
         - CHECKER_PRIVATE_KEY
     ignore:
-      - lint-common.yml:79
-      - lint-common.yml:82
-      - repository-dispatch.yml:117
-      - repository-dispatch.yml:120
-      - repository-dispatch.yml:338
-      - repository-dispatch.yml:341
-      - repository-dispatch.yml:390
-      - repository-dispatch.yml:391
-      - repository-dispatch.yml:461
-      - repository-dispatch.yml:464
-      - repository-dispatch.yml:471
-      - repository-dispatch.yml:474
+      - lint-common.yml:78
+      - lint-common.yml:81
+      - repository-dispatch.yml:125
+      - repository-dispatch.yml:128
+      - repository-dispatch.yml:346
+      - repository-dispatch.yml:349
+      - repository-dispatch.yml:398
+      - repository-dispatch.yml:399
+      - repository-dispatch.yml:477
+      - repository-dispatch.yml:480
+      - repository-dispatch.yml:487
+      - repository-dispatch.yml:490

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -16,7 +16,7 @@ rules:
       - repository-dispatch.yml:349
       - repository-dispatch.yml:398
       - repository-dispatch.yml:399
-      - repository-dispatch.yml:477
+      - repository-dispatch.yml:470
+      - repository-dispatch.yml:473
       - repository-dispatch.yml:480
-      - repository-dispatch.yml:487
-      - repository-dispatch.yml:490
+      - repository-dispatch.yml:483

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -8,13 +8,15 @@ rules:
         - CHECKER_APP_ID
         - CHECKER_PRIVATE_KEY
     ignore:
-      - lint-common.yml:78
-      - lint-common.yml:81
-      - repository-dispatch.yml:112
-      - repository-dispatch.yml:115
-      - repository-dispatch.yml:358
-      - repository-dispatch.yml:361
-      - repository-dispatch.yml:527
-      - repository-dispatch.yml:530
-      - repository-dispatch.yml:537
-      - repository-dispatch.yml:540
+      - lint-common.yml:79
+      - lint-common.yml:82
+      - repository-dispatch.yml:117
+      - repository-dispatch.yml:120
+      - repository-dispatch.yml:338
+      - repository-dispatch.yml:341
+      - repository-dispatch.yml:390
+      - repository-dispatch.yml:391
+      - repository-dispatch.yml:461
+      - repository-dispatch.yml:464
+      - repository-dispatch.yml:471
+      - repository-dispatch.yml:474


### PR DESCRIPTION
## Summary
- centralize shared linter metadata in `.github/scripts/linters/config.json`
- run selected linters through a reusable workflow matrix driven by `selected-linters-json`
- aggregate per-linter summary artifacts in `publish-results` instead of hardcoding per-linter outputs
- refresh `.github/zizmor.yml` line-based ignores for the workflow changes

## Validation
- `node -e 'JSON.parse(require("fs").readFileSync(".github/scripts/linters/config.json", "utf8"))'`
- `actionlint .github/workflows/*.yml`
- `ghalint run`
- `git diff --check`

## Notes
- `zizmor` could not be run locally in this environment because Python is unavailable; the temporary line-based ignores were refreshed manually and should be verified by hosted CI.