### PR TITLE
feat(linters): add yamlfmt shared linter

### DIFF
--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -55,6 +55,15 @@
       "details_fallback": "yamllint did not produce diagnostic output before the job failed."
     },
     {
+      "name": "yamlfmt",
+      "heading": "### yamlfmt",
+      "no_files": "No matching YAML files were selected for `yamlfmt`.",
+      "success": "✅ No issues were reported for the selected YAML target(s).",
+      "failure": "❌ Issues were reported for the selected YAML target(s).",
+      "infra_failure": "❌ The `yamlfmt` workflow failed before producing a detailed report. See the workflow logs.",
+      "details_fallback": "yamlfmt did not produce diagnostic output before the job failed."
+    },
+    {
       "name": "markdownlint-cli2",
       "heading": "### markdownlint-cli2",
       "no_files": "No matching Markdown files were selected for `markdownlint-cli2`.",

--- a/.github/scripts/linters/yamlfmt.sh
+++ b/.github/scripts/linters/yamlfmt.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../linter-library.sh
+source "$script_dir/../linter-library.sh"
+
+yamlfmt_find_config() {
+  local candidate
+
+  for candidate in .yamlfmt yamlfmt.yml yamlfmt.yaml .yamlfmt.yaml .yamlfmt.yml; do
+    if [ -f "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+mode=${1-}
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+case "$mode" in
+  patterns)
+    cat <<'EOF'
+\.(?:yaml|yml)$
+EOF
+    ;;
+  install)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+
+    if command -v yamlfmt >/dev/null 2>&1 && yamlfmt -version >/dev/null 2>&1; then
+      exit 0
+    fi
+
+    release_url="$(curl -fsSL -o /dev/null -w '%{url_effective}' https://github.com/google/yamlfmt/releases/latest)"
+    version="$(basename "$release_url")"
+    asset_version="${version#v}"
+    asset="yamlfmt_${asset_version}_Linux_x86_64.tar.gz"
+    archive_path="$RUNNER_TEMP/$asset"
+    extract_dir="$RUNNER_TEMP/yamlfmt-extract"
+    bin_dir="$RUNNER_TEMP/yamlfmt/bin"
+
+    rm -rf "$extract_dir" "$bin_dir"
+    mkdir -p "$extract_dir" "$bin_dir"
+
+    curl -fsSL "https://github.com/google/yamlfmt/releases/download/$version/$asset" -o "$archive_path"
+    tar -xzf "$archive_path" -C "$extract_dir"
+    cp "$extract_dir/yamlfmt" "$bin_dir/yamlfmt"
+    chmod +x "$bin_dir/yamlfmt"
+    linter_lib::add_path "$bin_dir"
+    ;;
+  run)
+    : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+    output_file="$RUNNER_TEMP/linter-output.txt"
+    yamlfmt_config=""
+
+    if ! yamlfmt_config="$(yamlfmt_find_config)"; then
+      yamlfmt_config="$RUNNER_TEMP/yamlfmt.yaml"
+      cat > "$yamlfmt_config" <<'EOF'
+formatter:
+  type: basic
+EOF
+    fi
+
+    linter_lib::run_and_emit_json \
+      "$output_file" \
+      yamlfmt \
+      -lint \
+      -conf "$yamlfmt_config" \
+      "$@"
+    ;;
+  *)
+    echo "usage: $0 {patterns|install|run}" >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/linters/yamlfmt.test.js
+++ b/.github/scripts/linters/yamlfmt.test.js
@@ -1,0 +1,276 @@
+const test = require("node:test");
+const { execFileSync } = require("node:child_process");
+const {
+	assert,
+	cleanupTempRepo,
+	fs,
+	makeTempRepo,
+	path,
+	writeExecutable,
+	writeFile,
+} = require("./cargo-linter-test-lib");
+
+const scriptPath = path.join(__dirname, "yamlfmt.sh");
+
+function createEnv(context, extraEnv = {}) {
+	return {
+		...process.env,
+		...extraEnv,
+		PATH: `${context.binDir}:${process.env.PATH}`,
+		RUNNER_TEMP: context.runnerTemp,
+	};
+}
+
+function createReleaseAsset(assetPath) {
+	const assetDir = path.join(path.dirname(assetPath), "asset");
+
+	fs.mkdirSync(assetDir, { recursive: true });
+	writeExecutable(
+		path.join(assetDir, "yamlfmt"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1-}" = "-version" ]; then
+  echo "yamlfmt version 0.0.0"
+  exit 0
+fi
+exit 0
+`,
+	);
+	execFileSync("tar", ["-czf", assetPath, "-C", assetDir, "yamlfmt"]);
+}
+
+function createCurlStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "curl"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+out_file=""
+write_format=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      out_file="$2"
+      shift 2
+      ;;
+    -w)
+      write_format="$2"
+      shift 2
+      ;;
+    -f|-s|-S|-L|-fsSL)
+      shift
+      ;;
+    http://*|https://*)
+      url="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+printf '%s\\n' "$url" >> "$CURL_URL_LOG"
+if [ "$url" = "https://github.com/google/yamlfmt/releases/latest" ]; then
+  if [ -n "$out_file" ] && [ "$out_file" != "/dev/null" ]; then
+    : > "$out_file"
+  fi
+  if [ "$write_format" = "%{url_effective}" ]; then
+    printf '%s' "\${YAMLFMT_RELEASE_URL:-https://github.com/google/yamlfmt/releases/tag/v9.9.9}"
+  fi
+  exit 0
+fi
+cp "$YAMLFMT_ASSET_SOURCE" "$out_file"
+`,
+	);
+}
+
+function createYamlfmtStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "yamlfmt"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1-}" = "-version" ]; then
+  echo "yamlfmt version 0.0.0"
+  exit 0
+fi
+printf '%s\\n' "$*" >> "$YAMLFMT_ARGS_LOG"
+printf 'linted %s\\n' "$*"
+for arg in "$@"; do
+  if [ -n "\${FAIL_TARGET:-}" ] && [ "$arg" = "$FAIL_TARGET" ]; then
+    printf 'issue in %s\\n' "$arg" >&2
+    exit 1
+  fi
+done
+`,
+	);
+}
+
+test("yamlfmt.sh patterns match YAML files", () => {
+	const output = execFileSync("bash", [scriptPath, "patterns"], {
+		encoding: "utf8",
+	});
+	const patterns = output
+		.trim()
+		.split("\n")
+		.filter(Boolean)
+		.map((pattern) => new RegExp(pattern, "i"));
+
+	const matches = (filePath) =>
+		patterns.some((pattern) => pattern.test(filePath));
+
+	assert.equal(matches("config.yaml"), true);
+	assert.equal(matches("config.yml"), true);
+	assert.equal(matches("nested/app/settings.yaml"), true);
+	assert.equal(matches("docs/yaml-guide.md"), false);
+	assert.equal(matches("config.json"), false);
+});
+
+test("yamlfmt.sh install downloads the latest Linux x86_64 release archive", () => {
+	const context = makeTempRepo("yamlfmt-install-");
+	const curlUrlLog = path.join(context.tempDir, "curl-urls.log");
+	const assetPath = path.join(
+		context.tempDir,
+		"yamlfmt_0.21.0_Linux_x86_64.tar.gz",
+	);
+
+	createReleaseAsset(assetPath);
+	createCurlStub(context.binDir);
+
+	try {
+		execFileSync("bash", [scriptPath, "install"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createEnv(context, {
+				CURL_URL_LOG: curlUrlLog,
+				YAMLFMT_ASSET_SOURCE: assetPath,
+				YAMLFMT_RELEASE_URL:
+					"https://github.com/google/yamlfmt/releases/tag/v0.21.0",
+			}),
+		});
+
+		assert.deepEqual(fs.readFileSync(curlUrlLog, "utf8").trim().split("\n"), [
+			"https://github.com/google/yamlfmt/releases/latest",
+			"https://github.com/google/yamlfmt/releases/download/v0.21.0/yamlfmt_0.21.0_Linux_x86_64.tar.gz",
+		]);
+		assert.equal(
+			fs.existsSync(path.join(context.runnerTemp, "yamlfmt/bin/yamlfmt")),
+			true,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("yamlfmt.sh prefers the highest-priority repo config file", () => {
+	const context = makeTempRepo("yamlfmt-config-priority-");
+	const argsLog = path.join(context.tempDir, "yamlfmt-args.log");
+
+	createYamlfmtStub(context.binDir);
+	writeFile(
+		path.join(context.repoDir, ".yamlfmt"),
+		"formatter:\n  type: basic\n",
+	);
+	writeFile(
+		path.join(context.repoDir, "yamlfmt.yaml"),
+		"formatter:\n  type: kyaml\n",
+	);
+	writeFile(path.join(context.repoDir, "config/app.yaml"), "foo: bar\n");
+	writeFile(path.join(context.repoDir, "deploy/service.yml"), "bar: baz\n");
+
+	try {
+		const output = execFileSync(
+			"bash",
+			[scriptPath, "run", "config/app.yaml", "deploy/service.yml"],
+			{
+				cwd: context.repoDir,
+				encoding: "utf8",
+				env: createEnv(context, {
+					YAMLFMT_ARGS_LOG: argsLog,
+				}),
+			},
+		);
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 0);
+		assert.equal(
+			fs.readFileSync(argsLog, "utf8").trim(),
+			"-lint -conf .yamlfmt config/app.yaml deploy/service.yml",
+		);
+		assert.match(
+			result.details,
+			/linted -lint -conf \.yamlfmt config\/app\.yaml deploy\/service\.yml/,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("yamlfmt.sh falls back to a temp default config when the repo has none", () => {
+	const context = makeTempRepo("yamlfmt-default-config-");
+	const argsLog = path.join(context.tempDir, "yamlfmt-args.log");
+	const defaultConfigPath = path.join(context.runnerTemp, "yamlfmt.yaml");
+
+	createYamlfmtStub(context.binDir);
+	writeFile(path.join(context.repoDir, "service.yaml"), "foo: bar\n");
+
+	try {
+		const output = execFileSync("bash", [scriptPath, "run", "service.yaml"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createEnv(context, {
+				YAMLFMT_ARGS_LOG: argsLog,
+			}),
+		});
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 0);
+		assert.equal(
+			fs.readFileSync(argsLog, "utf8").trim(),
+			`-lint -conf ${defaultConfigPath} service.yaml`,
+		);
+		assert.equal(
+			fs.readFileSync(defaultConfigPath, "utf8"),
+			"formatter:\n  type: basic\n",
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("yamlfmt.sh reports yamlfmt failures for selected files", () => {
+	const context = makeTempRepo("yamlfmt-failure-");
+	const argsLog = path.join(context.tempDir, "yamlfmt-args.log");
+
+	createYamlfmtStub(context.binDir);
+	writeFile(
+		path.join(context.repoDir, ".yamlfmt.yml"),
+		"formatter:\n  type: basic\n",
+	);
+	writeFile(path.join(context.repoDir, "valid.yaml"), "foo: bar\n");
+	writeFile(path.join(context.repoDir, "needs-format.yml"), "bar: baz\n");
+
+	try {
+		const output = execFileSync(
+			"bash",
+			[scriptPath, "run", "valid.yaml", "needs-format.yml"],
+			{
+				cwd: context.repoDir,
+				encoding: "utf8",
+				env: createEnv(context, {
+					FAIL_TARGET: "needs-format.yml",
+					YAMLFMT_ARGS_LOG: argsLog,
+				}),
+			},
+		);
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 1);
+		assert.equal(
+			fs.readFileSync(argsLog, "utf8").trim(),
+			"-lint -conf .yamlfmt.yml valid.yaml needs-format.yml",
+		);
+		assert.match(result.details, /issue in needs-format\.yml/);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ GitHub Actions が共通ルールで lint します。
 | `dotenv-linter` | `.env`, `.env.*` | なし | shared workflow は upstream default checks を changed `.env` file に直接適用します。`--schema` や ignore-checks の注入は現状未対応です。 |
 | `spectral` | `*.json`, `*.yaml`, `*.yml` | `.spectral.yml` / `.spectral.yaml` / `.spectral.json` | 未配置時は `spectral:oas` を使い、unknown format は無視します。`.spectral.js` は任意コード実行を避けるため対象外です。 |
 | `yamllint` | `*.yaml`, `*.yml` | `.yamllint` → `.yamllint.yaml` → `.yamllint.yml` | - |
+| `yamlfmt` | `*.yaml`, `*.yml` | `.yamlfmt` → `yamlfmt.yml` → `yamlfmt.yaml` → `.yamlfmt.yaml` → `.yamlfmt.yml` | shared workflow は repo root の静的 config を `-conf` で明示し、未配置時は temp default config で `-lint` を実行します。global config は使いません。 |
 | `markdownlint-cli2` | `*.md`, `*.markdown` | `.markdownlint-cli2.jsonc` / `.markdownlint-cli2.yaml` / `.markdownlint.jsonc` / `.markdownlint.json` / `.markdownlint.yaml` / `.markdownlint.yml` | 静的 config のみを扱います。`.cjs` / `.mjs` は任意コード実行を避けるため対象外です。共有 workflow は `globs` を使わず、変更対象だけを検査します。 |
 | `ruff` | `*.py`, `*.pyi` | 対象ファイルごとに近い `pyproject.toml` の `[tool.ruff]` / `ruff.toml` / `.ruff.toml` を使い、同一 directory では `.ruff.toml` → `ruff.toml` → `pyproject.toml` の順です。 | 共有 workflow は `--force-exclude` を付け、設定上の除外も尊重します。 |
 | `cargo-fmt` | `*.rs` | `rustfmt.toml` / `.rustfmt.toml` と `rust-toolchain.toml` / `rust-toolchain` は Cargo / rustup の既定探索を使います。 | 変更された Rust ファイルごとに最も近い `Cargo.toml` を基準に、重複を除いた package 単位で `cargo fmt --check --manifest-path ...` を実行します。 |


### PR DESCRIPTION
## Summary
- add a shared `yamlfmt` wrapper that installs the upstream Linux x86_64 release and runs `yamlfmt -lint` on changed YAML files
- make config selection deterministic by preferring repo-root static config files and falling back to a temp default config instead of host/global config
- add focused regression tests and document the new shared linter in `README.md`

## Testing
- `node --test .github/scripts/linters/yamlfmt.test.js`
- `node --test .github/scripts/*.test.js .github/scripts/linters/*.test.js`
- `bash -n .github/scripts/linters/yamlfmt.sh`
- `git --no-pager diff --check`
- smoke test with the real upstream `yamlfmt` binary through the wrapper