### PR TITLE
feat(linters): add taplo support

### DIFF
--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -37,6 +37,15 @@
       "details_fallback": "yamllint did not produce diagnostic output before the job failed."
     },
     {
+      "name": "taplo",
+      "heading": "### taplo",
+      "no_files": "No matching TOML files were selected for `taplo`.",
+      "success": "✅ No issues found in {count} changed TOML file(s).",
+      "failure": "❌ Issues found in {count} changed TOML file(s).",
+      "infra_failure": "❌ The `taplo` workflow failed before producing a detailed report. See the workflow logs.",
+      "details_fallback": "taplo did not produce diagnostic output before the job failed."
+    },
+    {
       "name": "biome",
       "heading": "### biome",
       "no_files": "No matching JavaScript, TypeScript, or JSON/JSONC files were selected for `biome`.",

--- a/.github/scripts/linters/taplo.sh
+++ b/.github/scripts/linters/taplo.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../linter-library.sh
+source "$script_dir/../linter-library.sh"
+
+mode=${1-}
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+case "$mode" in
+  patterns)
+    cat <<'EOF'
+\.(?:toml)$
+EOF
+    ;;
+  install)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+    release_url="$(curl -fsSL -o /dev/null -w '%{url_effective}' https://github.com/tamasfe/taplo/releases/latest)"
+    version="$(basename "$release_url")"
+    asset="taplo-linux-x86_64.gz"
+    bin_dir="$RUNNER_TEMP/taplo/bin"
+    download_path="$bin_dir/taplo.gz"
+
+    rm -rf "$bin_dir"
+    mkdir -p "$bin_dir"
+
+    curl -fsSL "https://github.com/tamasfe/taplo/releases/download/$version/$asset" -o "$download_path"
+    gzip -d "$download_path"
+    chmod +x "$bin_dir/taplo"
+    linter_lib::add_path "$bin_dir"
+    ;;
+  run)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+    output_file="$RUNNER_TEMP/linter-output.txt"
+    linter_lib::run_and_emit_json \
+      "$output_file" \
+      taplo fmt \
+      --check \
+      --diff \
+      --colors never \
+      "$@"
+    ;;
+  *)
+    echo "usage: $0 {patterns|install|run}" >&2
+    exit 1
+    ;;
+esac

--- a/worker/README.md
+++ b/worker/README.md
@@ -135,6 +135,7 @@ Worker は self-webhook を落として二重起動を防ぎます。
 | `ghalint` | `.ghalint.yaml` / `.ghalint.yml` / `ghalint.yaml` / `ghalint.yml` / `.github/ghalint.yaml` / `.github/ghalint.yml` を順に探します。 |
 | `spectral` | `.spectral.yml` / `.spectral.yaml` / `.spectral.json` を読みます。未配置時は `spectral:oas` を使い、unknown format は無視します。 |
 | `yamllint` | `.yamllint` 系 3 形式を順に探します。 |
+| `taplo` | `.taplo.toml` を優先し、なければ `taplo.toml` を repo root で探します。未配置時は既定値で `fmt --check` を行います。 |
 | `biome` | Biome の既定探索で `biome.json` / `biome.jsonc` / `.biome.json` / `.biome.jsonc` を探し、未配置時は既定値を使います。 |
 | `shellcheck` | `.shellcheckrc` / `shellcheckrc` を対象 script の場所から親へ向けて探します。 |
 | `zizmor` | このリポジトリでは `zizmor.yml` / `zizmor.yaml` / `.github/zizmor.yml` / `.github/zizmor.yaml` を配置先として案内します。 |


### PR DESCRIPTION
## Summary
- add a shared Taplo wrapper that follows the existing patterns/install/run contract
- register Taplo in the shared linter config so repository-dispatch can select it dynamically
- document Taplo config discovery in worker/README.md

## Validation
- node -e 'JSON.parse(require("fs").readFileSync(".github/scripts/linters/config.json", "utf8"))'\n- bash -n .github/scripts/secure-artifact.sh .github/scripts/linter-library.sh .github/scripts/linters/*.sh\n- bash .github/scripts/linters/actionlint.sh install && actionlint .github/workflows/*.yml\n- bash .github/scripts/linters/ghalint.sh install && ghalint run\n- bash .github/scripts/linters/shellcheck.sh install && shellcheck -x -P SCRIPTDIR .github/scripts/linters/taplo.sh\n- bash .github/scripts/linters/taplo.sh install && direct taplo CLI smoke tests for success and failure\n- git diff --check\n\n## Notes\n- local worker checks were skipped because the repo-local worker dependencies are not installed in this environment; hosted `validate-worker` will verify that surface