### PR TITLE
refactor(linters): batch cargo-clippy docker runs

### DIFF
--- a/.github/scripts/linters/cargo-clippy.sh
+++ b/.github/scripts/linters/cargo-clippy.sh
@@ -183,32 +183,73 @@ EOF
     run_cargo_clippy() {
       local failure=0
       local current_manifest
+      local fetch_failures_path="$cargo_home/fetch-failed-manifests.txt"
+      local clippy_manifests=()
+      local -A failed_fetches=()
 
       if ! seed_writable_rustup_home; then
         return 1
       fi
 
+      rm -f "$fetch_failures_path"
+
+      if ! docker run \
+        "${docker_run_common[@]}" \
+        --env LINTER_SERVICE_BATCH_MODE=fetch \
+        "$image_ref" \
+        sh -ceu '
+          failed_path=/cargo-home/fetch-failed-manifests.txt
+          : > "$failed_path"
+          for manifest_path in "$@"; do
+            printf "==> docker run cargo fetch --manifest-path %s\n" "$manifest_path"
+            if ! cargo fetch --manifest-path "$manifest_path"; then
+              printf "%s\n" "$manifest_path" >> "$failed_path"
+            fi
+            echo
+          done
+        ' sh "${manifests[@]}"; then
+        return 1
+      fi
+
+      if [ -s "$fetch_failures_path" ]; then
+        failure=1
+        while IFS= read -r current_manifest; do
+          if [ -n "$current_manifest" ]; then
+            failed_fetches["$current_manifest"]=1
+          fi
+        done < "$fetch_failures_path"
+      fi
+
       for current_manifest in "${manifests[@]}"; do
-        printf '==> docker run cargo fetch --manifest-path %s\n' "$current_manifest"
-        if ! docker run \
-          "${docker_run_common[@]}" \
-          "$image_ref" \
-          cargo fetch --manifest-path "$current_manifest"; then
-          failure=1
-          echo
+        if [ -n "${failed_fetches[$current_manifest]+x}" ]; then
+          printf '==> skip cargo clippy --manifest-path %s because cargo fetch failed\n\n' "$current_manifest"
           continue
         fi
-
-        printf '==> docker run cargo clippy --manifest-path %s --all-targets -- -D warnings\n' "$current_manifest"
-        if ! docker run \
-          "${docker_run_common[@]}" \
-          --network=none \
-          "$image_ref" \
-          cargo clippy --manifest-path "$current_manifest" --all-targets -- -D warnings; then
-          failure=1
-        fi
-        echo
+        clippy_manifests+=("$current_manifest")
       done
+
+      if [ "${#clippy_manifests[@]}" -eq 0 ]; then
+        return "$failure"
+      fi
+
+      if ! docker run \
+        "${docker_run_common[@]}" \
+        --env LINTER_SERVICE_BATCH_MODE=clippy \
+        --network=none \
+        "$image_ref" \
+        sh -ceu '
+          failure=0
+          for manifest_path in "$@"; do
+            printf "==> docker run cargo clippy --manifest-path %s --all-targets -- -D warnings\n" "$manifest_path"
+            if ! cargo clippy --manifest-path "$manifest_path" --all-targets -- -D warnings; then
+              failure=1
+            fi
+            echo
+          done
+          exit "$failure"
+        ' sh "${clippy_manifests[@]}"; then
+        failure=1
+      fi
 
       return "$failure"
     }

--- a/.github/scripts/linters/cargo-clippy.test.js
+++ b/.github/scripts/linters/cargo-clippy.test.js
@@ -41,29 +41,69 @@ case "$command" in
     cp "$context/Dockerfile" "$DOCKERFILE_COPY"
     ;;
   run)
+    cargo_home_mount_src=""
+    command_args=()
+    image_ref=""
     manifest=""
     prev=""
     is_clippy=0
     is_rustup_seed=0
     has_rustup_runtime_mount=0
+    option_with_value=""
     work_mount_src=""
+    batch_mode=""
     for arg in "$@"; do
+      if [ -n "$option_with_value" ]; then
+        case "$option_with_value" in
+          --mount)
+            case "$arg" in
+              *"dst=/work"*|*"target=/work"*)
+                work_mount_src="\${arg#*src=}"
+                work_mount_src="\${work_mount_src%%,*}"
+                ;;
+              *"dst=/cargo-home"*|*"target=/cargo-home"*)
+                cargo_home_mount_src="\${arg#*src=}"
+                cargo_home_mount_src="\${cargo_home_mount_src%%,*}"
+                ;;
+              *"dst=/usr/local/rustup"*|*"target=/usr/local/rustup"*)
+                has_rustup_runtime_mount=1
+                ;;
+            esac
+            ;;
+          --env|-e)
+            case "$arg" in
+              LINTER_SERVICE_BATCH_MODE=*)
+                batch_mode="\${arg#LINTER_SERVICE_BATCH_MODE=}"
+                ;;
+            esac
+            ;;
+        esac
+        option_with_value=""
+        prev="$arg"
+        continue
+      fi
+      case "$arg" in
+        --mount|--user|--workdir|--tmpfs|--security-opt|--cap-drop|--env|-e)
+          option_with_value="$arg"
+          prev="$arg"
+          continue
+          ;;
+        --rm|--read-only|--network=*)
+          prev="$arg"
+          continue
+          ;;
+      esac
+      if [ -z "$image_ref" ]; then
+        image_ref="$arg"
+        prev="$arg"
+        continue
+      fi
+      command_args+=("$arg")
       if [ "$prev" = "--manifest-path" ]; then
         manifest="$arg"
       fi
       if [ "$prev" = "cargo" ] && [ "$arg" = "clippy" ]; then
         is_clippy=1
-      fi
-      if [ "$prev" = "--mount" ]; then
-        case "$arg" in
-          *"dst=/work"*|*"target=/work"*)
-            work_mount_src="\${arg#*src=}"
-            work_mount_src="\${work_mount_src%%,*}"
-            ;;
-          *"dst=/usr/local/rustup"*|*"target=/usr/local/rustup"*)
-            has_rustup_runtime_mount=1
-            ;;
-        esac
       fi
       prev="$arg"
     done
@@ -89,10 +129,49 @@ case "$command" in
       printf 'error: could not create temp file /usr/local/rustup/tmp/test_file: Read-only file system (os error 30)\\n' >&2
       exit 1
     fi
+    if [ -n "$batch_mode" ]; then
+      batch_manifests=()
+      if [ "\${#command_args[@]}" -ge 4 ] && [ "\${command_args[0]}" = "sh" ] && [ "\${command_args[1]}" = "-ceu" ] && [ "\${command_args[3]}" = "sh" ]; then
+        batch_manifests=("\${command_args[@]:4}")
+      fi
+      if [ "$batch_mode" = "fetch" ]; then
+        failed_file=""
+        if [ -n "$cargo_home_mount_src" ]; then
+          failed_file="$cargo_home_mount_src/fetch-failed-manifests.txt"
+          : > "$failed_file"
+        fi
+        for manifest in "\${batch_manifests[@]}"; do
+          printf '%s\\n' "$manifest" >> "$DOCKER_FETCH_MANIFEST_LOG"
+          printf '==> docker run cargo fetch --manifest-path %s\\n' "$manifest"
+          printf 'prefetched %s\\n' "$manifest"
+          if [ -n "\${FAIL_FETCH_MANIFEST:-}" ] && [ "$manifest" = "$FAIL_FETCH_MANIFEST" ]; then
+            if [ -n "$failed_file" ]; then
+              printf '%s\\n' "$manifest" >> "$failed_file"
+            fi
+            printf 'fetch failure %s\\n' "$manifest" >&2
+          fi
+          echo
+        done
+        exit 0
+      fi
+      failure=0
+      for manifest in "\${batch_manifests[@]}"; do
+        printf '%s\\n' "$manifest" >> "$DOCKER_MANIFEST_LOG"
+        printf '==> docker run cargo clippy --manifest-path %s --all-targets -- -D warnings\\n' "$manifest"
+        printf 'checked %s\\n' "$manifest"
+        if [ -n "\${FAIL_MANIFEST:-}" ] && [ "$manifest" = "$FAIL_MANIFEST" ]; then
+          printf 'clippy failure %s\\n' "$manifest" >&2
+          failure=1
+        fi
+        echo
+      done
+      exit "$failure"
+    fi
     if [ "$is_clippy" -eq 1 ]; then
       printf '%s\\n' "$manifest" >> "$DOCKER_MANIFEST_LOG"
       printf 'checked %s\\n' "$manifest"
     else
+      printf '%s\\n' "$manifest" >> "$DOCKER_FETCH_MANIFEST_LOG"
       printf 'prefetched %s\\n' "$manifest"
       if [ -n "\${FAIL_FETCH_MANIFEST:-}" ] && [ "$manifest" = "$FAIL_FETCH_MANIFEST" ]; then
         printf 'fetch failure %s\\n' "$manifest" >&2
@@ -118,6 +197,10 @@ function setupDockerTooling(context) {
 
 	const tooling = {
 		dockerBuildArgsLog: path.join(context.tempDir, "docker-build-args.log"),
+		dockerFetchManifestLog: path.join(
+			context.tempDir,
+			"docker-fetch-manifests.log",
+		),
 		dockerImageInspectLog: path.join(
 			context.tempDir,
 			"docker-image-inspect.log",
@@ -135,6 +218,7 @@ function setupDockerTooling(context) {
 		...tooling,
 		env: {
 			DOCKER_BUILD_ARGS_LOG: tooling.dockerBuildArgsLog,
+			DOCKER_FETCH_MANIFEST_LOG: tooling.dockerFetchManifestLog,
 			DOCKER_IMAGE_INSPECT_LOG: tooling.dockerImageInspectLog,
 			DOCKER_MANIFEST_LOG: tooling.dockerManifestLog,
 			DOCKER_RUN_ARGS_LOG: tooling.dockerRunArgsLog,
@@ -191,39 +275,43 @@ defineCommonCargoManifestTests({
 	toolName: "cargo-clippy.sh",
 	setupTooling: setupDockerTooling,
 	assertGroupedResult({ context, result, tooling }) {
+		const runArgs = fs.readFileSync(tooling.dockerRunArgsLog, "utf8");
+
 		assert.equal(result.exit_code, 0);
 		assert.equal(fs.existsSync(path.join(context.repoDir, ".git/HEAD")), true);
+		assert.deepEqual(
+			fs
+				.readFileSync(tooling.dockerFetchManifestLog, "utf8")
+				.trim()
+				.split("\n"),
+			["Cargo.toml", "crates/member/Cargo.toml"],
+		);
 		assert.deepEqual(
 			fs.readFileSync(tooling.dockerManifestLog, "utf8").trim().split("\n"),
 			["Cargo.toml", "crates/member/Cargo.toml"],
 		);
 		assert.match(
-			fs.readFileSync(tooling.dockerRunArgsLog, "utf8"),
-			/cargo fetch --manifest-path Cargo\.toml/,
+			runArgs,
+			/--env LINTER_SERVICE_BATCH_MODE=fetch localhost\/linter-service-cargo-clippy:rust-1-bookworm sh -ceu/,
 		);
 		assert.match(
-			fs.readFileSync(tooling.dockerRunArgsLog, "utf8"),
+			runArgs,
+			/--env LINTER_SERVICE_BATCH_MODE=clippy --network=none localhost\/linter-service-cargo-clippy:rust-1-bookworm sh -ceu/,
+		);
+		assert.match(
+			runArgs,
 			/--cap-drop ALL --security-opt no-new-privileges --read-only --tmpfs \/tmp/,
 		);
-		assert.match(
-			fs.readFileSync(tooling.dockerRunArgsLog, "utf8"),
-			/--user \d+:\d+/,
-		);
-		assert.match(
-			fs.readFileSync(tooling.dockerRunArgsLog, "utf8"),
-			/--network=none localhost\/linter-service-cargo-clippy:rust-1-bookworm cargo clippy --manifest-path Cargo\.toml --all-targets -- -D warnings/,
-		);
-		assert.match(
-			fs.readFileSync(tooling.dockerRunArgsLog, "utf8"),
-			/CARGO_HOME=\/cargo-home/,
-		);
-		assert.match(
-			fs.readFileSync(tooling.dockerRunArgsLog, "utf8"),
-			/dst=\/usr\/local\/rustup/,
-		);
+		assert.match(runArgs, /--user \d+:\d+/);
+		assert.match(runArgs, /CARGO_HOME=\/cargo-home/);
+		assert.match(runArgs, /dst=\/usr\/local\/rustup/);
 		assert.deepEqual(
 			fs.readFileSync(tooling.worktreeGitLog, "utf8").trim().split("\n"),
-			["absent", "absent", "absent", "absent"],
+			["absent", "absent"],
+		);
+		assert.match(
+			result.details,
+			/docker run cargo fetch --manifest-path Cargo\.toml/,
 		);
 		assert.match(
 			result.details,
@@ -252,8 +340,8 @@ defineCommonCargoManifestTests({
 		);
 		assert.match(result.details, /clippy failure Cargo\.toml/);
 		assert.match(
-			fs.readFileSync(tooling.dockerRunArgsLog, "utf8"),
-			/--network=none localhost\/linter-service-cargo-clippy:rust-1-bookworm cargo clippy --manifest-path crates\/member\/Cargo\.toml --all-targets -- -D warnings/,
+			result.details,
+			/docker run cargo clippy --manifest-path crates\/member\/Cargo\.toml --all-targets -- -D warnings/,
 		);
 	},
 });
@@ -394,22 +482,27 @@ edition = "2021"
 			},
 		);
 		const result = JSON.parse(output);
-		const runArgs = fs.readFileSync(tooling.dockerRunArgsLog, "utf8");
 
 		assert.equal(result.exit_code, 1);
 		assert.match(result.details, /fetch failure Cargo\.toml/);
-		assert.match(runArgs, /cargo fetch --manifest-path Cargo\.toml/);
+		assert.deepEqual(
+			fs
+				.readFileSync(tooling.dockerFetchManifestLog, "utf8")
+				.trim()
+				.split("\n"),
+			["Cargo.toml", "crates/member/Cargo.toml"],
+		);
 		assert.doesNotMatch(
-			runArgs,
-			/--network=none localhost\/linter-service-cargo-clippy:rust-1-bookworm cargo clippy --manifest-path Cargo\.toml --all-targets -- -D warnings/,
+			result.details,
+			/docker run cargo clippy --manifest-path Cargo\.toml --all-targets -- -D warnings/,
 		);
 		assert.match(
-			runArgs,
-			/cargo fetch --manifest-path crates\/member\/Cargo\.toml/,
+			result.details,
+			/docker run cargo fetch --manifest-path crates\/member\/Cargo\.toml/,
 		);
 		assert.match(
-			runArgs,
-			/--network=none localhost\/linter-service-cargo-clippy:rust-1-bookworm cargo clippy --manifest-path crates\/member\/Cargo\.toml --all-targets -- -D warnings/,
+			result.details,
+			/docker run cargo clippy --manifest-path crates\/member\/Cargo\.toml --all-targets -- -D warnings/,
 		);
 		assert.deepEqual(
 			fs.readFileSync(tooling.dockerManifestLog, "utf8").trim().split("\n"),


### PR DESCRIPTION
## Summary
- batch `cargo fetch --manifest-path ...` calls into a single container run while preserving per-manifest handling
- batch networkless `cargo clippy --manifest-path ... --all-targets -- -D warnings` calls into a single container run
- extend the cargo-clippy regression suite to cover batched execution, fetch-failure skipping, and the clippy `--network=none` isolation guarantee

## Testing
- `bash -n .github/scripts/linters/cargo-clippy.sh`
- `node --test .github/scripts/linters/cargo-clippy.test.js`
- `node --test .github/scripts/*.test.js .github/scripts/linters/*.test.js`
- `git --no-pager diff --check`