### PR TITLE
fix(repository-dispatch): encrypt dispatch context artifacts

### DIFF
--- a/.github/scripts/artifact-passphrase.sh
+++ b/.github/scripts/artifact-passphrase.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "node is required" >&2
+  exit 1
+fi
+
+: "${CHECKER_PRIVATE_KEY:?CHECKER_PRIVATE_KEY is required}"
+: "${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+
+node -e 'const crypto = require("node:crypto"); process.stdout.write(crypto.createHmac("sha256", process.env.CHECKER_PRIVATE_KEY).update(process.env.GITHUB_RUN_ID).digest("hex"));'

--- a/.github/scripts/artifact-passphrase.test.js
+++ b/.github/scripts/artifact-passphrase.test.js
@@ -1,0 +1,92 @@
+const assert = require("node:assert/strict");
+const { createHmac } = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+const test = require("node:test");
+
+const scriptPath = path.join(__dirname, "artifact-passphrase.sh");
+const secureArtifactPath = path.join(__dirname, "secure-artifact.sh");
+
+test("artifact-passphrase.sh derives the expected HMAC for the workflow run", () => {
+	const output = execFileSync("bash", [scriptPath], {
+		encoding: "utf8",
+		env: {
+			...process.env,
+			CHECKER_PRIVATE_KEY: "test-private-key",
+			GITHUB_RUN_ID: "123456789",
+		},
+	});
+
+	const expected = createHmac("sha256", "test-private-key")
+		.update("123456789")
+		.digest("hex");
+
+	assert.equal(output, expected);
+});
+
+test("secure-artifact.sh round-trips detect-targets context with the derived passphrase", () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "artifact-passphrase-"),
+	);
+	const inputPath = path.join(tempDir, "detect-targets-context.json");
+	const encryptedPath = path.join(tempDir, "detect-targets-context.json.enc");
+	const decryptedPath = path.join(
+		tempDir,
+		"detect-targets-context.decrypted.json",
+	);
+
+	fs.writeFileSync(
+		inputPath,
+		JSON.stringify(
+			{
+				pr_owner: "chalharu",
+				pr_repo: "linter-service",
+				source_head_sha: "abc123",
+			},
+			null,
+			2,
+		),
+		"utf8",
+	);
+
+	const passphrase = execFileSync("bash", [scriptPath], {
+		encoding: "utf8",
+		env: {
+			...process.env,
+			CHECKER_PRIVATE_KEY: "test-private-key",
+			GITHUB_RUN_ID: "123456789",
+		},
+	});
+
+	try {
+		execFileSync(
+			"bash",
+			[secureArtifactPath, "encrypt", inputPath, encryptedPath],
+			{
+				env: {
+					...process.env,
+					ARTIFACT_PASSPHRASE: passphrase,
+				},
+			},
+		);
+		execFileSync(
+			"bash",
+			[secureArtifactPath, "decrypt", encryptedPath, decryptedPath],
+			{
+				env: {
+					...process.env,
+					ARTIFACT_PASSPHRASE: passphrase,
+				},
+			},
+		);
+
+		assert.equal(
+			fs.readFileSync(decryptedPath, "utf8"),
+			fs.readFileSync(inputPath, "utf8"),
+		);
+	} finally {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+});

--- a/.github/workflows/lint-common.yml
+++ b/.github/workflows/lint-common.yml
@@ -39,6 +39,24 @@ jobs:
           persist-credentials: false
           ref: ${{ github.sha }}
 
+      - name: Derive artifact passphrase
+        env:
+          CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
+        run: |
+          passphrase="$(bash "$LINTER_SERVICE_PATH/.github/scripts/artifact-passphrase.sh")"
+          echo "::add-mask::$passphrase"
+          echo "ARTIFACT_PASSPHRASE=$passphrase" >> "$GITHUB_ENV"
+
+      - name: Decrypt dispatch context artifact
+        run: |
+          encrypted_path="$RUNNER_TEMP/detect-targets-context/detect-targets-context.json.enc"
+          decrypted_path="$RUNNER_TEMP/detect-targets-context/detect-targets-context.json"
+          bash "$LINTER_SERVICE_PATH/.github/scripts/secure-artifact.sh" \
+            decrypt \
+            "$encrypted_path" \
+            "$decrypted_path"
+          rm -f "$encrypted_path"
+
       - name: Mask repository metadata
         env:
           CONTEXT_PATH: ${{ runner.temp }}/detect-targets-context/detect-targets-context.json
@@ -243,15 +261,6 @@ jobs:
             encoding="utf-8",
           )
           PY
-
-      - name: Derive summary artifact passphrase
-        if: ${{ always() }}
-        env:
-          CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
-        run: |
-          passphrase="$(node -e 'const crypto = require("node:crypto"); process.stdout.write(crypto.createHmac("sha256", process.env.CHECKER_PRIVATE_KEY).update(process.env.GITHUB_RUN_ID).digest("hex"));')"
-          echo "::add-mask::$passphrase"
-          echo "ARTIFACT_PASSPHRASE=$passphrase" >> "$GITHUB_ENV"
 
       - name: Encrypt linter summary artifact
         id: encrypt_summary

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -279,11 +279,32 @@ jobs:
           echo "Routing targets resolved."
           echo "Selected linters: ${SELECTED_LINTERS_JSON}"
 
+      - name: Derive artifact passphrase
+        env:
+          CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
+          LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
+        run: |
+          passphrase="$(bash "$LINTER_SERVICE_PATH/.github/scripts/artifact-passphrase.sh")"
+          echo "::add-mask::$passphrase"
+          echo "ARTIFACT_PASSPHRASE=$passphrase" >> "$GITHUB_ENV"
+
+      - name: Encrypt dispatch context artifact
+        env:
+          CONTEXT_PATH: ${{ steps.collect.outputs.context-path }}
+          LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
+        run: |
+          encrypted_path="$RUNNER_TEMP/detect-targets-context.json.enc"
+          bash "$LINTER_SERVICE_PATH/.github/scripts/secure-artifact.sh" \
+            encrypt \
+            "$CONTEXT_PATH" \
+            "$encrypted_path"
+          rm -f "$CONTEXT_PATH"
+
       - name: Upload dispatch context artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: detect-targets-context
-          path: ${{ steps.collect.outputs.context-path }}
+          path: ${{ runner.temp }}/detect-targets-context.json.enc
           if-no-files-found: error
           retention-days: 1
 
@@ -307,6 +328,27 @@ jobs:
           path: linter-service
           persist-credentials: false
           ref: ${{ github.sha }}
+
+      - name: Derive artifact passphrase
+        env:
+          CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
+          LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
+        run: |
+          passphrase="$(bash "$LINTER_SERVICE_PATH/.github/scripts/artifact-passphrase.sh")"
+          echo "::add-mask::$passphrase"
+          echo "ARTIFACT_PASSPHRASE=$passphrase" >> "$GITHUB_ENV"
+
+      - name: Decrypt dispatch context artifact
+        env:
+          LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
+        run: |
+          encrypted_path="$RUNNER_TEMP/detect-targets-context/detect-targets-context.json.enc"
+          decrypted_path="$RUNNER_TEMP/detect-targets-context/detect-targets-context.json"
+          bash "$LINTER_SERVICE_PATH/.github/scripts/secure-artifact.sh" \
+            decrypt \
+            "$encrypted_path" \
+            "$decrypted_path"
+          rm -f "$encrypted_path"
 
       - name: Mask repository metadata
         env:
@@ -418,6 +460,27 @@ jobs:
           persist-credentials: false
           ref: ${{ github.sha }}
 
+      - name: Derive artifact passphrase
+        env:
+          CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
+          LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
+        run: |
+          passphrase="$(bash "$LINTER_SERVICE_PATH/.github/scripts/artifact-passphrase.sh")"
+          echo "::add-mask::$passphrase"
+          echo "ARTIFACT_PASSPHRASE=$passphrase" >> "$GITHUB_ENV"
+
+      - name: Decrypt dispatch context artifact
+        env:
+          LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
+        run: |
+          encrypted_path="$RUNNER_TEMP/detect-targets-context/detect-targets-context.json.enc"
+          decrypted_path="$RUNNER_TEMP/detect-targets-context/detect-targets-context.json"
+          bash "$LINTER_SERVICE_PATH/.github/scripts/secure-artifact.sh" \
+            decrypt \
+            "$encrypted_path" \
+            "$decrypted_path"
+          rm -f "$encrypted_path"
+
       - name: Download linter summary artifacts
         if: ${{ always() }}
         continue-on-error: true
@@ -477,15 +540,6 @@ jobs:
           permission-checks: write
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_repository_context.outputs.source-repo }}
-
-      - name: Derive summary artifact passphrase
-        if: ${{ always() }}
-        env:
-          CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
-        run: |
-          passphrase="$(node -e 'const crypto = require("node:crypto"); process.stdout.write(crypto.createHmac("sha256", process.env.CHECKER_PRIVATE_KEY).update(process.env.GITHUB_RUN_ID).digest("hex"));')"
-          echo "::add-mask::$passphrase"
-          echo "ARTIFACT_PASSPHRASE=$passphrase" >> "$GITHUB_ENV"
 
       - name: Decrypt linter summary artifacts
         id: decrypt_summaries

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -8,17 +8,19 @@ rules:
         - CHECKER_APP_ID
         - CHECKER_PRIVATE_KEY
     ignore:
-      - lint-common.yml:69
-      - lint-common.yml:72
-      - lint-common.yml:250
+      - lint-common.yml:44
+      - lint-common.yml:87
+      - lint-common.yml:90
       - repository-dispatch.yml:121
       - repository-dispatch.yml:124
-      - repository-dispatch.yml:342
-      - repository-dispatch.yml:345
-      - repository-dispatch.yml:394
-      - repository-dispatch.yml:395
+      - repository-dispatch.yml:284
+      - repository-dispatch.yml:334
+      - repository-dispatch.yml:384
+      - repository-dispatch.yml:387
+      - repository-dispatch.yml:436
+      - repository-dispatch.yml:437
       - repository-dispatch.yml:465
-      - repository-dispatch.yml:468
-      - repository-dispatch.yml:475
-      - repository-dispatch.yml:478
-      - repository-dispatch.yml:484
+      - repository-dispatch.yml:528
+      - repository-dispatch.yml:531
+      - repository-dispatch.yml:538
+      - repository-dispatch.yml:541


### PR DESCRIPTION
## Summary
- encrypt `detect-targets-context` before uploading the workflow artifact
- decrypt the context artifact in downstream jobs and reuse a shared passphrase helper
- add regression coverage for artifact passphrase derivation and encrypted artifact round trips

## Testing
- `node --test .github/scripts/artifact-passphrase.test.js`
- `actionlint .github/workflows/repository-dispatch.yml .github/workflows/lint-common.yml`
- `ghalint run`
- `shellcheck -x -P SCRIPTDIR .github/scripts/artifact-passphrase.sh .github/scripts/secure-artifact.sh`
- `git diff --check`

## Notes
- Local `yamllint` could not be run in this repository/runtime because the generic containerized helper expects repository files that are not present here and Python is unavailable locally. Hosted CI still covers that path.
