### PR TITLE
chore(workflows): prune old workflow runs

### DIFF
--- a/.github/scripts/cleanup-workflow-runs.js
+++ b/.github/scripts/cleanup-workflow-runs.js
@@ -1,0 +1,129 @@
+module.exports = async function cleanupWorkflowRuns({
+	env = process.env,
+	github,
+	logger = console,
+}) {
+	const owner = requireEnv(env, "REPOSITORY_OWNER");
+	const repo = requireEnv(env, "REPOSITORY_NAME");
+	const retentionHours = parsePositiveInteger(
+		env.RETENTION_HOURS ?? "24",
+		"RETENTION_HOURS",
+	);
+	const now = parseTimestamp(env.NOW ?? new Date().toISOString(), "NOW");
+	const cutoffTime = now.getTime() - retentionHours * 60 * 60 * 1000;
+	const runs = await github.paginate(
+		github.rest.actions.listWorkflowRunsForRepo,
+		{
+			owner,
+			per_page: 100,
+			repo,
+		},
+	);
+	const runsToDelete = collectRunsToDelete(runs, cutoffTime);
+
+	for (const run of runsToDelete) {
+		logger.log(
+			`Deleting completed workflow run ${run.id} (${describeRun(run)}) updated at ${run.updated_at}`,
+		);
+		await github.rest.actions.deleteWorkflowRun({
+			owner,
+			repo,
+			run_id: run.id,
+		});
+	}
+
+	if (runsToDelete.length === 0) {
+		logger.log(
+			`No completed workflow runs older than ${retentionHours} hour(s) were found for ${owner}/${repo}.`,
+		);
+	}
+
+	return {
+		cutoffTimestamp: new Date(cutoffTime).toISOString(),
+		deletedCount: runsToDelete.length,
+		deletedRunIds: runsToDelete.map((run) => run.id),
+		repository: `${owner}/${repo}`,
+		retentionHours,
+		scannedRunCount: Array.isArray(runs) ? runs.length : 0,
+	};
+};
+
+function requireEnv(env, key) {
+	const value = env[key];
+
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(`${key} is required`);
+	}
+
+	return value;
+}
+
+function parsePositiveInteger(rawValue, key) {
+	const value = Number(rawValue);
+
+	if (!Number.isInteger(value) || value < 1) {
+		throw new Error(`${key} must be a positive integer`);
+	}
+
+	return value;
+}
+
+function parseTimestamp(rawValue, key) {
+	const timestamp = Date.parse(rawValue);
+
+	if (!Number.isFinite(timestamp)) {
+		throw new Error(`${key} must be a valid timestamp`);
+	}
+
+	return new Date(timestamp);
+}
+
+function collectRunsToDelete(runs, cutoffTime) {
+	if (!Array.isArray(runs)) {
+		return [];
+	}
+
+	return runs
+		.filter((run) => shouldDeleteRun(run, cutoffTime))
+		.sort(compareRunsForDeletion);
+}
+
+function shouldDeleteRun(run, cutoffTime) {
+	if (
+		!run ||
+		typeof run.id !== "number" ||
+		run.id < 1 ||
+		run.status !== "completed" ||
+		typeof run.updated_at !== "string"
+	) {
+		return false;
+	}
+
+	const updatedTime = Date.parse(run.updated_at);
+	return Number.isFinite(updatedTime) && updatedTime <= cutoffTime;
+}
+
+function compareRunsForDeletion(left, right) {
+	const updatedDelta =
+		Date.parse(left.updated_at) - Date.parse(right.updated_at);
+
+	if (updatedDelta !== 0) {
+		return updatedDelta;
+	}
+
+	return left.id - right.id;
+}
+
+function describeRun(run) {
+	if (typeof run.name === "string" && run.name.length > 0) {
+		return run.name;
+	}
+
+	if (typeof run.display_title === "string" && run.display_title.length > 0) {
+		return run.display_title;
+	}
+
+	return "unnamed workflow";
+}
+
+module.exports.collectRunsToDelete = collectRunsToDelete;

--- a/.github/scripts/cleanup-workflow-runs.test.js
+++ b/.github/scripts/cleanup-workflow-runs.test.js
@@ -1,0 +1,156 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const cleanupWorkflowRuns = require("./cleanup-workflow-runs.js");
+
+test("deletes only completed workflow runs older than the retention window", async () => {
+	const deleteCalls = [];
+	const paginateCalls = [];
+	const logs = [];
+	const github = createGitHubClient({
+		deleteCalls,
+		paginateCalls,
+		runs: [
+			{
+				id: 51,
+				name: "Repository Dispatch",
+				status: "completed",
+				updated_at: "2026-03-31T11:59:59Z",
+			},
+			{
+				id: 52,
+				name: "CI",
+				status: "completed",
+				updated_at: "2026-03-31T12:00:00Z",
+			},
+			{
+				id: 53,
+				name: "CI",
+				status: "completed",
+				updated_at: "2026-03-31T12:00:01Z",
+			},
+			{
+				id: 54,
+				name: "Cleanup Workflow Runs",
+				status: "in_progress",
+				updated_at: "2026-03-31T01:00:00Z",
+			},
+			{
+				id: 55,
+				name: "Broken",
+				status: "completed",
+				updated_at: "not-a-timestamp",
+			},
+		],
+	});
+
+	const result = await cleanupWorkflowRuns({
+		env: {
+			NOW: "2026-04-01T12:00:00Z",
+			REPOSITORY_NAME: "linter-service",
+			REPOSITORY_OWNER: "chalharu",
+			RETENTION_HOURS: "24",
+		},
+		github,
+		logger: { log: (message) => logs.push(message) },
+	});
+
+	assert.deepEqual(paginateCalls, [
+		{
+			owner: "chalharu",
+			per_page: 100,
+			repo: "linter-service",
+		},
+	]);
+	assert.deepEqual(deleteCalls, [
+		{ owner: "chalharu", repo: "linter-service", run_id: 51 },
+		{ owner: "chalharu", repo: "linter-service", run_id: 52 },
+	]);
+	assert.deepEqual(result, {
+		cutoffTimestamp: "2026-03-31T12:00:00.000Z",
+		deletedCount: 2,
+		deletedRunIds: [51, 52],
+		repository: "chalharu/linter-service",
+		retentionHours: 24,
+		scannedRunCount: 5,
+	});
+	assert.match(logs[0], /Deleting completed workflow run 51/);
+	assert.match(logs[1], /Deleting completed workflow run 52/);
+});
+
+test("logs a no-op message when no old completed workflow runs exist", async () => {
+	const deleteCalls = [];
+	const logs = [];
+	const github = createGitHubClient({
+		deleteCalls,
+		paginateCalls: [],
+		runs: [
+			{
+				id: 91,
+				display_title: "validate-worker",
+				status: "completed",
+				updated_at: "2026-04-01T11:00:00Z",
+			},
+		],
+	});
+
+	const result = await cleanupWorkflowRuns({
+		env: {
+			NOW: "2026-04-01T12:00:00Z",
+			REPOSITORY_NAME: "linter-service",
+			REPOSITORY_OWNER: "chalharu",
+		},
+		github,
+		logger: { log: (message) => logs.push(message) },
+	});
+
+	assert.deepEqual(deleteCalls, []);
+	assert.equal(result.deletedCount, 0);
+	assert.equal(result.retentionHours, 24);
+	assert.equal(
+		logs[0],
+		"No completed workflow runs older than 24 hour(s) were found for chalharu/linter-service.",
+	);
+});
+
+test("rejects invalid retention values", async () => {
+	const github = createGitHubClient({
+		deleteCalls: [],
+		paginateCalls: [],
+		runs: [],
+	});
+
+	await assert.rejects(
+		cleanupWorkflowRuns({
+			env: {
+				REPOSITORY_NAME: "linter-service",
+				REPOSITORY_OWNER: "chalharu",
+				RETENTION_HOURS: "0",
+			},
+			github,
+		}),
+		/RETENTION_HOURS must be a positive integer/,
+	);
+});
+
+function createGitHubClient({ deleteCalls, paginateCalls, runs }) {
+	return {
+		paginate: async (handler, params) => {
+			assert.equal(handler, actions.listWorkflowRunsForRepo);
+			paginateCalls.push(params);
+			return runs;
+		},
+		rest: {
+			actions: {
+				deleteWorkflowRun: async (params) => {
+					deleteCalls.push(params);
+				},
+				listWorkflowRunsForRepo: actions.listWorkflowRunsForRepo,
+			},
+		},
+	};
+}
+
+const actions = {
+	listWorkflowRunsForRepo() {},
+};

--- a/.github/workflows/cleanup-workflow-runs.yml
+++ b/.github/workflows/cleanup-workflow-runs.yml
@@ -1,0 +1,57 @@
+name: Cleanup Workflow Runs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 */6 * * *'
+
+concurrency:
+  group: ${{ format('cleanup-workflow-runs-{0}', github.repository) }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  cleanup:
+    permissions:
+      actions: write
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Delete workflow runs older than 24 hours
+        id: cleanup_runs
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          RETENTION_HOURS: '24'
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const cleanupWorkflowRuns = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/cleanup-workflow-runs.js`
+            );
+            const result = await cleanupWorkflowRuns({
+              env: {
+                REPOSITORY_NAME: context.repo.repo,
+                REPOSITORY_OWNER: context.repo.owner,
+                RETENTION_HOURS: process.env.RETENTION_HOURS,
+              },
+              github,
+              logger: console,
+            });
+
+            core.setOutput("cutoff-timestamp", result.cutoffTimestamp);
+            core.setOutput("deleted-count", String(result.deletedCount));
+            core.info(JSON.stringify(result, null, 2));
+            await core.summary
+              .addHeading("Workflow run cleanup")
+              .addRaw(
+                `Deleted ${result.deletedCount} completed workflow run(s) updated on or before ${result.cutoffTimestamp}.`,
+                true,
+              )
+              .write();


### PR DESCRIPTION
## Summary
- add a scheduled maintenance workflow that deletes completed workflow runs older than 24 hours across the repository
- implement the cleanup logic in a reusable `.github/scripts/cleanup-workflow-runs.js` module with focused node tests
- support both periodic execution and manual `workflow_dispatch` runs

## Validation
- `node --test .github/scripts/cleanup-workflow-runs.test.js`
- `node --test .github/scripts/*.test.js .github/scripts/linters/*.test.js`
- `git --no-pager diff --check`
- focused GPT-5.4 review
- focused Claude Opus 4.6 review

## Notes
- attempted `cd worker && npm ci && npm run check`, but `npm ci` stalled in the shared environment and a follow-up `npm run check` without a completed install failed because `tsc` was unavailable locally
- hosted `validate-worker` on this PR remains the authoritative check for the unchanged worker package
