### PR TITLE
feat(linters): add cargo-clippy shared linter

### DIFF
--- a/.github/scripts/linter-library.sh
+++ b/.github/scripts/linter-library.sh
@@ -55,6 +55,76 @@ linter_lib::copy_paths_to_root() {
   done
 }
 
+linter_lib::copy_worktree_without_git() {
+  local target_root=$1
+  local source_root=${2:-.}
+
+  rm -rf "$target_root"
+  mkdir -p "$target_root"
+  tar --exclude=.git -C "$source_root" -cf - . | tar -xf - -C "$target_root"
+}
+
+linter_lib::find_cargo_manifest() {
+  local path=$1
+  local current_dir candidate
+
+  current_dir=$(dirname "$path")
+  while :; do
+    candidate="$current_dir/Cargo.toml"
+    if [ -f "$candidate" ]; then
+      printf '%s\n' "${candidate#./}"
+      return 0
+    fi
+
+    if [ "$current_dir" = "." ] || [ "$current_dir" = "/" ]; then
+      break
+    fi
+
+    current_dir=$(dirname "$current_dir")
+  done
+
+  return 1
+}
+
+linter_lib::collect_cargo_manifests() {
+  local output_file=$1
+  local tool_name=$2
+  local manifests_var=$3
+  shift 3
+
+  local -n manifests_ref="$manifests_var"
+  local -A seen_manifests=()
+  local missing_files=()
+  local path manifest_path
+
+  manifests_ref=()
+
+  for path in "$@"; do
+    if ! manifest_path=$(linter_lib::find_cargo_manifest "$path"); then
+      missing_files+=("$path")
+      continue
+    fi
+
+    if [ -z "${seen_manifests[$manifest_path]+x}" ]; then
+      seen_manifests["$manifest_path"]=1
+      manifests_ref+=("$manifest_path")
+    fi
+  done
+
+  if [ "${#missing_files[@]}" -gt 0 ]; then
+    {
+      printf '%s requires each selected Rust file to belong to a Cargo package.\n' "$tool_name"
+      echo "No Cargo.toml found for:"
+      for path in "${missing_files[@]}"; do
+        printf ' - %s\n' "$path"
+      done
+    } > "$output_file"
+    return 1
+  fi
+
+  return 0
+}
+
 linter_lib::emit_json_result() {
   local exit_code=$1
   local output_file=$2

--- a/.github/scripts/linters/cargo-clippy.sh
+++ b/.github/scripts/linters/cargo-clippy.sh
@@ -21,23 +21,44 @@ cargo_clippy_require_docker() {
   fi
 }
 
-cargo_clippy_find_manifest() {
-  local path=$1
-  local current_dir candidate
+cargo_clippy_collect_relevant_dirs() {
+  local -A seen=()
+  local manifest_path current_dir
 
-  current_dir=$(dirname "$path")
-  while :; do
-    candidate="$current_dir/Cargo.toml"
-    if [ -f "$candidate" ]; then
-      printf '%s\n' "${candidate#./}"
-      return 0
-    fi
+  seen["."]=1
+  printf '%s\n' "."
 
-    if [ "$current_dir" = "." ] || [ "$current_dir" = "/" ]; then
-      break
-    fi
+  for manifest_path in "$@"; do
+    current_dir=$(dirname "$manifest_path")
 
-    current_dir=$(dirname "$current_dir")
+    while :; do
+      if [ -z "${seen[$current_dir]+x}" ]; then
+        seen["$current_dir"]=1
+        printf '%s\n' "$current_dir"
+      fi
+
+      if [ "$current_dir" = "." ] || [ "$current_dir" = "/" ]; then
+        break
+      fi
+
+      current_dir=$(dirname "$current_dir")
+    done
+  done
+}
+
+cargo_clippy_find_unsupported_config() {
+  local dir candidate
+
+  for dir in "$@"; do
+    for candidate in \
+      "$dir/.cargo/config.toml" \
+      "$dir/.cargo/config"
+    do
+      if [ -f "$candidate" ]; then
+        printf '%s\n' "${candidate#./}"
+        return 0
+      fi
+    done
   done
 
   return 1
@@ -87,31 +108,18 @@ EOF
     cargo_clippy_require_docker
     output_file="$RUNNER_TEMP/linter-output.txt"
     manifests=()
-    missing_files=()
-    declare -A seen_manifests=()
-    path=""
-    manifest_path=""
-
-    for path in "$@"; do
-      if ! manifest_path=$(cargo_clippy_find_manifest "$path"); then
-        missing_files+=("$path")
-        continue
-      fi
-
-      if [ -z "${seen_manifests[$manifest_path]+x}" ]; then
-        seen_manifests["$manifest_path"]=1
-        manifests+=("$manifest_path")
-      fi
-    done
-
-    if [ "${#missing_files[@]}" -gt 0 ]; then
-      {
-        echo "Cargo clippy requires each selected Rust file to belong to a Cargo package."
-        echo "No Cargo.toml found for:"
-        for path in "${missing_files[@]}"; do
-          printf ' - %s\n' "$path"
-        done
-      } > "$output_file"
+    relevant_dirs=()
+    unsupported_config=""
+    if ! linter_lib::collect_cargo_manifests "$output_file" "Cargo clippy" manifests "$@"; then
+      linter_lib::emit_json_result 1 "$output_file"
+      exit 0
+    fi
+    mapfile -t relevant_dirs < <(cargo_clippy_collect_relevant_dirs "${manifests[@]}")
+    if unsupported_config="$(cargo_clippy_find_unsupported_config "${relevant_dirs[@]}")"; then
+      cat > "$output_file" <<EOF
+Repository-supplied \`$unsupported_config\` is not supported in this shared linter service because \`cargo fetch\` for untrusted pull requests cannot safely honor repository-controlled Cargo configuration.
+Use the default Cargo registry configuration for the shared \`cargo-clippy\` path.
+EOF
       linter_lib::emit_json_result 1 "$output_file"
       exit 0
     fi
@@ -125,8 +133,8 @@ EOF
     group_id=$(id -g)
 
     rm -rf "$workspace_root"
-    mkdir -p "$source_root" "$cargo_home" "$target_root"
-    cp -a ./. "$source_root/"
+    mkdir -p "$cargo_home" "$target_root"
+    linter_lib::copy_worktree_without_git "$source_root"
 
     cleanup_workspace() {
       rm -rf "$workspace_root"

--- a/.github/scripts/linters/cargo-clippy.sh
+++ b/.github/scripts/linters/cargo-clippy.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../linter-library.sh
+source "$script_dir/../linter-library.sh"
+
+cargo_clippy_base_image() {
+  printf '%s\n' "${CARGO_CLIPPY_BASE_IMAGE:-docker.io/library/rust:1-bookworm}"
+}
+
+cargo_clippy_image_ref() {
+  printf '%s\n' "${CARGO_CLIPPY_IMAGE_REF:-localhost/linter-service-cargo-clippy:rust-1-bookworm}"
+}
+
+cargo_clippy_require_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "docker is required to run cargo-clippy in an isolated container" >&2
+    return 1
+  fi
+}
+
+cargo_clippy_find_manifest() {
+  local path=$1
+  local current_dir candidate
+
+  current_dir=$(dirname "$path")
+  while :; do
+    candidate="$current_dir/Cargo.toml"
+    if [ -f "$candidate" ]; then
+      printf '%s\n' "${candidate#./}"
+      return 0
+    fi
+
+    if [ "$current_dir" = "." ] || [ "$current_dir" = "/" ]; then
+      break
+    fi
+
+    current_dir=$(dirname "$current_dir")
+  done
+
+  return 1
+}
+
+mode=${1-}
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+case "$mode" in
+  patterns)
+    cat <<'EOF'
+\.(?:rs)$
+EOF
+    ;;
+  install)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+    cargo_clippy_require_docker
+
+    image_ref=$(cargo_clippy_image_ref)
+    base_image=$(cargo_clippy_base_image)
+    build_context="$RUNNER_TEMP/cargo-clippy-image"
+
+    if docker image inspect "$image_ref" >/dev/null 2>&1; then
+      exit 0
+    fi
+
+    rm -rf "$build_context"
+    mkdir -p "$build_context"
+
+    cat > "$build_context/Dockerfile" <<EOF
+FROM ${base_image}
+RUN apt-get update \\
+ && apt-get install -y --no-install-recommends ca-certificates git \\
+ && rm -rf /var/lib/apt/lists/* \\
+ && rustup component add clippy
+EOF
+
+    docker build \
+      --pull \
+      --tag "$image_ref" \
+      "$build_context"
+    ;;
+  run)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+    cargo_clippy_require_docker
+    output_file="$RUNNER_TEMP/linter-output.txt"
+    manifests=()
+    missing_files=()
+    declare -A seen_manifests=()
+    path=""
+    manifest_path=""
+
+    for path in "$@"; do
+      if ! manifest_path=$(cargo_clippy_find_manifest "$path"); then
+        missing_files+=("$path")
+        continue
+      fi
+
+      if [ -z "${seen_manifests[$manifest_path]+x}" ]; then
+        seen_manifests["$manifest_path"]=1
+        manifests+=("$manifest_path")
+      fi
+    done
+
+    if [ "${#missing_files[@]}" -gt 0 ]; then
+      {
+        echo "Cargo clippy requires each selected Rust file to belong to a Cargo package."
+        echo "No Cargo.toml found for:"
+        for path in "${missing_files[@]}"; do
+          printf ' - %s\n' "$path"
+        done
+      } > "$output_file"
+      linter_lib::emit_json_result 1 "$output_file"
+      exit 0
+    fi
+
+    workspace_root="$RUNNER_TEMP/cargo-clippy-workspace"
+    source_root="$workspace_root/source"
+    cargo_home="$workspace_root/cargo-home"
+    target_root="$workspace_root/cargo-target"
+    image_ref=$(cargo_clippy_image_ref)
+    user_id=$(id -u)
+    group_id=$(id -g)
+
+    rm -rf "$workspace_root"
+    mkdir -p "$source_root" "$cargo_home" "$target_root"
+    cp -a ./. "$source_root/"
+
+    cleanup_workspace() {
+      rm -rf "$workspace_root"
+    }
+
+    trap cleanup_workspace EXIT
+
+    docker_run_common=(
+      --rm
+      --cap-drop ALL
+      --security-opt no-new-privileges
+      --read-only
+      --tmpfs /tmp
+      --user "$user_id:$group_id"
+      --workdir /work
+      --mount "type=bind,src=$source_root,dst=/work"
+      --mount "type=bind,src=$cargo_home,dst=/cargo-home"
+      --mount "type=bind,src=$target_root,dst=/cargo-target"
+      --env CARGO_HOME=/cargo-home
+      --env CARGO_TARGET_DIR=/cargo-target
+      --env CARGO_TERM_COLOR=never
+      --env HOME=/cargo-home
+    )
+
+    run_cargo_clippy() {
+      local failure=0
+      local current_manifest
+
+      for current_manifest in "${manifests[@]}"; do
+        printf '==> docker run cargo fetch --manifest-path %s\n' "$current_manifest"
+        if ! docker run \
+          "${docker_run_common[@]}" \
+          "$image_ref" \
+          cargo fetch --manifest-path "$current_manifest"; then
+          failure=1
+          echo
+          continue
+        fi
+
+        printf '==> docker run cargo clippy --manifest-path %s --all-targets -- -D warnings\n' "$current_manifest"
+        if ! docker run \
+          "${docker_run_common[@]}" \
+          --network=none \
+          "$image_ref" \
+          cargo clippy --manifest-path "$current_manifest" --all-targets -- -D warnings; then
+          failure=1
+        fi
+        echo
+      done
+
+      return "$failure"
+    }
+
+    linter_lib::run_and_emit_json "$output_file" run_cargo_clippy
+    ;;
+  *)
+    echo "usage: $0 {patterns|install|run}" >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/linters/cargo-clippy.test.js
+++ b/.github/scripts/linters/cargo-clippy.test.js
@@ -1,36 +1,18 @@
-const assert = require("node:assert/strict");
-const fs = require("node:fs");
-const os = require("node:os");
-const path = require("node:path");
-const { execFileSync } = require("node:child_process");
 const test = require("node:test");
+const {
+	assert,
+	cleanupTempRepo,
+	defineCommonCargoManifestTests,
+	fs,
+	makeTempRepo,
+	path,
+	writeExecutable,
+	writeFile,
+} = require("./cargo-linter-test-lib");
+
+const { execFileSync } = require("node:child_process");
 
 const scriptPath = path.join(__dirname, "cargo-clippy.sh");
-
-function writeExecutable(filePath, content) {
-	fs.writeFileSync(filePath, content, "utf8");
-	fs.chmodSync(filePath, 0o755);
-}
-
-function createPythonStub(binDir) {
-	writeExecutable(
-		path.join(binDir, "python3"),
-		`#!/usr/bin/env bash
-set -euo pipefail
-cat >/dev/null
-exit_code="$2"
-output_file="$3"
-node - "$exit_code" "$output_file" <<'NODE'
-const fs = require("node:fs");
-const [exitCode, outputFile] = process.argv.slice(2);
-const details = fs.existsSync(outputFile)
-\t? fs.readFileSync(outputFile, "utf8").trim()
-\t: "";
-process.stdout.write(JSON.stringify({ details, exit_code: Number(exitCode) }));
-NODE
-`,
-	);
-}
 
 function createDockerStub(binDir) {
 	writeExecutable(
@@ -62,6 +44,7 @@ case "$command" in
     manifest=""
     prev=""
     is_clippy=0
+    work_mount_src=""
     for arg in "$@"; do
       if [ "$prev" = "--manifest-path" ]; then
         manifest="$arg"
@@ -69,9 +52,24 @@ case "$command" in
       if [ "$prev" = "cargo" ] && [ "$arg" = "clippy" ]; then
         is_clippy=1
       fi
+      if [ "$prev" = "--mount" ]; then
+        case "$arg" in
+          *"dst=/work"*|*"target=/work"*)
+            work_mount_src="\${arg#*src=}"
+            work_mount_src="\${work_mount_src%%,*}"
+            ;;
+        esac
+      fi
       prev="$arg"
     done
     printf '%s\\n' "$*" >> "$DOCKER_RUN_ARGS_LOG"
+    if [ -n "$work_mount_src" ]; then
+      if [ -e "$work_mount_src/.git" ]; then
+        printf 'present\\n' >> "$WORKTREE_GIT_LOG"
+      else
+        printf 'absent\\n' >> "$WORKTREE_GIT_LOG"
+      fi
+    fi
     if [ "$is_clippy" -eq 1 ]; then
       printf '%s\\n' "$manifest" >> "$DOCKER_MANIFEST_LOG"
       printf 'checked %s\\n' "$manifest"
@@ -96,367 +94,205 @@ esac
 	);
 }
 
-function makeTempRepo(prefix) {
-	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-	const repoDir = path.join(tempDir, "repo");
-	const runnerTemp = path.join(tempDir, "runner");
-	const binDir = path.join(tempDir, "bin");
-	const dockerBuildArgsLog = path.join(tempDir, "docker-build-args.log");
-	const dockerImageInspectLog = path.join(tempDir, "docker-image-inspect.log");
-	const dockerManifestLog = path.join(tempDir, "docker-manifests.log");
-	const dockerRunArgsLog = path.join(tempDir, "docker-run-args.log");
-	const dockerfileCopy = path.join(tempDir, "Dockerfile.copy");
+function setupDockerTooling(context) {
+	writeFile(path.join(context.repoDir, ".git/HEAD"), "ref: refs/heads/test\n");
 
-	fs.mkdirSync(repoDir, { recursive: true });
-	fs.mkdirSync(runnerTemp, { recursive: true });
-	fs.mkdirSync(binDir, { recursive: true });
+	const tooling = {
+		dockerBuildArgsLog: path.join(context.tempDir, "docker-build-args.log"),
+		dockerImageInspectLog: path.join(
+			context.tempDir,
+			"docker-image-inspect.log",
+		),
+		dockerManifestLog: path.join(context.tempDir, "docker-manifests.log"),
+		dockerRunArgsLog: path.join(context.tempDir, "docker-run-args.log"),
+		dockerfileCopy: path.join(context.tempDir, "Dockerfile.copy"),
+		worktreeGitLog: path.join(context.tempDir, "worktree-git.log"),
+	};
 
-	createPythonStub(binDir);
-	createDockerStub(binDir);
+	createDockerStub(context.binDir);
 
 	return {
-		binDir,
-		dockerBuildArgsLog,
-		dockerImageInspectLog,
-		dockerManifestLog,
-		dockerRunArgsLog,
-		dockerfileCopy,
-		repoDir,
-		runnerTemp,
-		tempDir,
+		...tooling,
+		env: {
+			DOCKER_BUILD_ARGS_LOG: tooling.dockerBuildArgsLog,
+			DOCKER_IMAGE_INSPECT_LOG: tooling.dockerImageInspectLog,
+			DOCKER_MANIFEST_LOG: tooling.dockerManifestLog,
+			DOCKER_RUN_ARGS_LOG: tooling.dockerRunArgsLog,
+			DOCKERFILE_COPY: tooling.dockerfileCopy,
+			WORKTREE_GIT_LOG: tooling.worktreeGitLog,
+		},
 	};
 }
 
-function writeFile(filePath, content) {
-	fs.mkdirSync(path.dirname(filePath), { recursive: true });
-	fs.writeFileSync(filePath, content, "utf8");
-}
-
 test("cargo-clippy.sh install builds a dedicated clippy container image when missing", () => {
-	const {
-		binDir,
-		dockerBuildArgsLog,
-		dockerImageInspectLog,
-		dockerfileCopy,
-		repoDir,
-		runnerTemp,
-		tempDir,
-	} = makeTempRepo("cargo-clippy-install-");
+	const context = makeTempRepo("cargo-clippy-install-");
+	const tooling = setupDockerTooling(context);
 
 	try {
 		execFileSync("bash", [scriptPath, "install"], {
-			cwd: repoDir,
+			cwd: context.repoDir,
 			encoding: "utf8",
 			env: {
 				...process.env,
+				...tooling.env,
 				CARGO_CLIPPY_BASE_IMAGE: "docker.io/library/rust:1-bookworm",
 				CARGO_CLIPPY_IMAGE_REF: "localhost/test/cargo-clippy:latest",
-				DOCKER_BUILD_ARGS_LOG: dockerBuildArgsLog,
-				DOCKER_IMAGE_INSPECT_LOG: dockerImageInspectLog,
-				DOCKERFILE_COPY: dockerfileCopy,
 				MISSING_IMAGE: "1",
-				PATH: `${binDir}:${process.env.PATH}`,
-				RUNNER_TEMP: runnerTemp,
+				PATH: `${context.binDir}:${process.env.PATH}`,
+				RUNNER_TEMP: context.runnerTemp,
 			},
 		});
 
 		assert.match(
-			fs.readFileSync(dockerImageInspectLog, "utf8"),
+			fs.readFileSync(tooling.dockerImageInspectLog, "utf8"),
 			/localhost\/test\/cargo-clippy:latest/,
 		);
 		assert.match(
-			fs.readFileSync(dockerBuildArgsLog, "utf8"),
+			fs.readFileSync(tooling.dockerBuildArgsLog, "utf8"),
 			/--pull --tag localhost\/test\/cargo-clippy:latest/,
 		);
 		assert.match(
-			fs.readFileSync(dockerfileCopy, "utf8"),
+			fs.readFileSync(tooling.dockerfileCopy, "utf8"),
 			/FROM docker\.io\/library\/rust:1-bookworm/,
 		);
 		assert.match(
-			fs.readFileSync(dockerfileCopy, "utf8"),
+			fs.readFileSync(tooling.dockerfileCopy, "utf8"),
 			/rustup component add clippy/,
 		);
 	} finally {
-		fs.rmSync(tempDir, { recursive: true, force: true });
+		cleanupTempRepo(context.tempDir);
 	}
 });
 
-test("cargo-clippy.sh groups changed Rust files by nearest Cargo.toml", () => {
-	const {
-		binDir,
-		dockerBuildArgsLog,
-		dockerImageInspectLog,
-		dockerManifestLog,
-		dockerRunArgsLog,
-		dockerfileCopy,
-		repoDir,
-		runnerTemp,
-		tempDir,
-	} = makeTempRepo("cargo-clippy-grouped-");
-
-	writeFile(
-		path.join(repoDir, "Cargo.toml"),
-		`[package]
-name = "root"
-version = "0.1.0"
-edition = "2021"
-`,
-	);
-	writeFile(path.join(repoDir, "src/lib.rs"), "pub fn root_lib() {}\n");
-	writeFile(path.join(repoDir, "src/main.rs"), "fn main() {}\n");
-	writeFile(
-		path.join(repoDir, "crates/member/Cargo.toml"),
-		`[package]
-name = "member"
-version = "0.1.0"
-edition = "2021"
-`,
-	);
-	writeFile(
-		path.join(repoDir, "crates/member/src/lib.rs"),
-		"pub fn member_lib() {}\n",
-	);
-
-	try {
-		const output = execFileSync(
-			"bash",
-			[
-				scriptPath,
-				"run",
-				"src/lib.rs",
-				"src/main.rs",
-				"crates/member/src/lib.rs",
-			],
-			{
-				cwd: repoDir,
-				encoding: "utf8",
-				env: {
-					...process.env,
-					DOCKER_BUILD_ARGS_LOG: dockerBuildArgsLog,
-					DOCKER_IMAGE_INSPECT_LOG: dockerImageInspectLog,
-					DOCKER_MANIFEST_LOG: dockerManifestLog,
-					DOCKER_RUN_ARGS_LOG: dockerRunArgsLog,
-					DOCKERFILE_COPY: dockerfileCopy,
-					PATH: `${binDir}:${process.env.PATH}`,
-					RUNNER_TEMP: runnerTemp,
-				},
-			},
-		);
-		const result = JSON.parse(output);
-
+defineCommonCargoManifestTests({
+	scriptPath,
+	tempPrefix: "cargo-clippy-",
+	toolName: "cargo-clippy.sh",
+	setupTooling: setupDockerTooling,
+	assertGroupedResult({ context, result, tooling }) {
 		assert.equal(result.exit_code, 0);
+		assert.equal(fs.existsSync(path.join(context.repoDir, ".git/HEAD")), true);
 		assert.deepEqual(
-			fs.readFileSync(dockerManifestLog, "utf8").trim().split("\n"),
+			fs.readFileSync(tooling.dockerManifestLog, "utf8").trim().split("\n"),
 			["Cargo.toml", "crates/member/Cargo.toml"],
 		);
 		assert.match(
-			fs.readFileSync(dockerRunArgsLog, "utf8"),
+			fs.readFileSync(tooling.dockerRunArgsLog, "utf8"),
 			/cargo fetch --manifest-path Cargo\.toml/,
 		);
 		assert.match(
-			fs.readFileSync(dockerRunArgsLog, "utf8"),
+			fs.readFileSync(tooling.dockerRunArgsLog, "utf8"),
 			/--cap-drop ALL --security-opt no-new-privileges --read-only --tmpfs \/tmp/,
 		);
-		assert.match(fs.readFileSync(dockerRunArgsLog, "utf8"), /--user \d+:\d+/);
 		assert.match(
-			fs.readFileSync(dockerRunArgsLog, "utf8"),
+			fs.readFileSync(tooling.dockerRunArgsLog, "utf8"),
+			/--user \d+:\d+/,
+		);
+		assert.match(
+			fs.readFileSync(tooling.dockerRunArgsLog, "utf8"),
 			/--network=none localhost\/linter-service-cargo-clippy:rust-1-bookworm cargo clippy --manifest-path Cargo\.toml --all-targets -- -D warnings/,
 		);
 		assert.match(
-			fs.readFileSync(dockerRunArgsLog, "utf8"),
+			fs.readFileSync(tooling.dockerRunArgsLog, "utf8"),
 			/CARGO_HOME=\/cargo-home/,
+		);
+		assert.deepEqual(
+			fs.readFileSync(tooling.worktreeGitLog, "utf8").trim().split("\n"),
+			["absent", "absent", "absent", "absent"],
 		);
 		assert.match(
 			result.details,
 			/docker run cargo clippy --manifest-path Cargo\.toml/,
 		);
-	} finally {
-		fs.rmSync(tempDir, { recursive: true, force: true });
-	}
-});
-
-test("cargo-clippy.sh reports Rust files outside Cargo packages", () => {
-	const {
-		binDir,
-		dockerBuildArgsLog,
-		dockerImageInspectLog,
-		dockerManifestLog,
-		dockerRunArgsLog,
-		dockerfileCopy,
-		repoDir,
-		runnerTemp,
-		tempDir,
-	} = makeTempRepo("cargo-clippy-missing-manifest-");
-
-	writeFile(path.join(repoDir, "standalone.rs"), "fn main() {}\n");
-
-	try {
-		const output = execFileSync("bash", [scriptPath, "run", "standalone.rs"], {
-			cwd: repoDir,
-			encoding: "utf8",
-			env: {
-				...process.env,
-				DOCKER_BUILD_ARGS_LOG: dockerBuildArgsLog,
-				DOCKER_IMAGE_INSPECT_LOG: dockerImageInspectLog,
-				DOCKER_MANIFEST_LOG: dockerManifestLog,
-				DOCKER_RUN_ARGS_LOG: dockerRunArgsLog,
-				DOCKERFILE_COPY: dockerfileCopy,
-				PATH: `${binDir}:${process.env.PATH}`,
-				RUNNER_TEMP: runnerTemp,
-			},
-		});
-		const result = JSON.parse(output);
-
+	},
+	assertMissingManifestResult({ pathValue, result, tooling }) {
 		assert.equal(result.exit_code, 1);
 		assert.match(result.details, /No Cargo\.toml found for:/);
-		assert.match(result.details, /standalone\.rs/);
-		assert.equal(fs.existsSync(dockerManifestLog), false);
-		assert.equal(fs.existsSync(dockerRunArgsLog), false);
-	} finally {
-		fs.rmSync(tempDir, { recursive: true, force: true });
-	}
-});
-
-test("cargo-clippy.sh handles absolute Rust file paths outside Cargo packages", () => {
-	const {
-		binDir,
-		dockerBuildArgsLog,
-		dockerImageInspectLog,
-		dockerManifestLog,
-		dockerRunArgsLog,
-		dockerfileCopy,
-		repoDir,
-		runnerTemp,
-		tempDir,
-	} = makeTempRepo("cargo-clippy-absolute-missing-manifest-");
-	const standalonePath = path.join(tempDir, "standalone.rs");
-
-	writeFile(standalonePath, "fn main() {}\n");
-
-	try {
-		const output = execFileSync("bash", [scriptPath, "run", standalonePath], {
-			cwd: repoDir,
-			encoding: "utf8",
-			env: {
-				...process.env,
-				DOCKER_BUILD_ARGS_LOG: dockerBuildArgsLog,
-				DOCKER_IMAGE_INSPECT_LOG: dockerImageInspectLog,
-				DOCKER_MANIFEST_LOG: dockerManifestLog,
-				DOCKER_RUN_ARGS_LOG: dockerRunArgsLog,
-				DOCKERFILE_COPY: dockerfileCopy,
-				PATH: `${binDir}:${process.env.PATH}`,
-				RUNNER_TEMP: runnerTemp,
-			},
-			timeout: 1000,
-		});
-		const result = JSON.parse(output);
-
-		assert.equal(result.exit_code, 1);
-		assert.match(result.details, /No Cargo\.toml found for:/);
-		assert.match(result.details, /standalone\.rs/);
-		assert.equal(fs.existsSync(dockerManifestLog), false);
-		assert.equal(fs.existsSync(dockerRunArgsLog), false);
-	} finally {
-		fs.rmSync(tempDir, { recursive: true, force: true });
-	}
-});
-
-test("cargo-clippy.sh continues checking later Cargo packages after one failure", () => {
-	const {
-		binDir,
-		dockerBuildArgsLog,
-		dockerImageInspectLog,
-		dockerManifestLog,
-		dockerRunArgsLog,
-		dockerfileCopy,
-		repoDir,
-		runnerTemp,
-		tempDir,
-	} = makeTempRepo("cargo-clippy-continue-");
-
-	writeFile(
-		path.join(repoDir, "Cargo.toml"),
-		`[package]
-name = "root"
-version = "0.1.0"
-edition = "2021"
-`,
-	);
-	writeFile(path.join(repoDir, "src/lib.rs"), "pub fn root_lib() {}\n");
-	writeFile(
-		path.join(repoDir, "crates/member/Cargo.toml"),
-		`[package]
-name = "member"
-version = "0.1.0"
-edition = "2021"
-`,
-	);
-	writeFile(
-		path.join(repoDir, "crates/member/src/lib.rs"),
-		"pub fn member_lib() {}\n",
-	);
-
-	try {
-		const output = execFileSync(
-			"bash",
-			[scriptPath, "run", "src/lib.rs", "crates/member/src/lib.rs"],
-			{
-				cwd: repoDir,
-				encoding: "utf8",
-				env: {
-					...process.env,
-					DOCKER_BUILD_ARGS_LOG: dockerBuildArgsLog,
-					DOCKER_IMAGE_INSPECT_LOG: dockerImageInspectLog,
-					DOCKER_MANIFEST_LOG: dockerManifestLog,
-					DOCKER_RUN_ARGS_LOG: dockerRunArgsLog,
-					DOCKERFILE_COPY: dockerfileCopy,
-					FAIL_MANIFEST: "Cargo.toml",
-					PATH: `${binDir}:${process.env.PATH}`,
-					RUNNER_TEMP: runnerTemp,
-				},
-			},
+		assert.match(
+			result.details,
+			new RegExp(pathValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
 		);
-		const result = JSON.parse(output);
-
+		assert.equal(fs.existsSync(tooling.dockerManifestLog), false);
+		assert.equal(fs.existsSync(tooling.dockerRunArgsLog), false);
+		assert.equal(fs.existsSync(tooling.worktreeGitLog), false);
+	},
+	continueFailureEnv: {
+		FAIL_MANIFEST: "Cargo.toml",
+	},
+	assertContinueAfterFailureResult({ result, tooling }) {
 		assert.equal(result.exit_code, 1);
 		assert.deepEqual(
-			fs.readFileSync(dockerManifestLog, "utf8").trim().split("\n"),
+			fs.readFileSync(tooling.dockerManifestLog, "utf8").trim().split("\n"),
 			["Cargo.toml", "crates/member/Cargo.toml"],
 		);
 		assert.match(result.details, /clippy failure Cargo\.toml/);
 		assert.match(
-			fs.readFileSync(dockerRunArgsLog, "utf8"),
-			/cargo clippy --manifest-path crates\/member\/Cargo\.toml --all-targets -- -D warnings/,
+			fs.readFileSync(tooling.dockerRunArgsLog, "utf8"),
+			/--network=none localhost\/linter-service-cargo-clippy:rust-1-bookworm cargo clippy --manifest-path crates\/member\/Cargo\.toml --all-targets -- -D warnings/,
 		);
-	} finally {
-		fs.rmSync(tempDir, { recursive: true, force: true });
-	}
+	},
 });
 
-test("cargo-clippy.sh skips clippy for a package when cargo fetch fails and continues with later packages", () => {
-	const {
-		binDir,
-		dockerBuildArgsLog,
-		dockerImageInspectLog,
-		dockerManifestLog,
-		dockerRunArgsLog,
-		dockerfileCopy,
-		repoDir,
-		runnerTemp,
-		tempDir,
-	} = makeTempRepo("cargo-clippy-fetch-failure-");
+test("cargo-clippy.sh rejects repository-supplied Cargo config on the shared path", () => {
+	const context = makeTempRepo("cargo-clippy-unsafe-config-");
+	const tooling = setupDockerTooling(context);
 
 	writeFile(
-		path.join(repoDir, "Cargo.toml"),
+		path.join(context.repoDir, "Cargo.toml"),
 		`[package]
 name = "root"
 version = "0.1.0"
 edition = "2021"
 `,
 	);
-	writeFile(path.join(repoDir, "src/lib.rs"), "pub fn root_lib() {}\n");
+	writeFile(path.join(context.repoDir, "src/lib.rs"), "pub fn root_lib() {}\n");
 	writeFile(
-		path.join(repoDir, "crates/member/Cargo.toml"),
+		path.join(context.repoDir, ".cargo/config.toml"),
+		`[registries.private]
+index = "sparse+https://example.invalid/index/"
+`,
+	);
+
+	try {
+		const output = execFileSync("bash", [scriptPath, "run", "src/lib.rs"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: {
+				...process.env,
+				...tooling.env,
+				PATH: `${context.binDir}:${process.env.PATH}`,
+				RUNNER_TEMP: context.runnerTemp,
+			},
+		});
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 1);
+		assert.match(
+			result.details,
+			/Repository-supplied `\.cargo\/config\.toml` is not supported/,
+		);
+		assert.equal(fs.existsSync(tooling.dockerRunArgsLog), false);
+		assert.equal(fs.existsSync(tooling.dockerManifestLog), false);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("cargo-clippy.sh skips clippy for a package when cargo fetch fails and continues with later packages", () => {
+	const context = makeTempRepo("cargo-clippy-fetch-failure-");
+	const tooling = setupDockerTooling(context);
+
+	writeFile(
+		path.join(context.repoDir, "Cargo.toml"),
+		`[package]
+name = "root"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(path.join(context.repoDir, "src/lib.rs"), "pub fn root_lib() {}\n");
+	writeFile(
+		path.join(context.repoDir, "crates/member/Cargo.toml"),
 		`[package]
 name = "member"
 version = "0.1.0"
@@ -464,7 +300,7 @@ edition = "2021"
 `,
 	);
 	writeFile(
-		path.join(repoDir, "crates/member/src/lib.rs"),
+		path.join(context.repoDir, "crates/member/src/lib.rs"),
 		"pub fn member_lib() {}\n",
 	);
 
@@ -473,23 +309,19 @@ edition = "2021"
 			"bash",
 			[scriptPath, "run", "src/lib.rs", "crates/member/src/lib.rs"],
 			{
-				cwd: repoDir,
+				cwd: context.repoDir,
 				encoding: "utf8",
 				env: {
 					...process.env,
-					DOCKER_BUILD_ARGS_LOG: dockerBuildArgsLog,
-					DOCKER_IMAGE_INSPECT_LOG: dockerImageInspectLog,
-					DOCKER_MANIFEST_LOG: dockerManifestLog,
-					DOCKER_RUN_ARGS_LOG: dockerRunArgsLog,
-					DOCKERFILE_COPY: dockerfileCopy,
+					...tooling.env,
 					FAIL_FETCH_MANIFEST: "Cargo.toml",
-					PATH: `${binDir}:${process.env.PATH}`,
-					RUNNER_TEMP: runnerTemp,
+					PATH: `${context.binDir}:${process.env.PATH}`,
+					RUNNER_TEMP: context.runnerTemp,
 				},
 			},
 		);
 		const result = JSON.parse(output);
-		const runArgs = fs.readFileSync(dockerRunArgsLog, "utf8");
+		const runArgs = fs.readFileSync(tooling.dockerRunArgsLog, "utf8");
 
 		assert.equal(result.exit_code, 1);
 		assert.match(result.details, /fetch failure Cargo\.toml/);
@@ -507,10 +339,10 @@ edition = "2021"
 			/--network=none localhost\/linter-service-cargo-clippy:rust-1-bookworm cargo clippy --manifest-path crates\/member\/Cargo\.toml --all-targets -- -D warnings/,
 		);
 		assert.deepEqual(
-			fs.readFileSync(dockerManifestLog, "utf8").trim().split("\n"),
+			fs.readFileSync(tooling.dockerManifestLog, "utf8").trim().split("\n"),
 			["crates/member/Cargo.toml"],
 		);
 	} finally {
-		fs.rmSync(tempDir, { recursive: true, force: true });
+		cleanupTempRepo(context.tempDir);
 	}
 });

--- a/.github/scripts/linters/cargo-clippy.test.js
+++ b/.github/scripts/linters/cargo-clippy.test.js
@@ -1,0 +1,516 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+const test = require("node:test");
+
+const scriptPath = path.join(__dirname, "cargo-clippy.sh");
+
+function writeExecutable(filePath, content) {
+	fs.writeFileSync(filePath, content, "utf8");
+	fs.chmodSync(filePath, 0o755);
+}
+
+function createPythonStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "python3"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+cat >/dev/null
+exit_code="$2"
+output_file="$3"
+node - "$exit_code" "$output_file" <<'NODE'
+const fs = require("node:fs");
+const [exitCode, outputFile] = process.argv.slice(2);
+const details = fs.existsSync(outputFile)
+\t? fs.readFileSync(outputFile, "utf8").trim()
+\t: "";
+process.stdout.write(JSON.stringify({ details, exit_code: Number(exitCode) }));
+NODE
+`,
+	);
+}
+
+function createDockerStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "docker"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+command="$1"
+shift
+
+case "$command" in
+  image)
+    subcommand="$1"
+    shift
+    if [ "$subcommand" != "inspect" ]; then
+      echo "unsupported docker image subcommand: $subcommand" >&2
+      exit 1
+    fi
+    printf '%s\\n' "$*" >> "$DOCKER_IMAGE_INSPECT_LOG"
+    if [ -n "\${MISSING_IMAGE:-}" ]; then
+      exit 1
+    fi
+    ;;
+  build)
+    printf '%s\\n' "$*" >> "$DOCKER_BUILD_ARGS_LOG"
+    context="\${*: -1}"
+    cp "$context/Dockerfile" "$DOCKERFILE_COPY"
+    ;;
+  run)
+    manifest=""
+    prev=""
+    is_clippy=0
+    for arg in "$@"; do
+      if [ "$prev" = "--manifest-path" ]; then
+        manifest="$arg"
+      fi
+      if [ "$prev" = "cargo" ] && [ "$arg" = "clippy" ]; then
+        is_clippy=1
+      fi
+      prev="$arg"
+    done
+    printf '%s\\n' "$*" >> "$DOCKER_RUN_ARGS_LOG"
+    if [ "$is_clippy" -eq 1 ]; then
+      printf '%s\\n' "$manifest" >> "$DOCKER_MANIFEST_LOG"
+      printf 'checked %s\\n' "$manifest"
+    else
+      printf 'prefetched %s\\n' "$manifest"
+      if [ -n "\${FAIL_FETCH_MANIFEST:-}" ] && [ "$manifest" = "$FAIL_FETCH_MANIFEST" ]; then
+        printf 'fetch failure %s\\n' "$manifest" >&2
+        exit 1
+      fi
+    fi
+    if [ "$is_clippy" -eq 1 ] && [ -n "\${FAIL_MANIFEST:-}" ] && [ "$manifest" = "$FAIL_MANIFEST" ]; then
+      printf 'clippy failure %s\\n' "$manifest" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "unsupported docker command: $command" >&2
+    exit 1
+    ;;
+esac
+`,
+	);
+}
+
+function makeTempRepo(prefix) {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	const repoDir = path.join(tempDir, "repo");
+	const runnerTemp = path.join(tempDir, "runner");
+	const binDir = path.join(tempDir, "bin");
+	const dockerBuildArgsLog = path.join(tempDir, "docker-build-args.log");
+	const dockerImageInspectLog = path.join(tempDir, "docker-image-inspect.log");
+	const dockerManifestLog = path.join(tempDir, "docker-manifests.log");
+	const dockerRunArgsLog = path.join(tempDir, "docker-run-args.log");
+	const dockerfileCopy = path.join(tempDir, "Dockerfile.copy");
+
+	fs.mkdirSync(repoDir, { recursive: true });
+	fs.mkdirSync(runnerTemp, { recursive: true });
+	fs.mkdirSync(binDir, { recursive: true });
+
+	createPythonStub(binDir);
+	createDockerStub(binDir);
+
+	return {
+		binDir,
+		dockerBuildArgsLog,
+		dockerImageInspectLog,
+		dockerManifestLog,
+		dockerRunArgsLog,
+		dockerfileCopy,
+		repoDir,
+		runnerTemp,
+		tempDir,
+	};
+}
+
+function writeFile(filePath, content) {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, content, "utf8");
+}
+
+test("cargo-clippy.sh install builds a dedicated clippy container image when missing", () => {
+	const {
+		binDir,
+		dockerBuildArgsLog,
+		dockerImageInspectLog,
+		dockerfileCopy,
+		repoDir,
+		runnerTemp,
+		tempDir,
+	} = makeTempRepo("cargo-clippy-install-");
+
+	try {
+		execFileSync("bash", [scriptPath, "install"], {
+			cwd: repoDir,
+			encoding: "utf8",
+			env: {
+				...process.env,
+				CARGO_CLIPPY_BASE_IMAGE: "docker.io/library/rust:1-bookworm",
+				CARGO_CLIPPY_IMAGE_REF: "localhost/test/cargo-clippy:latest",
+				DOCKER_BUILD_ARGS_LOG: dockerBuildArgsLog,
+				DOCKER_IMAGE_INSPECT_LOG: dockerImageInspectLog,
+				DOCKERFILE_COPY: dockerfileCopy,
+				MISSING_IMAGE: "1",
+				PATH: `${binDir}:${process.env.PATH}`,
+				RUNNER_TEMP: runnerTemp,
+			},
+		});
+
+		assert.match(
+			fs.readFileSync(dockerImageInspectLog, "utf8"),
+			/localhost\/test\/cargo-clippy:latest/,
+		);
+		assert.match(
+			fs.readFileSync(dockerBuildArgsLog, "utf8"),
+			/--pull --tag localhost\/test\/cargo-clippy:latest/,
+		);
+		assert.match(
+			fs.readFileSync(dockerfileCopy, "utf8"),
+			/FROM docker\.io\/library\/rust:1-bookworm/,
+		);
+		assert.match(
+			fs.readFileSync(dockerfileCopy, "utf8"),
+			/rustup component add clippy/,
+		);
+	} finally {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+});
+
+test("cargo-clippy.sh groups changed Rust files by nearest Cargo.toml", () => {
+	const {
+		binDir,
+		dockerBuildArgsLog,
+		dockerImageInspectLog,
+		dockerManifestLog,
+		dockerRunArgsLog,
+		dockerfileCopy,
+		repoDir,
+		runnerTemp,
+		tempDir,
+	} = makeTempRepo("cargo-clippy-grouped-");
+
+	writeFile(
+		path.join(repoDir, "Cargo.toml"),
+		`[package]
+name = "root"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(path.join(repoDir, "src/lib.rs"), "pub fn root_lib() {}\n");
+	writeFile(path.join(repoDir, "src/main.rs"), "fn main() {}\n");
+	writeFile(
+		path.join(repoDir, "crates/member/Cargo.toml"),
+		`[package]
+name = "member"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(
+		path.join(repoDir, "crates/member/src/lib.rs"),
+		"pub fn member_lib() {}\n",
+	);
+
+	try {
+		const output = execFileSync(
+			"bash",
+			[
+				scriptPath,
+				"run",
+				"src/lib.rs",
+				"src/main.rs",
+				"crates/member/src/lib.rs",
+			],
+			{
+				cwd: repoDir,
+				encoding: "utf8",
+				env: {
+					...process.env,
+					DOCKER_BUILD_ARGS_LOG: dockerBuildArgsLog,
+					DOCKER_IMAGE_INSPECT_LOG: dockerImageInspectLog,
+					DOCKER_MANIFEST_LOG: dockerManifestLog,
+					DOCKER_RUN_ARGS_LOG: dockerRunArgsLog,
+					DOCKERFILE_COPY: dockerfileCopy,
+					PATH: `${binDir}:${process.env.PATH}`,
+					RUNNER_TEMP: runnerTemp,
+				},
+			},
+		);
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 0);
+		assert.deepEqual(
+			fs.readFileSync(dockerManifestLog, "utf8").trim().split("\n"),
+			["Cargo.toml", "crates/member/Cargo.toml"],
+		);
+		assert.match(
+			fs.readFileSync(dockerRunArgsLog, "utf8"),
+			/cargo fetch --manifest-path Cargo\.toml/,
+		);
+		assert.match(
+			fs.readFileSync(dockerRunArgsLog, "utf8"),
+			/--cap-drop ALL --security-opt no-new-privileges --read-only --tmpfs \/tmp/,
+		);
+		assert.match(fs.readFileSync(dockerRunArgsLog, "utf8"), /--user \d+:\d+/);
+		assert.match(
+			fs.readFileSync(dockerRunArgsLog, "utf8"),
+			/--network=none localhost\/linter-service-cargo-clippy:rust-1-bookworm cargo clippy --manifest-path Cargo\.toml --all-targets -- -D warnings/,
+		);
+		assert.match(
+			fs.readFileSync(dockerRunArgsLog, "utf8"),
+			/CARGO_HOME=\/cargo-home/,
+		);
+		assert.match(
+			result.details,
+			/docker run cargo clippy --manifest-path Cargo\.toml/,
+		);
+	} finally {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+});
+
+test("cargo-clippy.sh reports Rust files outside Cargo packages", () => {
+	const {
+		binDir,
+		dockerBuildArgsLog,
+		dockerImageInspectLog,
+		dockerManifestLog,
+		dockerRunArgsLog,
+		dockerfileCopy,
+		repoDir,
+		runnerTemp,
+		tempDir,
+	} = makeTempRepo("cargo-clippy-missing-manifest-");
+
+	writeFile(path.join(repoDir, "standalone.rs"), "fn main() {}\n");
+
+	try {
+		const output = execFileSync("bash", [scriptPath, "run", "standalone.rs"], {
+			cwd: repoDir,
+			encoding: "utf8",
+			env: {
+				...process.env,
+				DOCKER_BUILD_ARGS_LOG: dockerBuildArgsLog,
+				DOCKER_IMAGE_INSPECT_LOG: dockerImageInspectLog,
+				DOCKER_MANIFEST_LOG: dockerManifestLog,
+				DOCKER_RUN_ARGS_LOG: dockerRunArgsLog,
+				DOCKERFILE_COPY: dockerfileCopy,
+				PATH: `${binDir}:${process.env.PATH}`,
+				RUNNER_TEMP: runnerTemp,
+			},
+		});
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 1);
+		assert.match(result.details, /No Cargo\.toml found for:/);
+		assert.match(result.details, /standalone\.rs/);
+		assert.equal(fs.existsSync(dockerManifestLog), false);
+		assert.equal(fs.existsSync(dockerRunArgsLog), false);
+	} finally {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+});
+
+test("cargo-clippy.sh handles absolute Rust file paths outside Cargo packages", () => {
+	const {
+		binDir,
+		dockerBuildArgsLog,
+		dockerImageInspectLog,
+		dockerManifestLog,
+		dockerRunArgsLog,
+		dockerfileCopy,
+		repoDir,
+		runnerTemp,
+		tempDir,
+	} = makeTempRepo("cargo-clippy-absolute-missing-manifest-");
+	const standalonePath = path.join(tempDir, "standalone.rs");
+
+	writeFile(standalonePath, "fn main() {}\n");
+
+	try {
+		const output = execFileSync("bash", [scriptPath, "run", standalonePath], {
+			cwd: repoDir,
+			encoding: "utf8",
+			env: {
+				...process.env,
+				DOCKER_BUILD_ARGS_LOG: dockerBuildArgsLog,
+				DOCKER_IMAGE_INSPECT_LOG: dockerImageInspectLog,
+				DOCKER_MANIFEST_LOG: dockerManifestLog,
+				DOCKER_RUN_ARGS_LOG: dockerRunArgsLog,
+				DOCKERFILE_COPY: dockerfileCopy,
+				PATH: `${binDir}:${process.env.PATH}`,
+				RUNNER_TEMP: runnerTemp,
+			},
+			timeout: 1000,
+		});
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 1);
+		assert.match(result.details, /No Cargo\.toml found for:/);
+		assert.match(result.details, /standalone\.rs/);
+		assert.equal(fs.existsSync(dockerManifestLog), false);
+		assert.equal(fs.existsSync(dockerRunArgsLog), false);
+	} finally {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+});
+
+test("cargo-clippy.sh continues checking later Cargo packages after one failure", () => {
+	const {
+		binDir,
+		dockerBuildArgsLog,
+		dockerImageInspectLog,
+		dockerManifestLog,
+		dockerRunArgsLog,
+		dockerfileCopy,
+		repoDir,
+		runnerTemp,
+		tempDir,
+	} = makeTempRepo("cargo-clippy-continue-");
+
+	writeFile(
+		path.join(repoDir, "Cargo.toml"),
+		`[package]
+name = "root"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(path.join(repoDir, "src/lib.rs"), "pub fn root_lib() {}\n");
+	writeFile(
+		path.join(repoDir, "crates/member/Cargo.toml"),
+		`[package]
+name = "member"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(
+		path.join(repoDir, "crates/member/src/lib.rs"),
+		"pub fn member_lib() {}\n",
+	);
+
+	try {
+		const output = execFileSync(
+			"bash",
+			[scriptPath, "run", "src/lib.rs", "crates/member/src/lib.rs"],
+			{
+				cwd: repoDir,
+				encoding: "utf8",
+				env: {
+					...process.env,
+					DOCKER_BUILD_ARGS_LOG: dockerBuildArgsLog,
+					DOCKER_IMAGE_INSPECT_LOG: dockerImageInspectLog,
+					DOCKER_MANIFEST_LOG: dockerManifestLog,
+					DOCKER_RUN_ARGS_LOG: dockerRunArgsLog,
+					DOCKERFILE_COPY: dockerfileCopy,
+					FAIL_MANIFEST: "Cargo.toml",
+					PATH: `${binDir}:${process.env.PATH}`,
+					RUNNER_TEMP: runnerTemp,
+				},
+			},
+		);
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 1);
+		assert.deepEqual(
+			fs.readFileSync(dockerManifestLog, "utf8").trim().split("\n"),
+			["Cargo.toml", "crates/member/Cargo.toml"],
+		);
+		assert.match(result.details, /clippy failure Cargo\.toml/);
+		assert.match(
+			fs.readFileSync(dockerRunArgsLog, "utf8"),
+			/cargo clippy --manifest-path crates\/member\/Cargo\.toml --all-targets -- -D warnings/,
+		);
+	} finally {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+});
+
+test("cargo-clippy.sh skips clippy for a package when cargo fetch fails and continues with later packages", () => {
+	const {
+		binDir,
+		dockerBuildArgsLog,
+		dockerImageInspectLog,
+		dockerManifestLog,
+		dockerRunArgsLog,
+		dockerfileCopy,
+		repoDir,
+		runnerTemp,
+		tempDir,
+	} = makeTempRepo("cargo-clippy-fetch-failure-");
+
+	writeFile(
+		path.join(repoDir, "Cargo.toml"),
+		`[package]
+name = "root"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(path.join(repoDir, "src/lib.rs"), "pub fn root_lib() {}\n");
+	writeFile(
+		path.join(repoDir, "crates/member/Cargo.toml"),
+		`[package]
+name = "member"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(
+		path.join(repoDir, "crates/member/src/lib.rs"),
+		"pub fn member_lib() {}\n",
+	);
+
+	try {
+		const output = execFileSync(
+			"bash",
+			[scriptPath, "run", "src/lib.rs", "crates/member/src/lib.rs"],
+			{
+				cwd: repoDir,
+				encoding: "utf8",
+				env: {
+					...process.env,
+					DOCKER_BUILD_ARGS_LOG: dockerBuildArgsLog,
+					DOCKER_IMAGE_INSPECT_LOG: dockerImageInspectLog,
+					DOCKER_MANIFEST_LOG: dockerManifestLog,
+					DOCKER_RUN_ARGS_LOG: dockerRunArgsLog,
+					DOCKERFILE_COPY: dockerfileCopy,
+					FAIL_FETCH_MANIFEST: "Cargo.toml",
+					PATH: `${binDir}:${process.env.PATH}`,
+					RUNNER_TEMP: runnerTemp,
+				},
+			},
+		);
+		const result = JSON.parse(output);
+		const runArgs = fs.readFileSync(dockerRunArgsLog, "utf8");
+
+		assert.equal(result.exit_code, 1);
+		assert.match(result.details, /fetch failure Cargo\.toml/);
+		assert.match(runArgs, /cargo fetch --manifest-path Cargo\.toml/);
+		assert.doesNotMatch(
+			runArgs,
+			/--network=none localhost\/linter-service-cargo-clippy:rust-1-bookworm cargo clippy --manifest-path Cargo\.toml --all-targets -- -D warnings/,
+		);
+		assert.match(
+			runArgs,
+			/cargo fetch --manifest-path crates\/member\/Cargo\.toml/,
+		);
+		assert.match(
+			runArgs,
+			/--network=none localhost\/linter-service-cargo-clippy:rust-1-bookworm cargo clippy --manifest-path crates\/member\/Cargo\.toml --all-targets -- -D warnings/,
+		);
+		assert.deepEqual(
+			fs.readFileSync(dockerManifestLog, "utf8").trim().split("\n"),
+			["crates/member/Cargo.toml"],
+		);
+	} finally {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+});

--- a/.github/scripts/linters/cargo-fmt.sh
+++ b/.github/scripts/linters/cargo-fmt.sh
@@ -21,28 +21,6 @@ cargo_fmt_persist_env() {
   fi
 }
 
-cargo_fmt_find_manifest() {
-  local path=$1
-  local current_dir candidate
-
-  current_dir=$(dirname "$path")
-  while :; do
-    candidate="$current_dir/Cargo.toml"
-    if [ -f "$candidate" ]; then
-      printf '%s\n' "${candidate#./}"
-      return 0
-    fi
-
-    if [ "$current_dir" = "." ] || [ "$current_dir" = "/" ]; then
-      break
-    fi
-
-    current_dir=$(dirname "$current_dir")
-  done
-
-  return 1
-}
-
 mode=${1-}
 if [ "$#" -gt 0 ]; then
   shift
@@ -88,31 +66,7 @@ EOF
     cargo_fmt_prepare_env
     output_file="$RUNNER_TEMP/linter-output.txt"
     manifests=()
-    missing_files=()
-    declare -A seen_manifests=()
-    path=""
-    manifest_path=""
-
-    for path in "$@"; do
-      if ! manifest_path=$(cargo_fmt_find_manifest "$path"); then
-        missing_files+=("$path")
-        continue
-      fi
-
-      if [ -z "${seen_manifests[$manifest_path]+x}" ]; then
-        seen_manifests["$manifest_path"]=1
-        manifests+=("$manifest_path")
-      fi
-    done
-
-    if [ "${#missing_files[@]}" -gt 0 ]; then
-      {
-        echo "Cargo fmt requires each selected Rust file to belong to a Cargo package."
-        echo "No Cargo.toml found for:"
-        for path in "${missing_files[@]}"; do
-          printf ' - %s\n' "$path"
-        done
-      } > "$output_file"
+    if ! linter_lib::collect_cargo_manifests "$output_file" "Cargo fmt" manifests "$@"; then
       linter_lib::emit_json_result 1 "$output_file"
       exit 0
     fi

--- a/.github/scripts/linters/cargo-fmt.test.js
+++ b/.github/scripts/linters/cargo-fmt.test.js
@@ -1,36 +1,12 @@
-const assert = require("node:assert/strict");
-const fs = require("node:fs");
-const os = require("node:os");
-const path = require("node:path");
-const { execFileSync } = require("node:child_process");
-const test = require("node:test");
+const {
+	assert,
+	defineCommonCargoManifestTests,
+	fs,
+	path,
+	writeExecutable,
+} = require("./cargo-linter-test-lib");
 
 const scriptPath = path.join(__dirname, "cargo-fmt.sh");
-
-function writeExecutable(filePath, content) {
-	fs.writeFileSync(filePath, content, "utf8");
-	fs.chmodSync(filePath, 0o755);
-}
-
-function createPythonStub(binDir) {
-	writeExecutable(
-		path.join(binDir, "python3"),
-		`#!/usr/bin/env bash
-set -euo pipefail
-cat >/dev/null
-exit_code="$2"
-output_file="$3"
-node - "$exit_code" "$output_file" <<'NODE'
-const fs = require("node:fs");
-const [exitCode, outputFile] = process.argv.slice(2);
-const details = fs.existsSync(outputFile)
-\t? fs.readFileSync(outputFile, "utf8").trim()
-\t: "";
-process.stdout.write(JSON.stringify({ details, exit_code: Number(exitCode) }));
-NODE
-`,
-	);
-}
 
 function createCargoStub(binDir) {
 	writeExecutable(
@@ -59,81 +35,24 @@ fi
 	);
 }
 
-function makeTempRepo(prefix) {
-	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-	const repoDir = path.join(tempDir, "repo");
-	const runnerTemp = path.join(tempDir, "runner");
-	const binDir = path.join(tempDir, "bin");
-	const cargoManifestLog = path.join(tempDir, "cargo-manifests.log");
-
-	fs.mkdirSync(repoDir, { recursive: true });
-	fs.mkdirSync(runnerTemp, { recursive: true });
-	fs.mkdirSync(binDir, { recursive: true });
-
-	createPythonStub(binDir);
-	createCargoStub(binDir);
-
-	return { binDir, cargoManifestLog, repoDir, runnerTemp, tempDir };
-}
-
-function writeFile(filePath, content) {
-	fs.mkdirSync(path.dirname(filePath), { recursive: true });
-	fs.writeFileSync(filePath, content, "utf8");
-}
-
-test("cargo-fmt.sh groups changed Rust files by nearest Cargo.toml", () => {
-	const { binDir, cargoManifestLog, repoDir, runnerTemp, tempDir } =
-		makeTempRepo("cargo-fmt-grouped-");
-
-	writeFile(
-		path.join(repoDir, "Cargo.toml"),
-		`[package]
-name = "root"
-version = "0.1.0"
-edition = "2021"
-`,
-	);
-	writeFile(path.join(repoDir, "src/lib.rs"), "pub fn root_lib() {}\n");
-	writeFile(path.join(repoDir, "src/main.rs"), "fn main() {}\n");
-	writeFile(
-		path.join(repoDir, "crates/member/Cargo.toml"),
-		`[package]
-name = "member"
-version = "0.1.0"
-edition = "2021"
-`,
-	);
-	writeFile(
-		path.join(repoDir, "crates/member/src/lib.rs"),
-		"pub fn member_lib() {}\n",
-	);
-
-	try {
-		const output = execFileSync(
-			"bash",
-			[
-				scriptPath,
-				"run",
-				"src/lib.rs",
-				"src/main.rs",
-				"crates/member/src/lib.rs",
-			],
-			{
-				cwd: repoDir,
-				encoding: "utf8",
-				env: {
-					...process.env,
-					CARGO_MANIFEST_LOG: cargoManifestLog,
-					PATH: `${binDir}:${process.env.PATH}`,
-					RUNNER_TEMP: runnerTemp,
-				},
+defineCommonCargoManifestTests({
+	scriptPath,
+	tempPrefix: "cargo-fmt-",
+	toolName: "cargo-fmt.sh",
+	setupTooling(context) {
+		const cargoManifestLog = path.join(context.tempDir, "cargo-manifests.log");
+		createCargoStub(context.binDir);
+		return {
+			cargoManifestLog,
+			env: {
+				CARGO_MANIFEST_LOG: cargoManifestLog,
 			},
-		);
-		const result = JSON.parse(output);
-
+		};
+	},
+	assertGroupedResult({ result, tooling }) {
 		assert.equal(result.exit_code, 0);
 		assert.deepEqual(
-			fs.readFileSync(cargoManifestLog, "utf8").trim().split("\n"),
+			fs.readFileSync(tooling.cargoManifestLog, "utf8").trim().split("\n"),
 			["Cargo.toml", "crates/member/Cargo.toml"],
 		);
 		assert.match(
@@ -144,116 +63,23 @@ edition = "2021"
 			result.details,
 			/cargo fmt --check --manifest-path crates\/member\/Cargo\.toml/,
 		);
-	} finally {
-		fs.rmSync(tempDir, { recursive: true, force: true });
-	}
-});
-
-test("cargo-fmt.sh reports Rust files outside Cargo packages", () => {
-	const { binDir, cargoManifestLog, repoDir, runnerTemp, tempDir } =
-		makeTempRepo("cargo-fmt-missing-manifest-");
-
-	writeFile(path.join(repoDir, "standalone.rs"), "fn main() {}\n");
-
-	try {
-		const output = execFileSync("bash", [scriptPath, "run", "standalone.rs"], {
-			cwd: repoDir,
-			encoding: "utf8",
-			env: {
-				...process.env,
-				CARGO_MANIFEST_LOG: cargoManifestLog,
-				PATH: `${binDir}:${process.env.PATH}`,
-				RUNNER_TEMP: runnerTemp,
-			},
-		});
-		const result = JSON.parse(output);
-
+	},
+	assertMissingManifestResult({ pathValue, result, tooling }) {
 		assert.equal(result.exit_code, 1);
 		assert.match(result.details, /No Cargo\.toml found for:/);
-		assert.match(result.details, /standalone\.rs/);
-		assert.equal(fs.existsSync(cargoManifestLog), false);
-	} finally {
-		fs.rmSync(tempDir, { recursive: true, force: true });
-	}
-});
-
-test("cargo-fmt.sh handles absolute Rust file paths outside Cargo packages", () => {
-	const { binDir, cargoManifestLog, repoDir, runnerTemp, tempDir } =
-		makeTempRepo("cargo-fmt-absolute-missing-manifest-");
-	const standalonePath = path.join(tempDir, "standalone.rs");
-
-	writeFile(standalonePath, "fn main() {}\n");
-
-	try {
-		const output = execFileSync("bash", [scriptPath, "run", standalonePath], {
-			cwd: repoDir,
-			encoding: "utf8",
-			env: {
-				...process.env,
-				CARGO_MANIFEST_LOG: cargoManifestLog,
-				PATH: `${binDir}:${process.env.PATH}`,
-				RUNNER_TEMP: runnerTemp,
-			},
-			timeout: 1000,
-		});
-		const result = JSON.parse(output);
-
-		assert.equal(result.exit_code, 1);
-		assert.match(result.details, /No Cargo\.toml found for:/);
-		assert.match(result.details, /standalone\.rs/);
-		assert.equal(fs.existsSync(cargoManifestLog), false);
-	} finally {
-		fs.rmSync(tempDir, { recursive: true, force: true });
-	}
-});
-
-test("cargo-fmt.sh continues checking later Cargo packages after one failure", () => {
-	const { binDir, cargoManifestLog, repoDir, runnerTemp, tempDir } =
-		makeTempRepo("cargo-fmt-continue-");
-
-	writeFile(
-		path.join(repoDir, "Cargo.toml"),
-		`[package]
-name = "root"
-version = "0.1.0"
-edition = "2021"
-`,
-	);
-	writeFile(path.join(repoDir, "src/lib.rs"), "pub fn root_lib() {}\n");
-	writeFile(
-		path.join(repoDir, "crates/member/Cargo.toml"),
-		`[package]
-name = "member"
-version = "0.1.0"
-edition = "2021"
-`,
-	);
-	writeFile(
-		path.join(repoDir, "crates/member/src/lib.rs"),
-		"pub fn member_lib() {}\n",
-	);
-
-	try {
-		const output = execFileSync(
-			"bash",
-			[scriptPath, "run", "src/lib.rs", "crates/member/src/lib.rs"],
-			{
-				cwd: repoDir,
-				encoding: "utf8",
-				env: {
-					...process.env,
-					CARGO_MANIFEST_LOG: cargoManifestLog,
-					FAIL_MANIFEST: "Cargo.toml",
-					PATH: `${binDir}:${process.env.PATH}`,
-					RUNNER_TEMP: runnerTemp,
-				},
-			},
+		assert.match(
+			result.details,
+			new RegExp(pathValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
 		);
-		const result = JSON.parse(output);
-
+		assert.equal(fs.existsSync(tooling.cargoManifestLog), false);
+	},
+	continueFailureEnv: {
+		FAIL_MANIFEST: "Cargo.toml",
+	},
+	assertContinueAfterFailureResult({ result, tooling }) {
 		assert.equal(result.exit_code, 1);
 		assert.deepEqual(
-			fs.readFileSync(cargoManifestLog, "utf8").trim().split("\n"),
+			fs.readFileSync(tooling.cargoManifestLog, "utf8").trim().split("\n"),
 			["Cargo.toml", "crates/member/Cargo.toml"],
 		);
 		assert.match(result.details, /unformatted Cargo\.toml/);
@@ -261,7 +87,5 @@ edition = "2021"
 			result.details,
 			/cargo fmt --check --manifest-path crates\/member\/Cargo\.toml/,
 		);
-	} finally {
-		fs.rmSync(tempDir, { recursive: true, force: true });
-	}
+	},
 });

--- a/.github/scripts/linters/cargo-linter-test-lib.js
+++ b/.github/scripts/linters/cargo-linter-test-lib.js
@@ -1,0 +1,224 @@
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+function writeExecutable(filePath, content) {
+	fs.writeFileSync(filePath, content, "utf8");
+	fs.chmodSync(filePath, 0o755);
+}
+
+function createJsonPythonStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "python3"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+cat >/dev/null
+exit_code="$2"
+output_file="$3"
+node - "$exit_code" "$output_file" <<'NODE'
+const fs = require("node:fs");
+const [exitCode, outputFile] = process.argv.slice(2);
+const details = fs.existsSync(outputFile)
+\t? fs.readFileSync(outputFile, "utf8").trim()
+\t: "";
+process.stdout.write(JSON.stringify({ details, exit_code: Number(exitCode) }));
+NODE
+`,
+	);
+}
+
+function makeTempRepo(prefix) {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	const repoDir = path.join(tempDir, "repo");
+	const runnerTemp = path.join(tempDir, "runner");
+	const binDir = path.join(tempDir, "bin");
+
+	fs.mkdirSync(repoDir, { recursive: true });
+	fs.mkdirSync(runnerTemp, { recursive: true });
+	fs.mkdirSync(binDir, { recursive: true });
+
+	createJsonPythonStub(binDir);
+
+	return { binDir, repoDir, runnerTemp, tempDir };
+}
+
+function writeFile(filePath, content) {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, content, "utf8");
+}
+
+function cleanupTempRepo(tempDir) {
+	fs.rmSync(tempDir, { recursive: true, force: true });
+}
+
+function createScriptEnv(context, extraEnv = {}) {
+	return {
+		...process.env,
+		...extraEnv,
+		PATH: `${context.binDir}:${process.env.PATH}`,
+		RUNNER_TEMP: context.runnerTemp,
+	};
+}
+
+function populateTwoPackageRepo(repoDir) {
+	writeFile(
+		path.join(repoDir, "Cargo.toml"),
+		`[package]
+name = "root"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(path.join(repoDir, "src/lib.rs"), "pub fn root_lib() {}\n");
+	writeFile(path.join(repoDir, "src/main.rs"), "fn main() {}\n");
+	writeFile(
+		path.join(repoDir, "crates/member/Cargo.toml"),
+		`[package]
+name = "member"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(
+		path.join(repoDir, "crates/member/src/lib.rs"),
+		"pub fn member_lib() {}\n",
+	);
+}
+
+function defineCommonCargoManifestTests({
+	assertContinueAfterFailureResult,
+	assertGroupedResult,
+	assertMissingManifestResult,
+	continueFailureEnv,
+	scriptPath,
+	setupTooling,
+	tempPrefix,
+	toolName,
+}) {
+	test(`${toolName} groups changed Rust files by nearest Cargo.toml`, () => {
+		const context = makeTempRepo(`${tempPrefix}grouped-`);
+		const tooling = setupTooling(context);
+
+		populateTwoPackageRepo(context.repoDir);
+
+		try {
+			const output = execFileSync(
+				"bash",
+				[
+					scriptPath,
+					"run",
+					"src/lib.rs",
+					"src/main.rs",
+					"crates/member/src/lib.rs",
+				],
+				{
+					cwd: context.repoDir,
+					encoding: "utf8",
+					env: createScriptEnv(context, tooling.env),
+				},
+			);
+			const result = JSON.parse(output);
+
+			assertGroupedResult({ context, result, tooling });
+		} finally {
+			cleanupTempRepo(context.tempDir);
+		}
+	});
+
+	test(`${toolName} reports Rust files outside Cargo packages`, () => {
+		const context = makeTempRepo(`${tempPrefix}missing-manifest-`);
+		const tooling = setupTooling(context);
+
+		writeFile(path.join(context.repoDir, "standalone.rs"), "fn main() {}\n");
+
+		try {
+			const output = execFileSync(
+				"bash",
+				[scriptPath, "run", "standalone.rs"],
+				{
+					cwd: context.repoDir,
+					encoding: "utf8",
+					env: createScriptEnv(context, tooling.env),
+				},
+			);
+			const result = JSON.parse(output);
+
+			assertMissingManifestResult({
+				context,
+				pathValue: "standalone.rs",
+				result,
+				tooling,
+			});
+		} finally {
+			cleanupTempRepo(context.tempDir);
+		}
+	});
+
+	test(`${toolName} handles absolute Rust file paths outside Cargo packages`, () => {
+		const context = makeTempRepo(`${tempPrefix}absolute-missing-manifest-`);
+		const tooling = setupTooling(context);
+		const standalonePath = path.join(context.tempDir, "standalone.rs");
+
+		writeFile(standalonePath, "fn main() {}\n");
+
+		try {
+			const output = execFileSync("bash", [scriptPath, "run", standalonePath], {
+				cwd: context.repoDir,
+				encoding: "utf8",
+				env: createScriptEnv(context, tooling.env),
+				timeout: 1000,
+			});
+			const result = JSON.parse(output);
+
+			assertMissingManifestResult({
+				context,
+				pathValue: standalonePath,
+				result,
+				tooling,
+			});
+		} finally {
+			cleanupTempRepo(context.tempDir);
+		}
+	});
+
+	test(`${toolName} continues checking later Cargo packages after one failure`, () => {
+		const context = makeTempRepo(`${tempPrefix}continue-`);
+		const tooling = setupTooling(context);
+
+		populateTwoPackageRepo(context.repoDir);
+
+		try {
+			const output = execFileSync(
+				"bash",
+				[scriptPath, "run", "src/lib.rs", "crates/member/src/lib.rs"],
+				{
+					cwd: context.repoDir,
+					encoding: "utf8",
+					env: createScriptEnv(context, {
+						...tooling.env,
+						...(continueFailureEnv || {}),
+					}),
+				},
+			);
+			const result = JSON.parse(output);
+
+			assertContinueAfterFailureResult({ context, result, tooling });
+		} finally {
+			cleanupTempRepo(context.tempDir);
+		}
+	});
+}
+
+module.exports = {
+	assert,
+	cleanupTempRepo,
+	defineCommonCargoManifestTests,
+	fs,
+	makeTempRepo,
+	path,
+	writeExecutable,
+	writeFile,
+};

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -64,6 +64,15 @@
       "details_fallback": "cargo-fmt did not produce diagnostic output before the job failed."
     },
     {
+      "name": "cargo-clippy",
+      "heading": "### cargo-clippy",
+      "no_files": "No matching Rust files were selected for `cargo-clippy`.",
+      "success": "✅ No Clippy issues found in Cargo package(s) containing {count} changed Rust file(s).",
+      "failure": "❌ Clippy issues found in Cargo package(s) containing {count} changed Rust file(s).",
+      "infra_failure": "❌ The `cargo-clippy` workflow failed before producing a detailed report. See the workflow logs.",
+      "details_fallback": "cargo-clippy did not produce diagnostic output before the job failed."
+    },
+    {
       "name": "taplo",
       "heading": "### taplo",
       "no_files": "No matching TOML files were selected for `taplo`.",

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ GitHub Actions が共通ルールで lint します。
 | `markdownlint-cli2` | `*.md`, `*.markdown` | `.markdownlint-cli2.jsonc` / `.markdownlint-cli2.yaml` と `.markdownlint.jsonc` / `.markdownlint.json` / `.markdownlint.yaml` / `.markdownlint.yml` の静的 config のみを扱います。`.cjs` / `.mjs` は任意コード実行を避けるため対象外です。共有 workflow は `globs` を使わず、変更対象だけを検査します。 |
 | `ruff` | `*.py`, `*.pyi` | `pyproject.toml` の `[tool.ruff]`、`ruff.toml`、`.ruff.toml` を対象 file ごとに近いものから使います。同一 directory では `.ruff.toml` → `ruff.toml` → `pyproject.toml` の順です。共有 workflow は `--force-exclude` を付け、設定上の除外も尊重します。 |
 | `cargo-fmt` | `*.rs` | changed Rust file ごとに最も近い `Cargo.toml` を探し、重複を除いた package 単位で `cargo fmt --check --manifest-path ...` を実行します。`rustfmt.toml` / `.rustfmt.toml` と `rust-toolchain.toml` / `rust-toolchain` は Cargo / rustup の既定探索を使います。 |
-| `cargo-clippy` | `*.rs` | changed Rust file ごとに最も近い `Cargo.toml` を探し、重複を除いた package 単位で `cargo fetch` の後に `cargo clippy --manifest-path ... --all-targets -- -D warnings` を実行します。Clippy 実行本体は `--network none` 付き Docker container へ隔離し、source checkout は host 側から直接 build させません。private git dependency や認証が必要な registry は現状サポートしません。 |
+| `cargo-clippy` | `*.rs` | changed Rust file ごとに最も近い `Cargo.toml` を探し、重複を除いた package 単位で `cargo fetch` の後に `cargo clippy --manifest-path ... --all-targets -- -D warnings` を実行します。Clippy 実行本体は `--network none` 付き Docker container へ隔離し、source checkout は host 側から直接 build させません。repository-supplied `.cargo/config` / `.cargo/config.toml` は共有 path では未対応です。private git dependency や認証が必要な registry は現状サポートしません。 |
 | `taplo` | `*.toml` | `.taplo.toml` を優先し、なければ `taplo.toml` を repo root で探します。未配置時は既定値で `fmt --check` を行います。 |
 | `biome` | `*.js`, `*.jsx`, `*.ts`, `*.tsx`, `*.json`, `*.jsonc`, `*.cjs`, `*.cts`, `*.mjs`, `*.mts` | Biome の既定探索で `biome.json` / `biome.jsonc` / `.biome.json` / `.biome.jsonc` を探し、未配置時は既定値を使います。 |
 | `shellcheck` | `*.bash`, `*.ksh`, `*.sh` | `.shellcheckrc` / `shellcheckrc` を対象 script の場所から親へ向けて探します。 |
@@ -120,7 +120,7 @@ GitHub Actions が共通ルールで lint します。
    JavaScript のように任意コード実行につながる config は許可せず、
    静的 config のみを受けるか、wrapper で明示的に reject します。
    `markdownlint-cli2.sh` と `spectral.sh` は config 側の実例で、
-   `cargo-clippy` は Docker container 実行側の実例です。
+   `cargo-clippy` は Docker container 実行と `.cargo/config*` reject の実例です。
 
 5. `.github/scripts/linters/config.json` に entry を追加します。
    ここが comment 見出し、成功 / 失敗文言、fallback message の source of truth です。

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ GitHub Actions が共通ルールで lint します。
 | `markdownlint-cli2` | `*.md`, `*.markdown` | `.markdownlint-cli2.jsonc` / `.markdownlint-cli2.yaml` と `.markdownlint.jsonc` / `.markdownlint.json` / `.markdownlint.yaml` / `.markdownlint.yml` の静的 config のみを扱います。`.cjs` / `.mjs` は任意コード実行を避けるため対象外です。共有 workflow は `globs` を使わず、変更対象だけを検査します。 |
 | `ruff` | `*.py`, `*.pyi` | `pyproject.toml` の `[tool.ruff]`、`ruff.toml`、`.ruff.toml` を対象 file ごとに近いものから使います。同一 directory では `.ruff.toml` → `ruff.toml` → `pyproject.toml` の順です。共有 workflow は `--force-exclude` を付け、設定上の除外も尊重します。 |
 | `cargo-fmt` | `*.rs` | changed Rust file ごとに最も近い `Cargo.toml` を探し、重複を除いた package 単位で `cargo fmt --check --manifest-path ...` を実行します。`rustfmt.toml` / `.rustfmt.toml` と `rust-toolchain.toml` / `rust-toolchain` は Cargo / rustup の既定探索を使います。 |
+| `cargo-clippy` | `*.rs` | changed Rust file ごとに最も近い `Cargo.toml` を探し、重複を除いた package 単位で `cargo fetch` の後に `cargo clippy --manifest-path ... --all-targets -- -D warnings` を実行します。Clippy 実行本体は `--network none` 付き Docker container へ隔離し、source checkout は host 側から直接 build させません。private git dependency や認証が必要な registry は現状サポートしません。 |
 | `taplo` | `*.toml` | `.taplo.toml` を優先し、なければ `taplo.toml` を repo root で探します。未配置時は既定値で `fmt --check` を行います。 |
 | `biome` | `*.js`, `*.jsx`, `*.ts`, `*.tsx`, `*.json`, `*.jsonc`, `*.cjs`, `*.cts`, `*.mjs`, `*.mts` | Biome の既定探索で `biome.json` / `biome.jsonc` / `.biome.json` / `.biome.jsonc` を探し、未配置時は既定値を使います。 |
 | `shellcheck` | `*.bash`, `*.ksh`, `*.sh` | `.shellcheckrc` / `shellcheckrc` を対象 script の場所から親へ向けて探します。 |
@@ -65,7 +66,7 @@ GitHub Actions が共通ルールで lint します。
 1. `.github/scripts/linters/<name>.sh` を追加します。
    `patterns`, `install`, `run` の 3 mode を実装してください。
    `repository-dispatch.yml` は `patterns` の regex で対象 linter を選び、
-   `lint-common.yml` は一致した changed file path を `run` に渡します。
+   reusable workflow は一致した changed file path を `run` に渡します。
 
    ```bash
    #!/usr/bin/env bash
@@ -113,16 +114,18 @@ GitHub Actions が共通ルールで lint します。
    変換します。`cargo-fmt.sh` は Cargo package 単位へまとめ、
    `markdownlint-cli2.sh` は temp repo を組み立てて changed file だけを検査します。
 
-4. 利用 repository 側の config を読む linter は、
+4. 利用 repository 側の config を読む linter や、
+   compile / build によって repository code を実行する linter は、
    untrusted pull request でも安全に扱えることを確認してください。
    JavaScript のように任意コード実行につながる config は許可せず、
    静的 config のみを受けるか、wrapper で明示的に reject します。
-   `markdownlint-cli2.sh` と `spectral.sh` はその実例です。
+   `markdownlint-cli2.sh` と `spectral.sh` は config 側の実例で、
+   `cargo-clippy` は Docker container 実行側の実例です。
 
 5. `.github/scripts/linters/config.json` に entry を追加します。
    ここが comment 見出し、成功 / 失敗文言、fallback message の source of truth です。
    通常は linter を増やすために `repository-dispatch.yml` や
-   `lint-common.yml` を個別修正する必要はありません。
+   reusable workflow 群を個別修正する必要はありません。
 
 6. この `README.md` の「共有 linter 一覧」に、
    対象ファイルと config 探索 / 挙動を 1 行追記します。

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ GitHub Actions が共通ルールで lint します。
 1. `.github/scripts/linters/<name>.sh` を追加します。
    `patterns`, `install`, `run` の 3 mode を実装してください。
    `repository-dispatch.yml` は `patterns` の regex で対象 linter を選び、
-   reusable workflow は一致した changed file path を `run` に渡します。
+   `lint-common.yml` は一致した changed file path を `run` に渡します。
 
    ```bash
    #!/usr/bin/env bash
@@ -125,7 +125,7 @@ GitHub Actions が共通ルールで lint します。
 5. `.github/scripts/linters/config.json` に entry を追加します。
    ここが comment 見出し、成功 / 失敗文言、fallback message の source of truth です。
    通常は linter を増やすために `repository-dispatch.yml` や
-   reusable workflow 群を個別修正する必要はありません。
+   `lint-common.yml` を個別修正する必要はありません。
 
 6. この `README.md` の「共有 linter 一覧」に、
    対象ファイルと config 探索 / 挙動を 1 行追記します。


### PR DESCRIPTION
## Summary
- add a shared `cargo-clippy` linter entry and README documentation
- implement `cargo-clippy.sh` with Docker-based isolation, manifest grouping, dependency prefetch, and `--network=none` for the clippy execution phase
- address review findings by extracting shared Cargo helpers, rejecting repository-supplied `.cargo/config*`, excluding `.git` from the copied worktree, and refactoring duplicated Cargo linter tests into a shared helper

## Validation
- `node --test .github/scripts/artifact-passphrase.test.js .github/scripts/upsert-pr-comment.test.js .github/scripts/linters/cargo-fmt.test.js .github/scripts/linters/cargo-clippy.test.js`
- `shellcheck -x -P SCRIPTDIR .github/scripts/linters/cargo-fmt.sh .github/scripts/linters/cargo-clippy.sh`
- `actionlint .github/workflows/repository-dispatch.yml .github/workflows/lint-common.yml`
- `ghalint run`
- `markdownlint-cli2 --no-globs :README.md`
- `git diff --check`