### PR TITLE
feat(linters): add hadolint shared linter

### DIFF
--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -19,6 +19,15 @@
       "details_fallback": "ghalint did not produce diagnostic output before the job failed."
     },
     {
+      "name": "hadolint",
+      "heading": "### hadolint",
+      "no_files": "No matching Dockerfile or Containerfile files were selected for `hadolint`.",
+      "success": "✅ No issues found in {count} changed Dockerfile or Containerfile file(s).",
+      "failure": "❌ Issues found in {count} changed Dockerfile or Containerfile file(s).",
+      "infra_failure": "❌ The `hadolint` workflow failed before producing a detailed report. See the workflow logs.",
+      "details_fallback": "hadolint did not produce diagnostic output before the job failed."
+    },
+    {
       "name": "spectral",
       "heading": "### spectral",
       "no_files": "No matching YAML or JSON files were selected for `spectral`.",

--- a/.github/scripts/linters/hadolint.sh
+++ b/.github/scripts/linters/hadolint.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../linter-library.sh
+source "$script_dir/../linter-library.sh"
+
+hadolint_find_config() {
+  local path=$1
+  local current_dir candidate
+
+  current_dir=$(dirname "$path")
+  while :; do
+    for candidate in "$current_dir/.hadolint.yaml" "$current_dir/.hadolint.yml"; do
+      if [ -f "$candidate" ]; then
+        printf '%s\n' "${candidate#./}"
+        return 0
+      fi
+    done
+
+    if [ "$current_dir" = "." ] || [ "$current_dir" = "/" ]; then
+      break
+    fi
+
+    current_dir=$(dirname "$current_dir")
+  done
+
+  return 1
+}
+
+mode=${1-}
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+case "$mode" in
+  patterns)
+    cat <<'EOF'
+(?:^|/)(?:Dockerfile(?:\.[^/]+)?|Containerfile(?:\.[^/]+)?|[^/]+\.(?:dockerfile|containerfile))$
+EOF
+    ;;
+  install)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+
+    if command -v hadolint >/dev/null 2>&1 && hadolint --version >/dev/null 2>&1; then
+      exit 0
+    fi
+
+    release_url="$(curl -fsSL -o /dev/null -w '%{url_effective}' https://github.com/hadolint/hadolint/releases/latest)"
+    version="$(basename "$release_url")"
+    asset="hadolint-linux-x86_64"
+    bin_dir="$RUNNER_TEMP/hadolint/bin"
+
+    rm -rf "$bin_dir"
+    mkdir -p "$bin_dir"
+
+    curl -fsSL "https://github.com/hadolint/hadolint/releases/download/$version/$asset" -o "$bin_dir/hadolint"
+    chmod +x "$bin_dir/hadolint"
+    linter_lib::add_path "$bin_dir"
+    ;;
+  run)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+    output_file="$RUNNER_TEMP/linter-output.txt"
+
+    run_hadolint() {
+      local failure=0
+      local path config_path
+
+      for path in "$@"; do
+        if config_path=$(hadolint_find_config "$path"); then
+          printf '==> hadolint --no-color --config %s %s\n' "$config_path" "$path"
+          if ! hadolint --no-color --config "$config_path" "$path"; then
+            failure=1
+          fi
+        else
+          printf '==> hadolint --no-color %s\n' "$path"
+          if ! hadolint --no-color "$path"; then
+            failure=1
+          fi
+        fi
+        echo
+      done
+
+      return "$failure"
+    }
+
+    linter_lib::run_and_emit_json "$output_file" run_hadolint "$@"
+    ;;
+  *)
+    echo "usage: $0 {patterns|install|run}" >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/linters/hadolint.test.js
+++ b/.github/scripts/linters/hadolint.test.js
@@ -1,0 +1,267 @@
+const test = require("node:test");
+const { execFileSync } = require("node:child_process");
+const {
+	assert,
+	cleanupTempRepo,
+	fs,
+	makeTempRepo,
+	path,
+	writeExecutable,
+	writeFile,
+} = require("./cargo-linter-test-lib");
+
+const scriptPath = path.join(__dirname, "hadolint.sh");
+
+function createEnv(context, extraEnv = {}) {
+	return {
+		...process.env,
+		...extraEnv,
+		PATH: `${context.binDir}:${process.env.PATH}`,
+		RUNNER_TEMP: context.runnerTemp,
+	};
+}
+
+function createCurlStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "curl"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+out_file=""
+write_format=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      out_file="$2"
+      shift 2
+      ;;
+    -w)
+      write_format="$2"
+      shift 2
+      ;;
+    -f|-s|-S|-L|-fsSL)
+      shift
+      ;;
+    http://*|https://*)
+      url="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+printf '%s\\n' "$url" >> "$CURL_URL_LOG"
+if [ "$url" = "https://github.com/hadolint/hadolint/releases/latest" ]; then
+  if [ -n "$out_file" ] && [ "$out_file" != "/dev/null" ]; then
+    : > "$out_file"
+  fi
+  if [ "$write_format" = "%{url_effective}" ]; then
+    printf '%s' "\${HADOLINT_RELEASE_URL:-https://github.com/hadolint/hadolint/releases/tag/v9.9.9}"
+  fi
+  exit 0
+fi
+cat > "$out_file" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+`,
+	);
+}
+
+function createHadolintStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "hadolint"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$HADOLINT_ARGS_LOG"
+target="\${*: -1}"
+printf 'checked %s\\n' "$target"
+if [ -n "\${FAIL_TARGET:-}" ] && [ "$target" = "$FAIL_TARGET" ]; then
+  printf 'issue in %s\\n' "$target" >&2
+  exit 1
+fi
+`,
+	);
+}
+
+test("hadolint.sh patterns match Dockerfile and Containerfile naming conventions", () => {
+	const output = execFileSync("bash", [scriptPath, "patterns"], {
+		encoding: "utf8",
+	});
+	const patterns = output
+		.trim()
+		.split("\n")
+		.filter(Boolean)
+		.map((pattern) => new RegExp(pattern, "i"));
+
+	const matches = (filePath) =>
+		patterns.some((pattern) => pattern.test(filePath));
+
+	assert.equal(matches("Dockerfile"), true);
+	assert.equal(matches("Dockerfile.dev"), true);
+	assert.equal(matches("containers/Containerfile"), true);
+	assert.equal(matches("containers/base.containerfile"), true);
+	assert.equal(matches("docker/api.dockerfile"), true);
+	assert.equal(matches("docs/docker-guide.md"), false);
+	assert.equal(matches("docs/container-guide.txt"), false);
+	assert.equal(matches(".dockerignore"), false);
+});
+
+test("hadolint.sh install downloads the latest Linux x86_64 release binary", () => {
+	const context = makeTempRepo("hadolint-install-");
+	const curlUrlLog = path.join(context.tempDir, "curl-urls.log");
+
+	createCurlStub(context.binDir);
+
+	try {
+		execFileSync("bash", [scriptPath, "install"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createEnv(context, {
+				CURL_URL_LOG: curlUrlLog,
+				HADOLINT_RELEASE_URL:
+					"https://github.com/hadolint/hadolint/releases/tag/v2.14.0",
+			}),
+		});
+
+		assert.deepEqual(fs.readFileSync(curlUrlLog, "utf8").trim().split("\n"), [
+			"https://github.com/hadolint/hadolint/releases/latest",
+			"https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-linux-x86_64",
+		]);
+		assert.equal(
+			fs.existsSync(path.join(context.runnerTemp, "hadolint/bin/hadolint")),
+			true,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("hadolint.sh selects the nearest hadolint config for each target file", () => {
+	const context = makeTempRepo("hadolint-config-search-");
+	const hadolintArgsLog = path.join(context.tempDir, "hadolint-args.log");
+
+	createHadolintStub(context.binDir);
+
+	writeFile(path.join(context.repoDir, ".hadolint.yml"), "ignored: [DL3008]\n");
+	writeFile(path.join(context.repoDir, "Dockerfile"), "FROM alpine:3.20\n");
+	writeFile(
+		path.join(context.repoDir, "services/api/.hadolint.yaml"),
+		"ignored: [DL3007]\n",
+	);
+	writeFile(
+		path.join(context.repoDir, "services/api/Dockerfile.dev"),
+		"FROM alpine:3.20\n",
+	);
+	writeFile(
+		path.join(context.repoDir, "containers/base.containerfile"),
+		"FROM alpine:3.20\n",
+	);
+
+	try {
+		const output = execFileSync(
+			"bash",
+			[
+				scriptPath,
+				"run",
+				"Dockerfile",
+				"services/api/Dockerfile.dev",
+				"containers/base.containerfile",
+			],
+			{
+				cwd: context.repoDir,
+				encoding: "utf8",
+				env: createEnv(context, {
+					HADOLINT_ARGS_LOG: hadolintArgsLog,
+				}),
+			},
+		);
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 0);
+		assert.deepEqual(
+			fs.readFileSync(hadolintArgsLog, "utf8").trim().split("\n"),
+			[
+				"--no-color --config .hadolint.yml Dockerfile",
+				"--no-color --config services/api/.hadolint.yaml services/api/Dockerfile.dev",
+				"--no-color --config .hadolint.yml containers/base.containerfile",
+			],
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("hadolint.sh omits --config when no repository config is found", () => {
+	const context = makeTempRepo("hadolint-no-config-");
+	const hadolintArgsLog = path.join(context.tempDir, "hadolint-args.log");
+
+	createHadolintStub(context.binDir);
+	writeFile(path.join(context.repoDir, "Dockerfile"), "FROM alpine:3.20\n");
+
+	try {
+		const output = execFileSync("bash", [scriptPath, "run", "Dockerfile"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createEnv(context, {
+				HADOLINT_ARGS_LOG: hadolintArgsLog,
+			}),
+		});
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 0);
+		assert.equal(
+			fs.readFileSync(hadolintArgsLog, "utf8").trim(),
+			"--no-color Dockerfile",
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("hadolint.sh continues linting later files after one file fails", () => {
+	const context = makeTempRepo("hadolint-continue-after-failure-");
+	const hadolintArgsLog = path.join(context.tempDir, "hadolint-args.log");
+
+	createHadolintStub(context.binDir);
+
+	writeFile(
+		path.join(context.repoDir, ".hadolint.yaml"),
+		"ignored: [DL3008]\n",
+	);
+	writeFile(path.join(context.repoDir, "Dockerfile"), "FROM alpine:3.20\n");
+	writeFile(
+		path.join(context.repoDir, "services/api/Containerfile"),
+		"FROM alpine:3.20\n",
+	);
+
+	try {
+		const output = execFileSync(
+			"bash",
+			[scriptPath, "run", "Dockerfile", "services/api/Containerfile"],
+			{
+				cwd: context.repoDir,
+				encoding: "utf8",
+				env: createEnv(context, {
+					FAIL_TARGET: "Dockerfile",
+					HADOLINT_ARGS_LOG: hadolintArgsLog,
+				}),
+			},
+		);
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 1);
+		assert.deepEqual(
+			fs.readFileSync(hadolintArgsLog, "utf8").trim().split("\n"),
+			[
+				"--no-color --config .hadolint.yaml Dockerfile",
+				"--no-color --config .hadolint.yaml services/api/Containerfile",
+			],
+		);
+		assert.match(result.details, /issue in Dockerfile/);
+		assert.match(result.details, /checked services\/api\/Containerfile/);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ GitHub Actions が共通ルールで lint します。
 |--------|--------------|---------------------|
 | `actionlint` | `.github/workflows/*.yml`, `.github/workflows/*.yaml` | `.github/actionlint.yaml` / `.github/actionlint.yml` を自動で読みます。 |
 | `ghalint` | `.github/workflows/*.yml`, `.github/workflows/*.yaml` | `.ghalint.yaml` / `.ghalint.yml` / `ghalint.yaml` / `ghalint.yml` / `.github/ghalint.yaml` / `.github/ghalint.yml` を順に探します。 |
+| `hadolint` | `Dockerfile`, `Dockerfile.*`, `Containerfile`, `Containerfile.*`, `*.dockerfile`, `*.containerfile` | 対象 file の directory から親へ向けて `.hadolint.yaml` / `.hadolint.yml` を探し、見つかれば `--config` で明示します。未配置時は hadolint の既定値を使います。 |
 | `spectral` | `*.json`, `*.yaml`, `*.yml` | `.spectral.yml` / `.spectral.yaml` / `.spectral.json` を読みます。未配置時は `spectral:oas` を使い、unknown format は無視します。`.spectral.js` は任意コード実行を避けるため対象外です。 |
 | `yamllint` | `*.yaml`, `*.yml` | `.yamllint` / `.yamllint.yaml` / `.yamllint.yml` を順に探します。 |
 | `markdownlint-cli2` | `*.md`, `*.markdown` | `.markdownlint-cli2.jsonc` / `.markdownlint-cli2.yaml` と `.markdownlint.jsonc` / `.markdownlint.json` / `.markdownlint.yaml` / `.markdownlint.yml` の静的 config のみを扱います。`.cjs` / `.mjs` は任意コード実行を避けるため対象外です。共有 workflow は `globs` を使わず、変更対象だけを検査します。 |


### PR DESCRIPTION
## Summary
- add a shared `hadolint` linter entry and README documentation
- implement `hadolint.sh` with Dockerfile/Containerfile pattern matching, latest-release binary install, and nearest `.hadolint.yaml` / `.hadolint.yml` discovery
- add focused regression coverage for pattern matching, install URL construction, config selection, no-config fallback, and continue-after-failure behavior

## Validation
- `node --test .github/scripts/linters/hadolint.test.js`
- `shellcheck -x -P SCRIPTDIR .github/scripts/linters/hadolint.sh`
- `jq empty .github/scripts/linters/config.json`
- `markdownlint-cli2 --no-globs :README.md`
- `git diff --check`
