### PR TITLE
feat(linters): add ruff support

### DIFF
--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -46,6 +46,15 @@
       "details_fallback": "markdownlint-cli2 did not produce diagnostic output before the job failed."
     },
     {
+      "name": "ruff",
+      "heading": "### ruff",
+      "no_files": "No matching Python files were selected for `ruff`.",
+      "success": "✅ No issues found in {count} changed Python file(s).",
+      "failure": "❌ Issues found in {count} changed Python file(s).",
+      "infra_failure": "❌ The `ruff` workflow failed before producing a detailed report. See the workflow logs.",
+      "details_fallback": "ruff did not produce diagnostic output before the job failed."
+    },
+    {
       "name": "taplo",
       "heading": "### taplo",
       "no_files": "No matching TOML files were selected for `taplo`.",

--- a/.github/scripts/linters/ruff.sh
+++ b/.github/scripts/linters/ruff.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../linter-library.sh
+source "$script_dir/../linter-library.sh"
+
+mode=${1-}
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+case "$mode" in
+  patterns)
+    cat <<'EOF'
+\.(?:py|pyi)$
+EOF
+    ;;
+  install)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+    linter_lib::install_python_tools "$RUNNER_TEMP/ruff-venv" ruff
+    ;;
+  run)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+    output_file="$RUNNER_TEMP/linter-output.txt"
+    linter_lib::run_and_emit_json \
+      "$output_file" \
+      ruff check \
+      --force-exclude \
+      --no-cache \
+      --output-format concise \
+      "$@"
+    ;;
+  *)
+    echo "usage: $0 {patterns|install|run}" >&2
+    exit 1
+    ;;
+esac

--- a/worker/README.md
+++ b/worker/README.md
@@ -136,6 +136,7 @@ Worker は self-webhook を落として二重起動を防ぎます。
 | `spectral` | `.spectral.yml` / `.spectral.yaml` / `.spectral.json` を読みます。未配置時は `spectral:oas` を使い、unknown format は無視します。 |
 | `yamllint` | `.yamllint` 系 3 形式を順に探します。 |
 | `markdownlint-cli2` | `.markdownlint-cli2.jsonc` / `.yaml` と `.markdownlint.jsonc` / `.json` / `.yaml` / `.yml` の静的 config のみを扱います。`.cjs` / `.mjs` は任意コード実行を避けるため対象外です。共有 workflow は `globs` を使わず変更対象だけを検査します。 |
+| `ruff` | `pyproject.toml` の `[tool.ruff]`、`ruff.toml`、`.ruff.toml` を対象 file ごとに近いものから使います。同一 directory では `.ruff.toml` → `ruff.toml` → `pyproject.toml` の順です。共有 workflow は `--force-exclude` を付け、設定上の除外も尊重します。 |
 | `taplo` | `.taplo.toml` を優先し、なければ `taplo.toml` を repo root で探します。未配置時は既定値で `fmt --check` を行います。 |
 | `biome` | Biome の既定探索で `biome.json` / `biome.jsonc` / `.biome.json` / `.biome.jsonc` を探し、未配置時は既定値を使います。 |
 | `shellcheck` | `.shellcheckrc` / `shellcheckrc` を対象 script の場所から親へ向けて探します。 |


### PR DESCRIPTION
## Summary
- add a shared `ruff` wrapper that follows the existing `patterns` / `install` / `run` contract
- register `ruff` in the shared linter config so repository-dispatch can select it dynamically
- document Ruff config discovery and `--force-exclude` behavior in `worker/README.md`

## Validation
- `node -e 'JSON.parse(require("fs").readFileSync(".github/scripts/linters/config.json", "utf8"))'`
- `bash -n .github/scripts/secure-artifact.sh .github/scripts/linter-library.sh .github/scripts/linters/*.sh`
- `bash .github/scripts/linters/actionlint.sh install` and `$RUNNER_TEMP/actionlint/bin/actionlint .github/workflows/*.yml`
- `bash .github/scripts/linters/ghalint.sh install` and `$RUNNER_TEMP/ghalint/bin/ghalint run`
- `bash .github/scripts/linters/shellcheck.sh install` and `$RUNNER_TEMP/shellcheck/bin/shellcheck -x -P SCRIPTDIR .github/scripts/linters/ruff.sh`
- wrapper smoke tests with the standalone Ruff Linux binary covering clean files, lint failures, config-driven excludes, and nested `.ruff.toml` discovery
- `git diff --check`

## Notes
- local `worker` checks were attempted, but `worker/node_modules` is not present in this environment; hosted `validate-worker` will verify that surface
- this PR does not change any `.py` or `.pyi` files, so the repository-dispatch workflow is not expected to schedule `ruff / run-linter` for this PR itself