### PR TITLE
feat(linters): add cargo-fmt shared linter

### DIFF
--- a/.github/scripts/linters/cargo-fmt.sh
+++ b/.github/scripts/linters/cargo-fmt.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../linter-library.sh
+source "$script_dir/../linter-library.sh"
+
+cargo_fmt_prepare_env() {
+  : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+
+  export CARGO_HOME="${CARGO_HOME:-$RUNNER_TEMP/cargo}"
+  export RUSTUP_HOME="${RUSTUP_HOME:-$RUNNER_TEMP/rustup}"
+  export PATH="$CARGO_HOME/bin:$PATH"
+}
+
+cargo_fmt_persist_env() {
+  if [ -n "${GITHUB_ENV:-}" ]; then
+    printf 'CARGO_HOME=%s\n' "$CARGO_HOME" >> "$GITHUB_ENV"
+    printf 'RUSTUP_HOME=%s\n' "$RUSTUP_HOME" >> "$GITHUB_ENV"
+  fi
+}
+
+cargo_fmt_find_manifest() {
+  local path=$1
+  local current_dir candidate
+
+  current_dir=$(dirname "$path")
+  while :; do
+    candidate="$current_dir/Cargo.toml"
+    if [ -f "$candidate" ]; then
+      printf '%s\n' "${candidate#./}"
+      return 0
+    fi
+
+    if [ "$current_dir" = "." ] || [ "$current_dir" = "/" ]; then
+      break
+    fi
+
+    current_dir=$(dirname "$current_dir")
+  done
+
+  return 1
+}
+
+mode=${1-}
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+case "$mode" in
+  patterns)
+    cat <<'EOF'
+\.(?:rs)$
+EOF
+    ;;
+  install)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+    cargo_fmt_prepare_env
+
+    if command -v cargo >/dev/null 2>&1 && cargo fmt --version >/dev/null 2>&1; then
+      exit 0
+    fi
+
+    rustup_init="$RUNNER_TEMP/rustup-init"
+
+    rm -rf "$CARGO_HOME" "$RUSTUP_HOME"
+    mkdir -p "$CARGO_HOME" "$RUSTUP_HOME"
+
+    curl -fsSL \
+      https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init \
+      -o "$rustup_init"
+    chmod +x "$rustup_init"
+
+    "$rustup_init" \
+      -y \
+      --profile minimal \
+      --default-toolchain stable \
+      --component rustfmt \
+      --no-modify-path \
+      >/dev/null
+
+    cargo_fmt_persist_env
+    linter_lib::add_path "$CARGO_HOME/bin"
+    ;;
+  run)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+    cargo_fmt_prepare_env
+    output_file="$RUNNER_TEMP/linter-output.txt"
+    manifests=()
+    missing_files=()
+    declare -A seen_manifests=()
+    path=""
+    manifest_path=""
+
+    for path in "$@"; do
+      if ! manifest_path=$(cargo_fmt_find_manifest "$path"); then
+        missing_files+=("$path")
+        continue
+      fi
+
+      if [ -z "${seen_manifests[$manifest_path]+x}" ]; then
+        seen_manifests["$manifest_path"]=1
+        manifests+=("$manifest_path")
+      fi
+    done
+
+    if [ "${#missing_files[@]}" -gt 0 ]; then
+      {
+        echo "Cargo fmt requires each selected Rust file to belong to a Cargo package."
+        echo "No Cargo.toml found for:"
+        for path in "${missing_files[@]}"; do
+          printf ' - %s\n' "$path"
+        done
+      } > "$output_file"
+      linter_lib::emit_json_result 1 "$output_file"
+      exit 0
+    fi
+
+    run_cargo_fmt() {
+      local failure=0
+      local current_manifest
+
+      for current_manifest in "${manifests[@]}"; do
+        printf '==> cargo fmt --check --manifest-path %s\n' "$current_manifest"
+        if ! cargo fmt --check --manifest-path "$current_manifest"; then
+          failure=1
+        fi
+        echo
+      done
+
+      return "$failure"
+    }
+
+    linter_lib::run_and_emit_json "$output_file" run_cargo_fmt
+    ;;
+  *)
+    echo "usage: $0 {patterns|install|run}" >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/linters/cargo-fmt.test.js
+++ b/.github/scripts/linters/cargo-fmt.test.js
@@ -1,0 +1,267 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+const test = require("node:test");
+
+const scriptPath = path.join(__dirname, "cargo-fmt.sh");
+
+function writeExecutable(filePath, content) {
+	fs.writeFileSync(filePath, content, "utf8");
+	fs.chmodSync(filePath, 0o755);
+}
+
+function createPythonStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "python3"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+cat >/dev/null
+exit_code="$2"
+output_file="$3"
+node - "$exit_code" "$output_file" <<'NODE'
+const fs = require("node:fs");
+const [exitCode, outputFile] = process.argv.slice(2);
+const details = fs.existsSync(outputFile)
+\t? fs.readFileSync(outputFile, "utf8").trim()
+\t: "";
+process.stdout.write(JSON.stringify({ details, exit_code: Number(exitCode) }));
+NODE
+`,
+	);
+}
+
+function createCargoStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "cargo"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+manifest=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --manifest-path)
+      manifest="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+printf '%s\\n' "$manifest" >> "$CARGO_MANIFEST_LOG"
+printf 'checked %s\\n' "$manifest"
+if [ -n "\${FAIL_MANIFEST:-}" ] && [ "$manifest" = "$FAIL_MANIFEST" ]; then
+  printf 'unformatted %s\\n' "$manifest" >&2
+  exit 1
+fi
+`,
+	);
+}
+
+function makeTempRepo(prefix) {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	const repoDir = path.join(tempDir, "repo");
+	const runnerTemp = path.join(tempDir, "runner");
+	const binDir = path.join(tempDir, "bin");
+	const cargoManifestLog = path.join(tempDir, "cargo-manifests.log");
+
+	fs.mkdirSync(repoDir, { recursive: true });
+	fs.mkdirSync(runnerTemp, { recursive: true });
+	fs.mkdirSync(binDir, { recursive: true });
+
+	createPythonStub(binDir);
+	createCargoStub(binDir);
+
+	return { binDir, cargoManifestLog, repoDir, runnerTemp, tempDir };
+}
+
+function writeFile(filePath, content) {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, content, "utf8");
+}
+
+test("cargo-fmt.sh groups changed Rust files by nearest Cargo.toml", () => {
+	const { binDir, cargoManifestLog, repoDir, runnerTemp, tempDir } =
+		makeTempRepo("cargo-fmt-grouped-");
+
+	writeFile(
+		path.join(repoDir, "Cargo.toml"),
+		`[package]
+name = "root"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(path.join(repoDir, "src/lib.rs"), "pub fn root_lib() {}\n");
+	writeFile(path.join(repoDir, "src/main.rs"), "fn main() {}\n");
+	writeFile(
+		path.join(repoDir, "crates/member/Cargo.toml"),
+		`[package]
+name = "member"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(
+		path.join(repoDir, "crates/member/src/lib.rs"),
+		"pub fn member_lib() {}\n",
+	);
+
+	try {
+		const output = execFileSync(
+			"bash",
+			[
+				scriptPath,
+				"run",
+				"src/lib.rs",
+				"src/main.rs",
+				"crates/member/src/lib.rs",
+			],
+			{
+				cwd: repoDir,
+				encoding: "utf8",
+				env: {
+					...process.env,
+					CARGO_MANIFEST_LOG: cargoManifestLog,
+					PATH: `${binDir}:${process.env.PATH}`,
+					RUNNER_TEMP: runnerTemp,
+				},
+			},
+		);
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 0);
+		assert.deepEqual(
+			fs.readFileSync(cargoManifestLog, "utf8").trim().split("\n"),
+			["Cargo.toml", "crates/member/Cargo.toml"],
+		);
+		assert.match(
+			result.details,
+			/cargo fmt --check --manifest-path Cargo\.toml/,
+		);
+		assert.match(
+			result.details,
+			/cargo fmt --check --manifest-path crates\/member\/Cargo\.toml/,
+		);
+	} finally {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+});
+
+test("cargo-fmt.sh reports Rust files outside Cargo packages", () => {
+	const { binDir, cargoManifestLog, repoDir, runnerTemp, tempDir } =
+		makeTempRepo("cargo-fmt-missing-manifest-");
+
+	writeFile(path.join(repoDir, "standalone.rs"), "fn main() {}\n");
+
+	try {
+		const output = execFileSync("bash", [scriptPath, "run", "standalone.rs"], {
+			cwd: repoDir,
+			encoding: "utf8",
+			env: {
+				...process.env,
+				CARGO_MANIFEST_LOG: cargoManifestLog,
+				PATH: `${binDir}:${process.env.PATH}`,
+				RUNNER_TEMP: runnerTemp,
+			},
+		});
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 1);
+		assert.match(result.details, /No Cargo\.toml found for:/);
+		assert.match(result.details, /standalone\.rs/);
+		assert.equal(fs.existsSync(cargoManifestLog), false);
+	} finally {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+});
+
+test("cargo-fmt.sh handles absolute Rust file paths outside Cargo packages", () => {
+	const { binDir, cargoManifestLog, repoDir, runnerTemp, tempDir } =
+		makeTempRepo("cargo-fmt-absolute-missing-manifest-");
+	const standalonePath = path.join(tempDir, "standalone.rs");
+
+	writeFile(standalonePath, "fn main() {}\n");
+
+	try {
+		const output = execFileSync("bash", [scriptPath, "run", standalonePath], {
+			cwd: repoDir,
+			encoding: "utf8",
+			env: {
+				...process.env,
+				CARGO_MANIFEST_LOG: cargoManifestLog,
+				PATH: `${binDir}:${process.env.PATH}`,
+				RUNNER_TEMP: runnerTemp,
+			},
+			timeout: 1000,
+		});
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 1);
+		assert.match(result.details, /No Cargo\.toml found for:/);
+		assert.match(result.details, /standalone\.rs/);
+		assert.equal(fs.existsSync(cargoManifestLog), false);
+	} finally {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+});
+
+test("cargo-fmt.sh continues checking later Cargo packages after one failure", () => {
+	const { binDir, cargoManifestLog, repoDir, runnerTemp, tempDir } =
+		makeTempRepo("cargo-fmt-continue-");
+
+	writeFile(
+		path.join(repoDir, "Cargo.toml"),
+		`[package]
+name = "root"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(path.join(repoDir, "src/lib.rs"), "pub fn root_lib() {}\n");
+	writeFile(
+		path.join(repoDir, "crates/member/Cargo.toml"),
+		`[package]
+name = "member"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(
+		path.join(repoDir, "crates/member/src/lib.rs"),
+		"pub fn member_lib() {}\n",
+	);
+
+	try {
+		const output = execFileSync(
+			"bash",
+			[scriptPath, "run", "src/lib.rs", "crates/member/src/lib.rs"],
+			{
+				cwd: repoDir,
+				encoding: "utf8",
+				env: {
+					...process.env,
+					CARGO_MANIFEST_LOG: cargoManifestLog,
+					FAIL_MANIFEST: "Cargo.toml",
+					PATH: `${binDir}:${process.env.PATH}`,
+					RUNNER_TEMP: runnerTemp,
+				},
+			},
+		);
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 1);
+		assert.deepEqual(
+			fs.readFileSync(cargoManifestLog, "utf8").trim().split("\n"),
+			["Cargo.toml", "crates/member/Cargo.toml"],
+		);
+		assert.match(result.details, /unformatted Cargo\.toml/);
+		assert.match(
+			result.details,
+			/cargo fmt --check --manifest-path crates\/member\/Cargo\.toml/,
+		);
+	} finally {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+});

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -55,6 +55,15 @@
       "details_fallback": "ruff did not produce diagnostic output before the job failed."
     },
     {
+      "name": "cargo-fmt",
+      "heading": "### cargo-fmt",
+      "no_files": "No matching Rust files were selected for `cargo-fmt`.",
+      "success": "✅ No formatting issues found in Cargo package(s) containing {count} changed Rust file(s).",
+      "failure": "❌ Formatting issues found in Cargo package(s) containing {count} changed Rust file(s).",
+      "infra_failure": "❌ The `cargo-fmt` workflow failed before producing a detailed report. See the workflow logs.",
+      "details_fallback": "cargo-fmt did not produce diagnostic output before the job failed."
+    },
+    {
       "name": "taplo",
       "heading": "### taplo",
       "no_files": "No matching TOML files were selected for `taplo`.",

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ GitHub Actions が共通ルールで lint します。
 | `yamllint` | `*.yaml`, `*.yml` | `.yamllint` / `.yamllint.yaml` / `.yamllint.yml` を順に探します。 |
 | `markdownlint-cli2` | `*.md`, `*.markdown` | `.markdownlint-cli2.jsonc` / `.markdownlint-cli2.yaml` と `.markdownlint.jsonc` / `.markdownlint.json` / `.markdownlint.yaml` / `.markdownlint.yml` の静的 config のみを扱います。`.cjs` / `.mjs` は任意コード実行を避けるため対象外です。共有 workflow は `globs` を使わず、変更対象だけを検査します。 |
 | `ruff` | `*.py`, `*.pyi` | `pyproject.toml` の `[tool.ruff]`、`ruff.toml`、`.ruff.toml` を対象 file ごとに近いものから使います。同一 directory では `.ruff.toml` → `ruff.toml` → `pyproject.toml` の順です。共有 workflow は `--force-exclude` を付け、設定上の除外も尊重します。 |
+| `cargo-fmt` | `*.rs` | changed Rust file ごとに最も近い `Cargo.toml` を探し、重複を除いた package 単位で `cargo fmt --check --manifest-path ...` を実行します。`rustfmt.toml` / `.rustfmt.toml` と `rust-toolchain.toml` / `rust-toolchain` は Cargo / rustup の既定探索を使います。 |
 | `taplo` | `*.toml` | `.taplo.toml` を優先し、なければ `taplo.toml` を repo root で探します。未配置時は既定値で `fmt --check` を行います。 |
 | `biome` | `*.js`, `*.jsx`, `*.ts`, `*.tsx`, `*.json`, `*.jsonc`, `*.cjs`, `*.cts`, `*.mjs`, `*.mts` | Biome の既定探索で `biome.json` / `biome.jsonc` / `.biome.json` / `.biome.jsonc` を探し、未配置時は既定値を使います。 |
 | `shellcheck` | `*.bash`, `*.ksh`, `*.sh` | `.shellcheckrc` / `shellcheckrc` を対象 script の場所から親へ向けて探します。 |


### PR DESCRIPTION
## Summary
- add a data-driven `cargo-fmt` shared linter wrapper and register it in `config.json`
- run `cargo fmt --check` once per affected Cargo package derived from changed Rust files
- add focused regression tests for manifest discovery, absolute paths, and multi-package execution
- document Cargo fmt target files and package-level behavior in `README.md`

## Testing
- `node --test .github/scripts/linters/cargo-fmt.test.js`
- `biome lint --colors=off --error-on-warnings --no-errors-on-unmatched .github/scripts/linters/cargo-fmt.test.js .github/scripts/linters/config.json`
- `markdownlint-cli2 --no-globs :README.md`
- `shellcheck -x -P SCRIPTDIR .github/scripts/linters/cargo-fmt.sh`
- `git diff --check`
