### PR TITLE
feat(linters): add dotenv-linter shared linter

### DIFF
--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -28,6 +28,15 @@
       "details_fallback": "hadolint did not produce diagnostic output before the job failed."
     },
     {
+      "name": "dotenv-linter",
+      "heading": "### dotenv-linter",
+      "no_files": "No matching .env files were selected for `dotenv-linter`.",
+      "success": "✅ No issues were reported for the selected .env file target(s).",
+      "failure": "❌ Issues were reported for the selected .env file target(s).",
+      "infra_failure": "❌ The `dotenv-linter` workflow failed before producing a detailed report. See the workflow logs.",
+      "details_fallback": "dotenv-linter did not produce diagnostic output before the job failed."
+    },
+    {
       "name": "spectral",
       "heading": "### spectral",
       "no_files": "No matching YAML or JSON files were selected for `spectral`.",

--- a/.github/scripts/linters/dotenv-linter.sh
+++ b/.github/scripts/linters/dotenv-linter.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../linter-library.sh
+source "$script_dir/../linter-library.sh"
+
+mode=${1-}
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+case "$mode" in
+  patterns)
+    cat <<'EOF'
+(?:^|/)\.env(?:\.[^/]+)?$
+EOF
+    ;;
+  install)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+
+    if command -v dotenv-linter >/dev/null 2>&1 && dotenv-linter --version >/dev/null 2>&1; then
+      exit 0
+    fi
+
+    release_url="$(curl -fsSL -o /dev/null -w '%{url_effective}' https://github.com/dotenv-linter/dotenv-linter/releases/latest)"
+    version="$(basename "$release_url")"
+    asset="dotenv-linter-linux-x86_64.tar.gz"
+    archive_path="$RUNNER_TEMP/$asset"
+    extract_dir="$RUNNER_TEMP/dotenv-linter-extract"
+    bin_dir="$RUNNER_TEMP/dotenv-linter/bin"
+
+    rm -rf "$extract_dir" "$bin_dir"
+    mkdir -p "$extract_dir" "$bin_dir"
+
+    curl -fsSL "https://github.com/dotenv-linter/dotenv-linter/releases/download/$version/$asset" -o "$archive_path"
+    tar -xzf "$archive_path" -C "$extract_dir"
+    cp "$extract_dir/dotenv-linter" "$bin_dir/dotenv-linter"
+    chmod +x "$bin_dir/dotenv-linter"
+    linter_lib::add_path "$bin_dir"
+    ;;
+  run)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+    output_file="$RUNNER_TEMP/linter-output.txt"
+    linter_lib::run_and_emit_json \
+      "$output_file" \
+      dotenv-linter \
+      check \
+      --plain \
+      --skip-updates \
+      "$@"
+    ;;
+  *)
+    echo "usage: $0 {patterns|install|run}" >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/linters/dotenv-linter.test.js
+++ b/.github/scripts/linters/dotenv-linter.test.js
@@ -1,0 +1,190 @@
+const test = require("node:test");
+const { execFileSync } = require("node:child_process");
+const {
+	assert,
+	cleanupTempRepo,
+	fs,
+	makeTempRepo,
+	path,
+	writeExecutable,
+	writeFile,
+} = require("./cargo-linter-test-lib");
+
+const scriptPath = path.join(__dirname, "dotenv-linter.sh");
+
+function createEnv(context, extraEnv = {}) {
+	return {
+		...process.env,
+		...extraEnv,
+		PATH: `${context.binDir}:${process.env.PATH}`,
+		RUNNER_TEMP: context.runnerTemp,
+	};
+}
+
+function createReleaseAsset(assetPath) {
+	const assetDir = path.join(path.dirname(assetPath), "asset");
+
+	fs.mkdirSync(assetDir, { recursive: true });
+	writeExecutable(
+		path.join(assetDir, "dotenv-linter"),
+		"#!/usr/bin/env bash\nexit 0\n",
+	);
+	execFileSync("tar", ["-czf", assetPath, "-C", assetDir, "dotenv-linter"]);
+}
+
+function createCurlStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "curl"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+out_file=""
+write_format=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      out_file="$2"
+      shift 2
+      ;;
+    -w)
+      write_format="$2"
+      shift 2
+      ;;
+    -f|-s|-S|-L|-fsSL)
+      shift
+      ;;
+    http://*|https://*)
+      url="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+printf '%s\\n' "$url" >> "$CURL_URL_LOG"
+if [ "$url" = "https://github.com/dotenv-linter/dotenv-linter/releases/latest" ]; then
+  if [ -n "$out_file" ] && [ "$out_file" != "/dev/null" ]; then
+    : > "$out_file"
+  fi
+  if [ "$write_format" = "%{url_effective}" ]; then
+    printf '%s' "\${DOTENV_LINTER_RELEASE_URL:-https://github.com/dotenv-linter/dotenv-linter/releases/tag/v9.9.9}"
+  fi
+  exit 0
+fi
+cp "$DOTENV_LINTER_ASSET_SOURCE" "$out_file"
+`,
+	);
+}
+
+function createDotenvLinterStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "dotenv-linter"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$DOTENV_LINTER_ARGS_LOG"
+printf 'linted %s\\n' "$*"
+for arg in "$@"; do
+  if [ -n "\${FAIL_TARGET:-}" ] && [ "$arg" = "$FAIL_TARGET" ]; then
+    printf 'issue in %s\\n' "$arg" >&2
+    exit 1
+  fi
+done
+`,
+	);
+}
+
+test("dotenv-linter.sh patterns match .env-prefixed files", () => {
+	const output = execFileSync("bash", [scriptPath, "patterns"], {
+		encoding: "utf8",
+	});
+	const patterns = output
+		.trim()
+		.split("\n")
+		.filter(Boolean)
+		.map((pattern) => new RegExp(pattern, "i"));
+
+	const matches = (filePath) =>
+		patterns.some((pattern) => pattern.test(filePath));
+
+	assert.equal(matches(".env"), true);
+	assert.equal(matches(".env.example"), true);
+	assert.equal(matches("config/.env.production.local"), true);
+	assert.equal(matches(".envrc"), false);
+	assert.equal(matches("docs/env.md"), false);
+	assert.equal(matches("config/app.env"), false);
+});
+
+test("dotenv-linter.sh install downloads the latest Linux x86_64 release archive", () => {
+	const context = makeTempRepo("dotenv-linter-install-");
+	const curlUrlLog = path.join(context.tempDir, "curl-urls.log");
+	const assetPath = path.join(
+		context.tempDir,
+		"dotenv-linter-linux-x86_64.tar.gz",
+	);
+
+	createReleaseAsset(assetPath);
+	createCurlStub(context.binDir);
+
+	try {
+		execFileSync("bash", [scriptPath, "install"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createEnv(context, {
+				CURL_URL_LOG: curlUrlLog,
+				DOTENV_LINTER_ASSET_SOURCE: assetPath,
+				DOTENV_LINTER_RELEASE_URL:
+					"https://github.com/dotenv-linter/dotenv-linter/releases/tag/v4.0.0",
+			}),
+		});
+
+		assert.deepEqual(fs.readFileSync(curlUrlLog, "utf8").trim().split("\n"), [
+			"https://github.com/dotenv-linter/dotenv-linter/releases/latest",
+			"https://github.com/dotenv-linter/dotenv-linter/releases/download/v4.0.0/dotenv-linter-linux-x86_64.tar.gz",
+		]);
+		assert.equal(
+			fs.existsSync(
+				path.join(context.runnerTemp, "dotenv-linter/bin/dotenv-linter"),
+			),
+			true,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("dotenv-linter.sh run passes changed files directly to dotenv-linter check", () => {
+	const context = makeTempRepo("dotenv-linter-run-");
+	const argsLog = path.join(context.tempDir, "dotenv-linter-args.log");
+
+	createDotenvLinterStub(context.binDir);
+	writeFile(path.join(context.repoDir, ".env"), "FOO=BAR\n");
+	writeFile(path.join(context.repoDir, ".env.example"), "BAR=BAZ\n");
+
+	try {
+		const output = execFileSync(
+			"bash",
+			[scriptPath, "run", ".env", ".env.example"],
+			{
+				cwd: context.repoDir,
+				encoding: "utf8",
+				env: createEnv(context, {
+					DOTENV_LINTER_ARGS_LOG: argsLog,
+				}),
+			},
+		);
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 0);
+		assert.equal(
+			fs.readFileSync(argsLog, "utf8").trim(),
+			"check --plain --skip-updates .env .env.example",
+		);
+		assert.match(
+			result.details,
+			/linted check --plain --skip-updates \.env \.env\.example/,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ GitHub Actions が共通ルールで lint します。
 | `actionlint` | `.github/workflows/*.yml`, `.github/workflows/*.yaml` | `.github/actionlint.yaml` / `.github/actionlint.yml` | - |
 | `ghalint` | `.github/workflows/*.yml`, `.github/workflows/*.yaml` | `.ghalint.yaml` → `.ghalint.yml` → `ghalint.yaml` → `ghalint.yml` → `.github/ghalint.yaml` → `.github/ghalint.yml` | - |
 | `hadolint` | `Dockerfile`, `Dockerfile.*`, `Containerfile`, `Containerfile.*`, `*.dockerfile`, `*.containerfile` | 対象ファイルの directory から親へ向けて `.hadolint.yaml` / `.hadolint.yml` を探し、見つかれば `--config` で明示します。 | 未配置時は既定値を使います。 |
+| `dotenv-linter` | `.env`, `.env.*` | なし | shared workflow は upstream default checks を changed `.env` file に直接適用します。`--schema` や ignore-checks の注入は現状未対応です。 |
 | `spectral` | `*.json`, `*.yaml`, `*.yml` | `.spectral.yml` / `.spectral.yaml` / `.spectral.json` | 未配置時は `spectral:oas` を使い、unknown format は無視します。`.spectral.js` は任意コード実行を避けるため対象外です。 |
 | `yamllint` | `*.yaml`, `*.yml` | `.yamllint` → `.yamllint.yaml` → `.yamllint.yml` | - |
 | `markdownlint-cli2` | `*.md`, `*.markdown` | `.markdownlint-cli2.jsonc` / `.markdownlint-cli2.yaml` / `.markdownlint.jsonc` / `.markdownlint.json` / `.markdownlint.yaml` / `.markdownlint.yml` | 静的 config のみを扱います。`.cjs` / `.mjs` は任意コード実行を避けるため対象外です。共有 workflow は `globs` を使わず、変更対象だけを検査します。 |


### PR DESCRIPTION
## Summary
- add a shared `dotenv-linter` wrapper and registration entry for `.env` / `.env.*` files
- add focused tests for pattern matching, install flow, and run-mode argument wiring
- document the new shared linter in the root README, including current limitations

## Validation
- `node --test .github/scripts/linters/dotenv-linter.test.js`
- `node --test .github/scripts/*.test.js .github/scripts/linters/*.test.js`
- `bash -n .github/scripts/linters/dotenv-linter.sh`
- `git --no-pager diff --check`
