### PR TITLE
feat(linters): add markdownlint-cli2 support

### DIFF
--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -37,6 +37,15 @@
       "details_fallback": "yamllint did not produce diagnostic output before the job failed."
     },
     {
+      "name": "markdownlint-cli2",
+      "heading": "### markdownlint-cli2",
+      "no_files": "No matching Markdown files were selected for `markdownlint-cli2`.",
+      "success": "✅ No issues found in {count} changed Markdown file(s).",
+      "failure": "❌ Issues found in {count} changed Markdown file(s).",
+      "infra_failure": "❌ The `markdownlint-cli2` workflow failed before producing a detailed report. See the workflow logs.",
+      "details_fallback": "markdownlint-cli2 did not produce diagnostic output before the job failed."
+    },
+    {
       "name": "taplo",
       "heading": "### taplo",
       "no_files": "No matching TOML files were selected for `taplo`.",

--- a/.github/scripts/linters/markdownlint-cli2.sh
+++ b/.github/scripts/linters/markdownlint-cli2.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../linter-library.sh
+source "$script_dir/../linter-library.sh"
+
+mode=${1-}
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+case "$mode" in
+  patterns)
+    cat <<'EOF'
+\.(?:md|markdown)$
+EOF
+    ;;
+  install)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+    linter_lib::install_node_tools "$RUNNER_TEMP/markdownlint-cli2/npm-global" markdownlint-cli2
+    ;;
+  run)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+    output_file="$RUNNER_TEMP/linter-output.txt"
+    literal_paths=()
+    for path in "$@"; do
+      literal_paths+=(":$path")
+    done
+
+    linter_lib::run_and_emit_json \
+      "$output_file" \
+      markdownlint-cli2 \
+      --no-globs \
+      "${literal_paths[@]}"
+    ;;
+  *)
+    echo "usage: $0 {patterns|install|run}" >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/linters/markdownlint-cli2.sh
+++ b/.github/scripts/linters/markdownlint-cli2.sh
@@ -6,6 +6,70 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../linter-library.sh
 source "$script_dir/../linter-library.sh"
 
+markdownlint_collect_relevant_dirs() {
+  local -A seen=()
+  local path current_dir
+
+  seen["."]=1
+  printf '%s\n' "."
+
+  for path in "$@"; do
+    current_dir=$(dirname "$path")
+
+    while :; do
+      if [ -z "${seen[$current_dir]+x}" ]; then
+        seen["$current_dir"]=1
+        printf '%s\n' "$current_dir"
+      fi
+
+      if [ "$current_dir" = "." ]; then
+        break
+      fi
+
+      current_dir=$(dirname "$current_dir")
+    done
+  done
+}
+
+markdownlint_find_unsafe_config() {
+  local dir candidate
+
+  for dir in "$@"; do
+    for candidate in \
+      "$dir/.markdownlint-cli2.cjs" \
+      "$dir/.markdownlint-cli2.mjs" \
+      "$dir/.markdownlint.cjs" \
+      "$dir/.markdownlint.mjs"
+    do
+      if [ -f "$candidate" ]; then
+        printf '%s\n' "${candidate#./}"
+        return 0
+      fi
+    done
+  done
+
+  return 1
+}
+
+markdownlint_collect_safe_configs() {
+  local dir candidate
+
+  for dir in "$@"; do
+    for candidate in \
+      "$dir/.markdownlint-cli2.jsonc" \
+      "$dir/.markdownlint-cli2.yaml" \
+      "$dir/.markdownlint.jsonc" \
+      "$dir/.markdownlint.json" \
+      "$dir/.markdownlint.yaml" \
+      "$dir/.markdownlint.yml"
+    do
+      if [ -f "$candidate" ]; then
+        printf '%s\n' "${candidate#./}"
+      fi
+    done
+  done
+}
+
 mode=${1-}
 if [ "$#" -gt 0 ]; then
   shift
@@ -24,16 +88,46 @@ EOF
   run)
     : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
     output_file="$RUNNER_TEMP/linter-output.txt"
+    temp_repo="$RUNNER_TEMP/markdownlint-cli2-repo"
+    files=("$@")
     literal_paths=()
-    for path in "$@"; do
+    safe_configs=()
+    relevant_dirs=()
+    unsafe_config=""
+
+    rm -rf "$temp_repo"
+    mkdir -p "$temp_repo"
+
+    linter_lib::copy_paths_to_root "$temp_repo" "${files[@]}"
+
+    mapfile -t relevant_dirs < <(markdownlint_collect_relevant_dirs "${files[@]}")
+    if unsafe_config="$(markdownlint_find_unsafe_config "${relevant_dirs[@]}")"; then
+      cat > "$output_file" <<EOF
+Repository-supplied \`$unsafe_config\` is not supported in this shared linter service because loading JavaScript-based markdownlint configs from untrusted pull requests is unsafe.
+Use one of: \`.markdownlint-cli2.jsonc\`, \`.markdownlint-cli2.yaml\`, \`.markdownlint.jsonc\`, \`.markdownlint.json\`, \`.markdownlint.yaml\`, or \`.markdownlint.yml\`.
+EOF
+      linter_lib::emit_json_result 1 "$output_file"
+      exit 0
+    fi
+
+    mapfile -t safe_configs < <(markdownlint_collect_safe_configs "${relevant_dirs[@]}")
+    if [ "${#safe_configs[@]}" -gt 0 ]; then
+      linter_lib::copy_paths_to_root "$temp_repo" "${safe_configs[@]}"
+    fi
+
+    literal_paths=()
+    for path in "${files[@]}"; do
       literal_paths+=(":$path")
     done
 
-    linter_lib::run_and_emit_json \
-      "$output_file" \
+    run_markdownlint() {
+      cd "$temp_repo" || exit 1
       markdownlint-cli2 \
-      --no-globs \
-      "${literal_paths[@]}"
+        --no-globs \
+        "${literal_paths[@]}"
+    }
+
+    linter_lib::run_and_emit_json "$output_file" run_markdownlint
     ;;
   *)
     echo "usage: $0 {patterns|install|run}" >&2

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,4 @@
+{
+  "MD013": false,
+  "MD060": false
+}

--- a/worker/README.md
+++ b/worker/README.md
@@ -135,6 +135,7 @@ Worker は self-webhook を落として二重起動を防ぎます。
 | `ghalint` | `.ghalint.yaml` / `.ghalint.yml` / `ghalint.yaml` / `ghalint.yml` / `.github/ghalint.yaml` / `.github/ghalint.yml` を順に探します。 |
 | `spectral` | `.spectral.yml` / `.spectral.yaml` / `.spectral.json` を読みます。未配置時は `spectral:oas` を使い、unknown format は無視します。 |
 | `yamllint` | `.yamllint` 系 3 形式を順に探します。 |
+| `markdownlint-cli2` | `.markdownlint-cli2.jsonc` / `.yaml` / `.cjs` / `.mjs` を優先し、次に `.markdownlint.jsonc` / `.json` / `.yaml` / `.yml` / `.cjs` / `.mjs` を探します。共有 workflow は `globs` を使わず変更対象だけを検査します。 |
 | `taplo` | `.taplo.toml` を優先し、なければ `taplo.toml` を repo root で探します。未配置時は既定値で `fmt --check` を行います。 |
 | `biome` | Biome の既定探索で `biome.json` / `biome.jsonc` / `.biome.json` / `.biome.jsonc` を探し、未配置時は既定値を使います。 |
 | `shellcheck` | `.shellcheckrc` / `shellcheckrc` を対象 script の場所から親へ向けて探します。 |

--- a/worker/README.md
+++ b/worker/README.md
@@ -135,7 +135,7 @@ Worker は self-webhook を落として二重起動を防ぎます。
 | `ghalint` | `.ghalint.yaml` / `.ghalint.yml` / `ghalint.yaml` / `ghalint.yml` / `.github/ghalint.yaml` / `.github/ghalint.yml` を順に探します。 |
 | `spectral` | `.spectral.yml` / `.spectral.yaml` / `.spectral.json` を読みます。未配置時は `spectral:oas` を使い、unknown format は無視します。 |
 | `yamllint` | `.yamllint` 系 3 形式を順に探します。 |
-| `markdownlint-cli2` | `.markdownlint-cli2.jsonc` / `.yaml` / `.cjs` / `.mjs` を優先し、次に `.markdownlint.jsonc` / `.json` / `.yaml` / `.yml` / `.cjs` / `.mjs` を探します。共有 workflow は `globs` を使わず変更対象だけを検査します。 |
+| `markdownlint-cli2` | `.markdownlint-cli2.jsonc` / `.yaml` と `.markdownlint.jsonc` / `.json` / `.yaml` / `.yml` の静的 config のみを扱います。`.cjs` / `.mjs` は任意コード実行を避けるため対象外です。共有 workflow は `globs` を使わず変更対象だけを検査します。 |
 | `taplo` | `.taplo.toml` を優先し、なければ `taplo.toml` を repo root で探します。未配置時は既定値で `fmt --check` を行います。 |
 | `biome` | Biome の既定探索で `biome.json` / `biome.jsonc` / `.biome.json` / `.biome.jsonc` を探し、未配置時は既定値を使います。 |
 | `shellcheck` | `.shellcheckrc` / `shellcheckrc` を対象 script の場所から親へ向けて探します。 |


### PR DESCRIPTION
## Summary
- add a shared `markdownlint-cli2` wrapper that follows the existing `patterns` / `install` / `run` contract
- register `markdownlint-cli2` in the shared linter config so repository-dispatch can select it dynamically
- document the default markdownlint-cli2 config discovery order and the changed-file-only behavior in `worker/README.md`
- add a repo-level `.markdownlint.jsonc` so this repository's existing docs style passes the new shared markdown lint in self-validation
- harden the markdownlint wrapper so `.cjs` / `.mjs` configs are rejected and only static JSON/YAML configs are copied into the isolated temp repo

## Validation
- `node -e 'JSON.parse(require("fs").readFileSync(".github/scripts/linters/config.json", "utf8"))'`
- `bash -n .github/scripts/secure-artifact.sh .github/scripts/linter-library.sh .github/scripts/linters/*.sh`
- `bash .github/scripts/linters/actionlint.sh install` and `$RUNNER_TEMP/actionlint/bin/actionlint .github/workflows/*.yml`
- `bash .github/scripts/linters/ghalint.sh install` and `$RUNNER_TEMP/ghalint/bin/ghalint run`
- `bash .github/scripts/linters/shellcheck.sh install` and `$RUNNER_TEMP/shellcheck/bin/shellcheck -x -P SCRIPTDIR .github/scripts/linters/markdownlint-cli2.sh`
- direct `markdownlint-cli2` smoke tests covering literal path handling and `--no-globs`
- direct `markdownlint-cli2 --no-globs :README.md :worker/README.md` with the committed repo config
- hardening smoke tests covering safe nested static configs plus root/nested `.cjs` / `.mjs` rejection through the wrapper JSON contract
- `git diff --check`

## Notes
- local `worker` checks were attempted earlier, but `worker/node_modules` is not present in this environment; hosted `validate-worker` remains the verification surface for that part