### PR TITLE
feat(linters): add biome support

### DIFF
--- a/.github/scripts/linters/biome.sh
+++ b/.github/scripts/linters/biome.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../linter-library.sh
+source "$script_dir/../linter-library.sh"
+
+mode=${1-}
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+case "$mode" in
+  patterns)
+    cat <<'EOF'
+\.(?:cjs|cts|js|json|jsonc|jsx|mjs|mts|ts|tsx)$
+EOF
+    ;;
+  install)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+    linter_lib::install_node_tools "$RUNNER_TEMP/biome/npm-global" @biomejs/biome
+    ;;
+  run)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+    output_file="$RUNNER_TEMP/linter-output.txt"
+    linter_lib::run_and_emit_json \
+      "$output_file" \
+      biome lint \
+      --colors=off \
+      --error-on-warnings \
+      --no-errors-on-unmatched \
+      "$@"
+    ;;
+  *)
+    echo "usage: $0 {patterns|install|run}" >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -37,6 +37,15 @@
       "details_fallback": "yamllint did not produce diagnostic output before the job failed."
     },
     {
+      "name": "biome",
+      "heading": "### biome",
+      "no_files": "No matching JavaScript, TypeScript, or JSON/JSONC files were selected for `biome`.",
+      "success": "✅ No issues found in {count} changed JavaScript, TypeScript, or JSON/JSONC file(s).",
+      "failure": "❌ Issues found in {count} changed JavaScript, TypeScript, or JSON/JSONC file(s).",
+      "infra_failure": "❌ The `biome` workflow failed before producing a detailed report. See the workflow logs.",
+      "details_fallback": "biome did not produce diagnostic output before the job failed."
+    },
+    {
       "name": "shellcheck",
       "heading": "### shellcheck",
       "no_files": "No matching shell script files were selected for `shellcheck`.",

--- a/worker/README.md
+++ b/worker/README.md
@@ -135,6 +135,7 @@ Worker は self-webhook を落として二重起動を防ぎます。
 | `ghalint` | `.ghalint.yaml` / `.ghalint.yml` / `ghalint.yaml` / `ghalint.yml` / `.github/ghalint.yaml` / `.github/ghalint.yml` を順に探します。 |
 | `spectral` | `.spectral.yml` / `.spectral.yaml` / `.spectral.json` を読みます。未配置時は `spectral:oas` を使い、unknown format は無視します。 |
 | `yamllint` | `.yamllint` 系 3 形式を順に探します。 |
+| `biome` | Biome の既定探索で `biome.json` / `biome.jsonc` / `.biome.json` / `.biome.jsonc` を探し、未配置時は既定値を使います。 |
 | `shellcheck` | `.shellcheckrc` / `shellcheckrc` を対象 script の場所から親へ向けて探します。 |
 | `zizmor` | このリポジトリでは `zizmor.yml` / `zizmor.yaml` / `.github/zizmor.yml` / `.github/zizmor.yaml` を配置先として案内します。 |
 


### PR DESCRIPTION
## Summary
- add a shared Biome wrapper that follows the existing patterns/install/run contract
- register Biome in the shared linter config so repository-dispatch can select it dynamically
- document Biome config discovery in worker/README.md

## Validation
- node -e 'JSON.parse(require("fs").readFileSync(".github/scripts/linters/config.json", "utf8"))'\n- bash -n .github/scripts/secure-artifact.sh .github/scripts/linter-library.sh .github/scripts/linters/*.sh\n- bash .github/scripts/linters/actionlint.sh install && actionlint .github/workflows/*.yml\n- bash .github/scripts/linters/ghalint.sh install && ghalint run\n- bash .github/scripts/linters/shellcheck.sh install && shellcheck -x -P SCRIPTDIR .github/scripts/linters/biome.sh\n- bash .github/scripts/linters/biome.sh install && direct biome CLI smoke tests for success/failure exit behavior\n- git diff --check