### PR TITLE
feat(linters): add editorconfig-checker shared linter

### DIFF
--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -100,6 +100,15 @@
       "details_fallback": "biome did not produce diagnostic output before the job failed."
     },
     {
+      "name": "editorconfig-checker",
+      "heading": "### editorconfig-checker",
+      "no_files": "No matching editorconfig-checker files were selected for `editorconfig-checker`.",
+      "success": "✅ No issues were reported for the selected editorconfig-checker target(s).",
+      "failure": "❌ Issues were reported for the selected editorconfig-checker target(s).",
+      "infra_failure": "❌ The `editorconfig-checker` workflow failed before producing a detailed report. See the workflow logs.",
+      "details_fallback": "editorconfig-checker did not produce diagnostic output before the job failed."
+    },
+    {
       "name": "shellcheck",
       "heading": "### shellcheck",
       "no_files": "No matching shell script files were selected for `shellcheck`.",

--- a/.github/scripts/linters/editorconfig-checker.sh
+++ b/.github/scripts/linters/editorconfig-checker.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../linter-library.sh
+source "$script_dir/../linter-library.sh"
+
+editorconfig_collect_relevant_dirs() {
+  local -A seen=()
+  local path current_dir
+
+  seen["."]=1
+  printf '%s\n' "."
+
+  for path in "$@"; do
+    current_dir=$(dirname "$path")
+
+    while :; do
+      if [ -z "${seen[$current_dir]+x}" ]; then
+        seen["$current_dir"]=1
+        printf '%s\n' "$current_dir"
+      fi
+
+      if [ "$current_dir" = "." ]; then
+        break
+      fi
+
+      current_dir=$(dirname "$current_dir")
+    done
+  done
+}
+
+editorconfig_collect_editorconfig_files() {
+  local dir candidate
+
+  for dir in "$@"; do
+    candidate="$dir/.editorconfig"
+    if [ -f "$candidate" ]; then
+      printf '%s\n' "${candidate#./}"
+    fi
+  done
+}
+
+editorconfig_resolve_repo_config() {
+  if [ -f .editorconfig-checker.json ]; then
+    printf '%s\n' .editorconfig-checker.json
+    return 0
+  fi
+
+  if [ -f .ecrc ]; then
+    printf '%s\n' .ecrc
+    return 0
+  fi
+
+  return 1
+}
+
+editorconfig_write_temp_config() {
+  local output_path=$1
+  local base_config_path=${2-}
+  shift 2
+
+  node - "$output_path" "$base_config_path" "$@" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const [, , outputPath, baseConfigPath, ...passedFiles] = process.argv;
+let config = {};
+
+  if (baseConfigPath && fs.existsSync(baseConfigPath)) {
+    config = JSON.parse(fs.readFileSync(baseConfigPath, "utf8"));
+    if (config === null || Array.isArray(config) || typeof config !== "object") {
+      throw new Error("editorconfig-checker config must be a JSON object");
+    }
+  }
+
+  delete config.Version;
+  config.PassedFiles = passedFiles;
+  config.NoColor = true;
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+NODE
+}
+
+mode=${1-}
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+case "$mode" in
+  patterns)
+    pattern='^(?!.*(?:^|/)(?:\.git|\.jj|node_modules|target|\.yarn)(?:/|$))'
+    pattern+='(?!.*(?:^|/)(?:Cargo\.lock|composer\.lock|Gemfile\.lock|Pipfile\.lock|'
+    pattern+='npm-shrinkwrap\.json|package-lock\.json|pnpm-lock\.yaml|poetry\.lock|'
+    pattern+='uv\.lock|yarn\.lock|go\.(?:mod|sum|work|work\.sum)|'
+    pattern+='gradle/wrapper/gradle-wrapper\.properties|gradlew(?:\.bat)?|'
+    pattern+='(?:buildscript-)?gradle\.lockfile?|'
+    pattern+='\.mvn/wrapper/maven-wrapper\.properties|'
+    pattern+='\.mvn/wrapper/MavenWrapperDownloader\.java|mvnw(?:\.cmd)?|'
+    pattern+='\.terraform\.lock\.hcl|\.pnp\.c?js|\.pnp\.loader\.mjs)$)'
+    pattern+='(?!.*\.(?:7z|avif|bak|bin|bz2|docx?|eot|exe|gif|gz|ico|jar|jpe?g|log|'
+    pattern+='mp4|otf|p[bgnp]m|patch|pdf|png|snap|svg|tar|tgz|tiff?|ttf|war|webp|'
+    pattern+='wmv|woff2?|xlsx?|zip)$)'
+    pattern+='(?!.*\.(?:css|js)\.map$)(?!.*min\.(?:css|js)$).+'
+    printf '%s\n' "$pattern"
+    ;;
+  install)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+
+    if command -v editorconfig-checker >/dev/null 2>&1 && editorconfig-checker -version >/dev/null 2>&1; then
+      exit 0
+    fi
+
+    release_url="$(curl -fsSL -o /dev/null -w '%{url_effective}' https://github.com/editorconfig-checker/editorconfig-checker/releases/latest)"
+    version="$(basename "$release_url")"
+    asset="ec-linux-amd64.tar.gz"
+    archive_path="$RUNNER_TEMP/$asset"
+    extract_dir="$RUNNER_TEMP/editorconfig-checker-extract"
+    bin_dir="$RUNNER_TEMP/editorconfig-checker/bin"
+
+    rm -rf "$extract_dir" "$bin_dir"
+    mkdir -p "$extract_dir" "$bin_dir"
+
+    curl -fsSL "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/$version/$asset" -o "$archive_path"
+    tar -xzf "$archive_path" -C "$extract_dir"
+    cp "$extract_dir/bin/ec-linux-amd64" "$bin_dir/editorconfig-checker"
+    chmod +x "$bin_dir/editorconfig-checker"
+    linter_lib::add_path "$bin_dir"
+    ;;
+  run)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+    output_file="$RUNNER_TEMP/linter-output.txt"
+    temp_repo="$RUNNER_TEMP/editorconfig-checker-repo"
+    temp_config="$temp_repo/.editorconfig-checker.shared.json"
+    files=("$@")
+    relevant_dirs=()
+    editorconfig_files=()
+    base_config=""
+
+    rm -rf "$temp_repo"
+    mkdir -p "$temp_repo"
+
+    linter_lib::copy_paths_to_root "$temp_repo" "${files[@]}"
+    mapfile -t relevant_dirs < <(editorconfig_collect_relevant_dirs "${files[@]}")
+    mapfile -t editorconfig_files < <(editorconfig_collect_editorconfig_files "${relevant_dirs[@]}")
+
+    if [ "${#editorconfig_files[@]}" -gt 0 ]; then
+      linter_lib::copy_paths_to_root "$temp_repo" "${editorconfig_files[@]}"
+    fi
+
+    if resolved_config="$(editorconfig_resolve_repo_config)"; then
+      base_config="$resolved_config"
+    fi
+
+    run_editorconfig_checker() {
+      editorconfig_write_temp_config "$temp_config" "$base_config" "${files[@]}"
+      cd "$temp_repo" || exit 1
+      editorconfig-checker -config .editorconfig-checker.shared.json
+    }
+
+    linter_lib::run_and_emit_json "$output_file" run_editorconfig_checker
+    ;;
+  *)
+    echo "usage: $0 {patterns|install|run}" >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/linters/editorconfig-checker.test.js
+++ b/.github/scripts/linters/editorconfig-checker.test.js
@@ -1,0 +1,341 @@
+const test = require("node:test");
+const { execFileSync } = require("node:child_process");
+const {
+	assert,
+	cleanupTempRepo,
+	fs,
+	makeTempRepo,
+	path,
+	writeExecutable,
+	writeFile,
+} = require("./cargo-linter-test-lib");
+
+const scriptPath = path.join(__dirname, "editorconfig-checker.sh");
+
+function createEnv(context, extraEnv = {}) {
+	return {
+		...process.env,
+		...extraEnv,
+		PATH: `${context.binDir}:${process.env.PATH}`,
+		RUNNER_TEMP: context.runnerTemp,
+	};
+}
+
+function createCurlStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "curl"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+out_file=""
+write_format=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      out_file="$2"
+      shift 2
+      ;;
+    -w)
+      write_format="$2"
+      shift 2
+      ;;
+    -f|-s|-S|-L|-fsSL)
+      shift
+      ;;
+    http://*|https://*)
+      url="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+printf '%s\\n' "$url" >> "$CURL_URL_LOG"
+if [ "$url" = "https://github.com/editorconfig-checker/editorconfig-checker/releases/latest" ]; then
+  if [ -n "$out_file" ] && [ "$out_file" != "/dev/null" ]; then
+    : > "$out_file"
+  fi
+  if [ "$write_format" = "%{url_effective}" ]; then
+    printf '%s' "\${EDITORCONFIG_RELEASE_URL:-https://github.com/editorconfig-checker/editorconfig-checker/releases/tag/v9.9.9}"
+  fi
+  exit 0
+fi
+printf 'archive' > "$out_file"
+`,
+	);
+}
+
+function createTarStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "tar"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+extract_dir=""
+archive_path=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -C)
+      extract_dir="$2"
+      shift 2
+      ;;
+    -xzf)
+      archive_path="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+printf '%s\\n' "$archive_path" >> "$TAR_ARCHIVE_LOG"
+mkdir -p "$extract_dir/bin"
+cat > "$extract_dir/bin/ec-linux-amd64" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$extract_dir/bin/ec-linux-amd64"
+`,
+	);
+}
+
+function createMissingVersionStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "editorconfig-checker"),
+		`#!/usr/bin/env bash
+exit 1
+`,
+	);
+}
+
+function createEditorconfigCheckerStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "editorconfig-checker"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+if [ -n "\${EDITORCONFIG_CHECKER_LOG:-}" ]; then
+  printf 'cwd=%s\\n' "$PWD" >> "$EDITORCONFIG_CHECKER_LOG"
+  printf 'args=%s\\n' "$*" >> "$EDITORCONFIG_CHECKER_LOG"
+fi
+if [ -n "\${FAIL_RUN:-}" ]; then
+  printf 'editorconfig issue\\n' >&2
+  exit 1
+fi
+printf 'editorconfig checked\\n'
+`,
+	);
+}
+
+test("editorconfig-checker.sh patterns match text-like files and skip common binary or generated files", () => {
+	const output = execFileSync("bash", [scriptPath, "patterns"], {
+		encoding: "utf8",
+	});
+	const patterns = output
+		.trim()
+		.split("\n")
+		.filter(Boolean)
+		.map((pattern) => new RegExp(pattern, "i"));
+
+	const matches = (filePath) =>
+		patterns.some((pattern) => pattern.test(filePath));
+
+	assert.equal(matches("README.md"), true);
+	assert.equal(matches(".editorconfig"), true);
+	assert.equal(matches("src/main.rs"), true);
+	assert.equal(matches("services/api/Dockerfile"), true);
+	assert.equal(matches("docs/image.png"), false);
+	assert.equal(matches("package-lock.json"), false);
+	assert.equal(matches("node_modules/pkg/index.js"), false);
+	assert.equal(matches("target/debug/app"), false);
+	assert.equal(matches(".terraform.lock.hcl"), false);
+	assert.equal(matches("gradle/wrapper/gradle-wrapper.properties"), false);
+	assert.equal(matches(".mvn/wrapper/maven-wrapper.properties"), false);
+	assert.equal(matches(".mvn/wrapper/MavenWrapperDownloader.java"), false);
+	assert.equal(matches("buildscript-gradle.lockfile"), false);
+	assert.equal(matches("dist/app.min.js"), false);
+});
+
+test("editorconfig-checker.sh install downloads the latest Linux amd64 release archive", () => {
+	const context = makeTempRepo("editorconfig-install-");
+	const curlUrlLog = path.join(context.tempDir, "curl-urls.log");
+	const tarArchiveLog = path.join(context.tempDir, "tar-archives.log");
+
+	createCurlStub(context.binDir);
+	createTarStub(context.binDir);
+	createMissingVersionStub(context.binDir);
+
+	try {
+		execFileSync("bash", [scriptPath, "install"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createEnv(context, {
+				CURL_URL_LOG: curlUrlLog,
+				EDITORCONFIG_RELEASE_URL:
+					"https://github.com/editorconfig-checker/editorconfig-checker/releases/tag/v3.6.1",
+				TAR_ARCHIVE_LOG: tarArchiveLog,
+			}),
+		});
+
+		assert.deepEqual(fs.readFileSync(curlUrlLog, "utf8").trim().split("\n"), [
+			"https://github.com/editorconfig-checker/editorconfig-checker/releases/latest",
+			"https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.6.1/ec-linux-amd64.tar.gz",
+		]);
+		assert.equal(
+			fs.readFileSync(tarArchiveLog, "utf8").trim(),
+			path.join(context.runnerTemp, "ec-linux-amd64.tar.gz"),
+		);
+		assert.equal(
+			fs.existsSync(
+				path.join(
+					context.runnerTemp,
+					"editorconfig-checker/bin/editorconfig-checker",
+				),
+			),
+			true,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("editorconfig-checker.sh merges repo config, copies relevant .editorconfig files, and limits checks to changed files", () => {
+	const context = makeTempRepo("editorconfig-run-");
+	const editorconfigLog = path.join(context.tempDir, "editorconfig.log");
+
+	createEditorconfigCheckerStub(context.binDir);
+
+	writeFile(path.join(context.repoDir, ".editorconfig"), "root = true\n");
+	writeFile(
+		path.join(context.repoDir, "services/.editorconfig"),
+		"[*.js]\nindent_style = space\n",
+	);
+	writeFile(
+		path.join(context.repoDir, ".editorconfig-checker.json"),
+		JSON.stringify(
+			{
+				Exclude: ["vendor"],
+				IgnoreDefaults: true,
+				NoColor: false,
+				PassedFiles: ["old-file.txt"],
+				Version: "v0.0.1",
+			},
+			null,
+			2,
+		) + "\n",
+	);
+	writeFile(
+		path.join(context.repoDir, "services/api/app.js"),
+		"const value = 1;\n",
+	);
+
+	try {
+		const output = execFileSync(
+			"bash",
+			[scriptPath, "run", "services/api/app.js"],
+			{
+				cwd: context.repoDir,
+				encoding: "utf8",
+				env: createEnv(context, {
+					EDITORCONFIG_CHECKER_LOG: editorconfigLog,
+				}),
+			},
+		);
+		const result = JSON.parse(output);
+		const tempRepo = path.join(context.runnerTemp, "editorconfig-checker-repo");
+		const mergedConfig = JSON.parse(
+			fs.readFileSync(
+				path.join(tempRepo, ".editorconfig-checker.shared.json"),
+				"utf8",
+			),
+		);
+		const log = fs.readFileSync(editorconfigLog, "utf8");
+
+		assert.equal(result.exit_code, 0);
+		assert.match(log, /cwd=.*editorconfig-checker-repo/);
+		assert.match(log, /args=-config \.editorconfig-checker\.shared\.json/);
+		assert.deepEqual(mergedConfig.PassedFiles, ["services/api/app.js"]);
+		assert.equal(mergedConfig.NoColor, true);
+		assert.equal(mergedConfig.IgnoreDefaults, true);
+		assert.deepEqual(mergedConfig.Exclude, ["vendor"]);
+		assert.equal("Version" in mergedConfig, false);
+		assert.equal(fs.existsSync(path.join(tempRepo, ".editorconfig")), true);
+		assert.equal(
+			fs.existsSync(path.join(tempRepo, "services/.editorconfig")),
+			true,
+		);
+		assert.equal(
+			fs.existsSync(path.join(tempRepo, "services/api/app.js")),
+			true,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("editorconfig-checker.sh falls back to .ecrc when the modern config file is absent", () => {
+	const context = makeTempRepo("editorconfig-ecrc-");
+	const editorconfigLog = path.join(context.tempDir, "editorconfig.log");
+
+	createEditorconfigCheckerStub(context.binDir);
+
+	writeFile(
+		path.join(context.repoDir, ".ecrc"),
+		JSON.stringify(
+			{
+				Debug: true,
+			},
+			null,
+			2,
+		) + "\n",
+	);
+	writeFile(path.join(context.repoDir, "docs/guide.md"), "# Guide\n");
+
+	try {
+		const output = execFileSync("bash", [scriptPath, "run", "docs/guide.md"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createEnv(context, {
+				EDITORCONFIG_CHECKER_LOG: editorconfigLog,
+			}),
+		});
+		const result = JSON.parse(output);
+		const mergedConfig = JSON.parse(
+			fs.readFileSync(
+				path.join(
+					context.runnerTemp,
+					"editorconfig-checker-repo/.editorconfig-checker.shared.json",
+				),
+				"utf8",
+			),
+		);
+
+		assert.equal(result.exit_code, 0);
+		assert.equal(mergedConfig.Debug, true);
+		assert.deepEqual(mergedConfig.PassedFiles, ["docs/guide.md"]);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("editorconfig-checker.sh reports failures from the underlying checker", () => {
+	const context = makeTempRepo("editorconfig-failure-");
+
+	createEditorconfigCheckerStub(context.binDir);
+	writeFile(path.join(context.repoDir, "README.md"), "trailing space \n");
+
+	try {
+		const output = execFileSync("bash", [scriptPath, "run", "README.md"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createEnv(context, {
+				FAIL_RUN: "1",
+			}),
+		});
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 1);
+		assert.match(result.details, /editorconfig issue/);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ GitHub Actions が共通ルールで lint します。
 | `cargo-clippy` | `*.rs` | `clippy.toml` / `.clippy.toml` と `rust-toolchain.toml` / `rust-toolchain` は tool の既定探索を使います。 | 変更された Rust ファイルごとに最も近い `Cargo.toml` を基準に、重複を除いた package 単位で `cargo fetch` の後に `cargo clippy --manifest-path ... --all-targets -- -D warnings` を実行します。Clippy 実行本体は `--network none` 付き Docker container へ隔離し、rustup state は writable mount へ seed してから使います。repository-supplied `.cargo/config` / `.cargo/config.toml` は共有 path では未対応です。private git dependency や認証が必要な registry は現状サポートしません。 |
 | `taplo` | `*.toml` | `.taplo.toml` を優先し、なければ repo root の `taplo.toml` を使います。 | 未配置時は既定値で `fmt --check` を行います。 |
 | `biome` | `*.js`, `*.jsx`, `*.ts`, `*.tsx`, `*.json`, `*.jsonc`, `*.cjs`, `*.cts`, `*.mjs`, `*.mts` | Biome の既定探索で `biome.json` / `biome.jsonc` / `.biome.json` / `.biome.jsonc` を探します。 | 未配置時は既定値を使います。 |
+| `editorconfig-checker` | ほぼ全ファイルのうち、upstream documented default exclude（lock / binary / generated asset など）に当たらない path | 対象ファイルの親 directory ごとの `.editorconfig` と、repo root の `.editorconfig-checker.json` / `.ecrc` を使います。 | 共有 workflow は changed file を `PassedFiles` で限定し、`NoColor` を強制します。repository-supplied `Version` pinning は共有 path では未対応です。 |
 | `shellcheck` | `*.bash`, `*.ksh`, `*.sh` | 対象 script の場所から親へ向けて `.shellcheckrc` / `shellcheckrc` を探します。 | - |
 | `zizmor` | `.github/workflows/*.yml`, `.github/workflows/*.yaml` | `zizmor.yml` / `zizmor.yaml` / `.github/zizmor.yml` / `.github/zizmor.yaml` | 共有 workflow は `--offline` で実行します。 |
 


### PR DESCRIPTION
## Summary
- add an `editorconfig-checker` shared linter wrapper with `patterns`, `install`, and `run` modes
- register the new linter in `.github/scripts/linters/config.json` and document it in `README.md`
- add focused regression coverage for install, config merge, target filtering, and failure propagation

## Validation
- `node --test .github/scripts/linters/editorconfig-checker.test.js`
- `jq empty .github/scripts/linters/config.json`
- `npx --yes markdownlint-cli2 --no-globs :README.md`
- `git diff --check`
- `docker run --rm -v /workspace:/workdir -w /workdir docker.io/koalaman/shellcheck:stable -x -P SCRIPTDIR .github/scripts/linters/editorconfig-checker.sh`

## Review
- blocking code review with GPT-5.4
- blocking code review with Claude Opus 4.6
