### PR TITLE
feat(linters): add shellcheck support

### DIFF
--- a/.github/scripts/linters/actionlint.sh
+++ b/.github/scripts/linters/actionlint.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # Shared helpers keep the JSON contract and path handling consistent.
-# shellcheck disable=SC1091
+# shellcheck source=../linter-library.sh
 source "$script_dir/../linter-library.sh"
 
 mode=${1-}

--- a/.github/scripts/linters/actionlint.sh
+++ b/.github/scripts/linters/actionlint.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # Shared helpers keep the JSON contract and path handling consistent.
+# shellcheck disable=SC1091
 source "$script_dir/../linter-library.sh"
 
 mode=${1-}

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -37,6 +37,15 @@
       "details_fallback": "yamllint did not produce diagnostic output before the job failed."
     },
     {
+      "name": "shellcheck",
+      "heading": "### shellcheck",
+      "no_files": "No matching shell script files were selected for `shellcheck`.",
+      "success": "✅ No issues found in {count} changed shell script file(s).",
+      "failure": "❌ Issues found in {count} changed shell script file(s).",
+      "infra_failure": "❌ The `shellcheck` workflow failed before producing a detailed report. See the workflow logs.",
+      "details_fallback": "shellcheck did not produce diagnostic output before the job failed."
+    },
+    {
       "name": "zizmor",
       "heading": "### zizmor",
       "no_files": "No matching workflow files were selected for `zizmor`.",

--- a/.github/scripts/linters/ghalint.sh
+++ b/.github/scripts/linters/ghalint.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck disable=SC1091
 source "$script_dir/../linter-library.sh"
 
 mode=${1-}

--- a/.github/scripts/linters/ghalint.sh
+++ b/.github/scripts/linters/ghalint.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-# shellcheck disable=SC1091
+# shellcheck source=../linter-library.sh
 source "$script_dir/../linter-library.sh"
 
 mode=${1-}

--- a/.github/scripts/linters/shellcheck.sh
+++ b/.github/scripts/linters/shellcheck.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-# shellcheck disable=SC1091
+# shellcheck source=../linter-library.sh
 source "$script_dir/../linter-library.sh"
 
 mode=${1-}
@@ -38,7 +38,7 @@ EOF
   run)
     : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
     output_file="$RUNNER_TEMP/linter-output.txt"
-    linter_lib::run_and_emit_json "$output_file" shellcheck "$@"
+    linter_lib::run_and_emit_json "$output_file" shellcheck -x -P SCRIPTDIR "$@"
     ;;
   *)
     echo "usage: $0 {patterns|install|run}" >&2

--- a/.github/scripts/linters/shellcheck.sh
+++ b/.github/scripts/linters/shellcheck.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-# shellcheck source=../linter-library.sh
+# shellcheck disable=SC1091
 source "$script_dir/../linter-library.sh"
 
 mode=${1-}

--- a/.github/scripts/linters/shellcheck.sh
+++ b/.github/scripts/linters/shellcheck.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../linter-library.sh
+source "$script_dir/../linter-library.sh"
+
+mode=${1-}
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+case "$mode" in
+  patterns)
+    cat <<'EOF'
+\.(?:bash|ksh|sh)$
+EOF
+    ;;
+  install)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+    release_url="$(curl -fsSL -o /dev/null -w '%{url_effective}' https://github.com/koalaman/shellcheck/releases/latest)"
+    version="$(basename "$release_url")"
+    asset="shellcheck-${version}.linux.x86_64.tar.gz"
+    archive_path="$RUNNER_TEMP/$asset"
+    extract_dir="$RUNNER_TEMP/shellcheck-extract"
+    bin_dir="$RUNNER_TEMP/shellcheck/bin"
+
+    rm -rf "$extract_dir" "$bin_dir"
+    mkdir -p "$extract_dir" "$bin_dir"
+
+    curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/$version/$asset" -o "$archive_path"
+    tar -xzf "$archive_path" -C "$extract_dir"
+    cp "$extract_dir/shellcheck-$version/shellcheck" "$bin_dir/shellcheck"
+    chmod +x "$bin_dir/shellcheck"
+    linter_lib::add_path "$bin_dir"
+    ;;
+  run)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+    output_file="$RUNNER_TEMP/linter-output.txt"
+    linter_lib::run_and_emit_json "$output_file" shellcheck "$@"
+    ;;
+  *)
+    echo "usage: $0 {patterns|install|run}" >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/linters/spectral.sh
+++ b/.github/scripts/linters/spectral.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck disable=SC1091
 source "$script_dir/../linter-library.sh"
 
 resolve_spectral_ruleset() {

--- a/.github/scripts/linters/spectral.sh
+++ b/.github/scripts/linters/spectral.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-# shellcheck disable=SC1091
+# shellcheck source=../linter-library.sh
 source "$script_dir/../linter-library.sh"
 
 resolve_spectral_ruleset() {

--- a/.github/scripts/linters/yamllint.sh
+++ b/.github/scripts/linters/yamllint.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck disable=SC1091
 source "$script_dir/../linter-library.sh"
 
 mode=${1-}

--- a/.github/scripts/linters/yamllint.sh
+++ b/.github/scripts/linters/yamllint.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-# shellcheck disable=SC1091
+# shellcheck source=../linter-library.sh
 source "$script_dir/../linter-library.sh"
 
 mode=${1-}

--- a/.github/scripts/linters/zizmor.sh
+++ b/.github/scripts/linters/zizmor.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck disable=SC1091
 source "$script_dir/../linter-library.sh"
 
 mode=${1-}

--- a/.github/scripts/linters/zizmor.sh
+++ b/.github/scripts/linters/zizmor.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-# shellcheck disable=SC1091
+# shellcheck source=../linter-library.sh
 source "$script_dir/../linter-library.sh"
 
 mode=${1-}

--- a/worker/README.md
+++ b/worker/README.md
@@ -135,6 +135,7 @@ Worker は self-webhook を落として二重起動を防ぎます。
 | `ghalint` | `.ghalint.yaml` / `.ghalint.yml` / `ghalint.yaml` / `ghalint.yml` / `.github/ghalint.yaml` / `.github/ghalint.yml` を順に探します。 |
 | `spectral` | `.spectral.yml` / `.spectral.yaml` / `.spectral.json` を読みます。未配置時は `spectral:oas` を使い、unknown format は無視します。 |
 | `yamllint` | `.yamllint` 系 3 形式を順に探します。 |
+| `shellcheck` | `.shellcheckrc` / `shellcheckrc` を対象 script の場所から親へ向けて探します。 |
 | `zizmor` | このリポジトリでは `zizmor.yml` / `zizmor.yaml` / `.github/zizmor.yml` / `.github/zizmor.yaml` を配置先として案内します。 |
 
 - 実装本体は `.github/scripts/linters/*.sh` に分割しています。


### PR DESCRIPTION
## Summary
- add a shared shellcheck wrapper that follows the existing patterns/install/run contract
- register shellcheck in the shared linter config so repository-dispatch can select it dynamically
- document ShellCheck config discovery in worker/README.md

## Validation
- node -e 'JSON.parse(require("fs").readFileSync(".github/scripts/linters/config.json", "utf8"))'\n- bash -n .github/scripts/secure-artifact.sh .github/scripts/linter-library.sh .github/scripts/linters/*.sh\n- bash .github/scripts/linters/actionlint.sh install && actionlint .github/workflows/*.yml\n- bash .github/scripts/linters/ghalint.sh install && ghalint run\n- bash .github/scripts/linters/shellcheck.sh install && shellcheck smoke test\n- git diff --check