### PR TITLE
fix(repository-dispatch): prevent duplicate PR comments

### DIFF
--- a/.github/scripts/upsert-pr-comment.js
+++ b/.github/scripts/upsert-pr-comment.js
@@ -1,0 +1,121 @@
+const fs = require("node:fs");
+
+module.exports = async function upsertPullRequestComment({ github, env }) {
+	const marker = requireEnv(env, "COMMENT_MARKER");
+	const owner = requireEnv(env, "PR_OWNER");
+	const repo = requireEnv(env, "PR_REPO");
+	const issueNumber = parseIssueNumber(env.PR_NUMBER);
+	const body = resolveCommentBody(env, marker);
+
+	const comments = await github.paginate(github.rest.issues.listComments, {
+		owner,
+		repo,
+		issue_number: issueNumber,
+		per_page: 100,
+	});
+	const markerComments = comments
+		.filter(
+			(comment) =>
+				comment &&
+				typeof comment.id === "number" &&
+				typeof comment.body === "string" &&
+				comment.body.includes(marker),
+		)
+		.sort(compareComments);
+
+	if (markerComments.length === 0) {
+		await github.rest.issues.createComment({
+			owner,
+			repo,
+			issue_number: issueNumber,
+			body,
+		});
+		return;
+	}
+
+	const [primaryComment, ...duplicateComments] = markerComments;
+
+	await github.rest.issues.updateComment({
+		owner,
+		repo,
+		comment_id: primaryComment.id,
+		body,
+	});
+
+	for (const duplicateComment of duplicateComments) {
+		await github.rest.issues.deleteComment({
+			owner,
+			repo,
+			comment_id: duplicateComment.id,
+		});
+	}
+};
+
+function requireEnv(env, key) {
+	const value = env[key];
+
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(`${key} is required`);
+	}
+
+	return value;
+}
+
+function parseIssueNumber(rawValue) {
+	const issueNumber = Number(rawValue);
+
+	if (!Number.isInteger(issueNumber) || issueNumber < 1) {
+		throw new Error("PR_NUMBER must be a positive integer");
+	}
+
+	return issueNumber;
+}
+
+function resolveCommentBody(env, marker) {
+	if (typeof env.COMMENT_BODY === "string" && env.COMMENT_BODY.length > 0) {
+		return env.COMMENT_BODY;
+	}
+
+	if (
+		typeof env.COMMENT_FILE === "string" &&
+		env.COMMENT_FILE.length > 0 &&
+		fs.existsSync(env.COMMENT_FILE)
+	) {
+		return fs.readFileSync(env.COMMENT_FILE, "utf8");
+	}
+
+	return [
+		marker,
+		"## linter-service",
+		"",
+		"❌ The linter-service workflow failed to generate a combined report. See the workflow logs.",
+		"",
+	].join("\n");
+}
+
+function compareComments(left, right) {
+	const createdAtDelta = compareCreatedAt(left?.created_at, right?.created_at);
+
+	if (createdAtDelta !== 0) {
+		return createdAtDelta;
+	}
+
+	return left.id - right.id;
+}
+
+function compareCreatedAt(leftValue, rightValue) {
+	const leftTime = Date.parse(leftValue ?? "");
+	const rightTime = Date.parse(rightValue ?? "");
+	const leftIsValid = Number.isFinite(leftTime);
+	const rightIsValid = Number.isFinite(rightTime);
+
+	if (leftIsValid && rightIsValid && leftTime !== rightTime) {
+		return leftTime - rightTime;
+	}
+
+	if (leftIsValid !== rightIsValid) {
+		return leftIsValid ? -1 : 1;
+	}
+
+	return 0;
+}

--- a/.github/scripts/upsert-pr-comment.test.js
+++ b/.github/scripts/upsert-pr-comment.test.js
@@ -1,0 +1,177 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const upsertPullRequestComment = require("./upsert-pr-comment.js");
+
+test("creates a new marker comment when none exists", async () => {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "upsert-pr-comment-"));
+	const commentPath = path.join(tempDir, "comment.md");
+	const body = "<!-- linter-service:results -->\ncreated\n";
+
+	fs.writeFileSync(commentPath, body, "utf8");
+
+	const createCalls = [];
+	const updateCalls = [];
+	const deleteCalls = [];
+	const github = createGitHubClient({
+		comments: [],
+		createCalls,
+		deleteCalls,
+		updateCalls,
+	});
+
+	try {
+		await upsertPullRequestComment({
+			env: {
+				COMMENT_FILE: commentPath,
+				COMMENT_MARKER: "<!-- linter-service:results -->",
+				PR_NUMBER: "38",
+				PR_OWNER: "chalharu",
+				PR_REPO: "copilot-sandbox-orchestrator",
+			},
+			github,
+		});
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+
+	assert.deepEqual(updateCalls, []);
+	assert.deepEqual(deleteCalls, []);
+	assert.equal(createCalls.length, 1);
+	assert.deepEqual(createCalls[0], {
+		body,
+		issue_number: 38,
+		owner: "chalharu",
+		repo: "copilot-sandbox-orchestrator",
+	});
+});
+
+test("updates the oldest marker comment and removes duplicate marker comments", async () => {
+	const createCalls = [];
+	const updateCalls = [];
+	const deleteCalls = [];
+	const github = createGitHubClient({
+		comments: [
+			{
+				body: "unrelated",
+				created_at: "2026-04-01T06:48:35Z",
+				id: 9,
+			},
+			{
+				body: "<!-- linter-service:results -->\nsecond\n",
+				created_at: "2026-04-01T06:48:36Z",
+				id: 22,
+			},
+			{
+				body: "<!-- linter-service:results -->\nfirst\n",
+				created_at: "2026-04-01T06:48:36Z",
+				id: 21,
+			},
+		],
+		createCalls,
+		deleteCalls,
+		updateCalls,
+	});
+
+	await upsertPullRequestComment({
+		env: {
+			COMMENT_BODY: "<!-- linter-service:results -->\nupdated\n",
+			COMMENT_MARKER: "<!-- linter-service:results -->",
+			PR_NUMBER: "38",
+			PR_OWNER: "chalharu",
+			PR_REPO: "copilot-sandbox-orchestrator",
+		},
+		github,
+	});
+
+	assert.deepEqual(createCalls, []);
+	assert.deepEqual(updateCalls, [
+		{
+			body: "<!-- linter-service:results -->\nupdated\n",
+			comment_id: 21,
+			owner: "chalharu",
+			repo: "copilot-sandbox-orchestrator",
+		},
+	]);
+	assert.deepEqual(deleteCalls, [
+		{
+			comment_id: 22,
+			owner: "chalharu",
+			repo: "copilot-sandbox-orchestrator",
+		},
+	]);
+});
+
+test("falls back to the default failure body when no comment file exists", async () => {
+	const createCalls = [];
+	const github = createGitHubClient({
+		comments: [],
+		createCalls,
+		deleteCalls: [],
+		updateCalls: [],
+	});
+
+	await upsertPullRequestComment({
+		env: {
+			COMMENT_FILE: path.join(os.tmpdir(), "missing-comment-file.md"),
+			COMMENT_MARKER: "<!-- linter-service:results -->",
+			PR_NUMBER: "38",
+			PR_OWNER: "chalharu",
+			PR_REPO: "copilot-sandbox-orchestrator",
+		},
+		github,
+	});
+
+	assert.equal(createCalls.length, 1);
+	assert.equal(
+		createCalls[0].body,
+		[
+			"<!-- linter-service:results -->",
+			"## linter-service",
+			"",
+			"❌ The linter-service workflow failed to generate a combined report. See the workflow logs.",
+			"",
+		].join("\n"),
+	);
+});
+
+function createGitHubClient({
+	comments,
+	createCalls,
+	deleteCalls,
+	updateCalls,
+}) {
+	return {
+		paginate: async (handler, params) => {
+			assert.equal(handler, issues.listComments);
+			assert.deepEqual(params, {
+				issue_number: 38,
+				owner: "chalharu",
+				per_page: 100,
+				repo: "copilot-sandbox-orchestrator",
+			});
+			return comments;
+		},
+		rest: {
+			issues: {
+				createComment: async (params) => {
+					createCalls.push(params);
+				},
+				deleteComment: async (params) => {
+					deleteCalls.push(params);
+				},
+				listComments: issues.listComments,
+				updateComment: async (params) => {
+					updateCalls.push(params);
+				},
+			},
+		},
+	};
+}
+
+const issues = {
+	listComments() {},
+};

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -11,6 +11,10 @@ on:
     types:
       - github_app_webhook
 
+concurrency:
+  group: ${{ format('repository-dispatch-{0}-{1}', github.event_name == 'pull_request' && github.repository || github.event.client_payload.repository.full_name || github.repository, github.event_name == 'pull_request' && github.event.pull_request.number || github.event.client_payload.pull_request.number || github.run_id) }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
@@ -602,53 +606,17 @@ jobs:
         env:
           COMMENT_FILE: ${{ runner.temp }}/combined-linter-comment.md
           COMMENT_MARKER: '<!-- linter-service:results -->'
+          LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
           PR_NUMBER: ${{ needs.detect-targets.outputs.pull-request-number }}
           PR_OWNER: ${{ steps.decode_repository_context.outputs.pr-owner }}
           PR_REPO: ${{ steps.decode_repository_context.outputs.pr-repo }}
         with:
           github-token: ${{ steps.get_pr_token.outputs.token }}
           script: |
-            const fs = require("node:fs");
-
-            const body = fs.existsSync(process.env.COMMENT_FILE)
-              ? fs.readFileSync(process.env.COMMENT_FILE, "utf8")
-              : [
-                  process.env.COMMENT_MARKER,
-                  "## linter-service",
-                  "",
-                  "❌ The linter-service workflow failed to generate a combined report. See the workflow logs.",
-                  "",
-                ].join("\n");
-            const marker = process.env.COMMENT_MARKER;
-            const owner = process.env.PR_OWNER;
-            const repo = process.env.PR_REPO;
-            const issueNumber = Number(process.env.PR_NUMBER);
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number: issueNumber,
-              per_page: 100,
-            });
-
-            const existing = comments.find((comment) => comment.body?.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body,
-              });
-              return;
-            }
-
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: issueNumber,
-              body,
-            });
+            const upsertPullRequestComment = require(
+              `${process.env.LINTER_SERVICE_PATH}/.github/scripts/upsert-pr-comment.js`,
+            );
+            await upsertPullRequestComment({ github, env: process.env });
 
       - name: Finalize processing check run
         if: ${{ always() }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -11,14 +11,14 @@ rules:
       - lint-common.yml:69
       - lint-common.yml:72
       - lint-common.yml:250
-      - repository-dispatch.yml:117
-      - repository-dispatch.yml:120
-      - repository-dispatch.yml:338
-      - repository-dispatch.yml:341
-      - repository-dispatch.yml:390
-      - repository-dispatch.yml:391
-      - repository-dispatch.yml:461
-      - repository-dispatch.yml:464
-      - repository-dispatch.yml:471
-      - repository-dispatch.yml:474
-      - repository-dispatch.yml:480
+      - repository-dispatch.yml:121
+      - repository-dispatch.yml:124
+      - repository-dispatch.yml:342
+      - repository-dispatch.yml:345
+      - repository-dispatch.yml:394
+      - repository-dispatch.yml:395
+      - repository-dispatch.yml:465
+      - repository-dispatch.yml:468
+      - repository-dispatch.yml:475
+      - repository-dispatch.yml:478
+      - repository-dispatch.yml:484


### PR DESCRIPTION
## Background
- `chalharu/copilot-sandbox-orchestrator#38` ended up with duplicate `linter-service` comments.
- Multiple `repository_dispatch` runs for the same PR could overlap, and the previous comment upsert logic used a non-atomic list/find/create flow.

## What changed
- add workflow-level concurrency keyed by target repository + PR number so same-PR runs do not publish comments in parallel
- extract PR comment upsert into `.github/scripts/upsert-pr-comment.js`
- keep the oldest marker comment, update it, and delete extra duplicates when they already exist
- add regression tests for create / update+dedupe / fallback behavior

## Validation
- `node --test .github/scripts/upsert-pr-comment.test.js`
- `git diff --check`

## Notes
- `actionlint` and `ghalint` are part of the normal validation flow, but those binaries were not available in this execution environment, so hosted CI will verify the workflow syntax.
