### PR TITLE
feat: add SARIF support for shared linters

### DIFF
--- a/.github/linters.json
+++ b/.github/linters.json
@@ -1,0 +1,46 @@
+{
+  "pipelines": [
+    {
+      "id": "scripts",
+      "matcher": [
+        "\\.(?:[cm]?[jt]s|[jt]sx)$"
+      ],
+      "steps": [
+        {
+          "tools": [
+            "biome-check-write",
+            "biome-check-write-npx"
+          ]
+        },
+        {
+          "tools": [
+            "oxlint-fix",
+            "oxlint-fix-npx"
+          ]
+        },
+        {
+          "tools": [
+            "biome-check-write",
+            "biome-check-write-npx"
+          ]
+        },
+        {
+          "tools": [
+            "biome-check",
+            "biome-check-npx"
+          ],
+          "reportFailure": true,
+          "failureLabel": "Biome reported unresolved issues:"
+        },
+        {
+          "tools": [
+            "oxlint-check",
+            "oxlint-check-npx"
+          ],
+          "reportFailure": true,
+          "failureLabel": "JavaScript/TypeScript linter reported unresolved issues:"
+        }
+      ]
+    }
+  ]
+}

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -67,7 +67,10 @@
       "success": "✅ No issues were reported for the selected YAML target(s).",
       "failure": "❌ Issues were reported for the selected YAML target(s).",
       "infra_failure": "❌ The `yamllint` workflow failed before producing a detailed report. See the workflow logs.",
-      "details_fallback": "yamllint did not produce diagnostic output before the job failed."
+      "details_fallback": "yamllint did not produce diagnostic output before the job failed.",
+      "sarif": {
+        "enabled": true
+      }
     },
     {
       "name": "yamlfmt",

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -176,7 +176,10 @@
       "success": "✅ No issues were reported for the selected editorconfig-checker target(s).",
       "failure": "❌ Issues were reported for the selected editorconfig-checker target(s).",
       "infra_failure": "❌ The `editorconfig-checker` workflow failed before producing a detailed report. See the workflow logs.",
-      "details_fallback": "editorconfig-checker did not produce diagnostic output before the job failed."
+      "details_fallback": "editorconfig-checker did not produce diagnostic output before the job failed.",
+      "sarif": {
+        "enabled": true
+      }
     },
     {
       "name": "shellcheck",

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -152,7 +152,10 @@
       "success": "✅ No issues were reported for the selected TOML target(s).",
       "failure": "❌ Issues were reported for the selected TOML target(s).",
       "infra_failure": "❌ The `taplo` workflow failed before producing a detailed report. See the workflow logs.",
-      "details_fallback": "taplo did not produce diagnostic output before the job failed."
+      "details_fallback": "taplo did not produce diagnostic output before the job failed.",
+      "sarif": {
+        "enabled": true
+      }
     },
     {
       "name": "biome",

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -139,7 +139,11 @@
       "success": "✅ No issues were reported for the selected Cargo project target(s).",
       "failure": "❌ Issues were reported for the selected Cargo project target(s).",
       "infra_failure": "❌ The `cargo-deny` workflow failed before producing a detailed report. See the workflow logs.",
-      "details_fallback": "cargo-deny did not produce diagnostic output before the job failed."
+      "details_fallback": "cargo-deny did not produce diagnostic output before the job failed.",
+      "sarif": {
+        "enabled": true,
+        "target_kind": "cargo-projects"
+      }
     },
     {
       "name": "taplo",

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -127,7 +127,10 @@
       "success": "✅ No issues were reported for the selected Cargo project target(s).",
       "failure": "❌ Issues were reported for the selected Cargo project target(s).",
       "infra_failure": "❌ The `cargo-clippy` workflow failed before producing a detailed report. See the workflow logs.",
-      "details_fallback": "cargo-clippy did not produce diagnostic output before the job failed."
+      "details_fallback": "cargo-clippy did not produce diagnostic output before the job failed.",
+      "sarif": {
+        "enabled": true
+      }
     },
     {
       "name": "cargo-deny",

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -19,7 +19,10 @@
       "success": "✅ No issues were reported for the selected GitHub Actions workflow target(s).",
       "failure": "❌ Issues were reported for the selected GitHub Actions workflow target(s).",
       "infra_failure": "❌ The `ghalint` workflow failed before producing a detailed report. See the workflow logs.",
-      "details_fallback": "ghalint did not produce diagnostic output before the job failed."
+      "details_fallback": "ghalint did not produce diagnostic output before the job failed.",
+      "sarif": {
+        "enabled": true
+      }
     },
     {
       "name": "hadolint",

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -55,7 +55,10 @@
       "success": "✅ No issues were reported for the selected YAML or JSON target(s).",
       "failure": "❌ Issues were reported for the selected YAML or JSON target(s).",
       "infra_failure": "❌ The `spectral` workflow failed before producing a detailed report. See the workflow logs.",
-      "details_fallback": "spectral did not produce diagnostic output before the job failed."
+      "details_fallback": "spectral did not produce diagnostic output before the job failed.",
+      "sarif": {
+        "enabled": true
+      }
     },
     {
       "name": "yamllint",

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -103,7 +103,10 @@
       "success": "✅ No issues were reported for the selected Python target(s).",
       "failure": "❌ Issues were reported for the selected Python target(s).",
       "infra_failure": "❌ The `ruff` workflow failed before producing a detailed report. See the workflow logs.",
-      "details_fallback": "ruff did not produce diagnostic output before the job failed."
+      "details_fallback": "ruff did not produce diagnostic output before the job failed.",
+      "sarif": {
+        "enabled": true
+      }
     },
     {
       "name": "cargo-fmt",

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -200,7 +200,10 @@
       "success": "✅ No issues were reported for the selected GitHub Actions workflow target(s).",
       "failure": "❌ Issues were reported for the selected GitHub Actions workflow target(s).",
       "infra_failure": "❌ The `zizmor` workflow failed before producing a detailed report. See the workflow logs.",
-      "details_fallback": "zizmor did not produce diagnostic output before the job failed."
+      "details_fallback": "zizmor did not produce diagnostic output before the job failed.",
+      "sarif": {
+        "enabled": true
+      }
     }
   ]
 }

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -115,7 +115,10 @@
       "success": "✅ No issues were reported for the selected Cargo project target(s).",
       "failure": "❌ Issues were reported for the selected Cargo project target(s).",
       "infra_failure": "❌ The `cargo-fmt` workflow failed before producing a detailed report. See the workflow logs.",
-      "details_fallback": "cargo-fmt did not produce diagnostic output before the job failed."
+      "details_fallback": "cargo-fmt did not produce diagnostic output before the job failed.",
+      "sarif": {
+        "enabled": true
+      }
     },
     {
       "name": "cargo-clippy",

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -91,7 +91,10 @@
       "success": "✅ No issues were reported for the selected Markdown target(s).",
       "failure": "❌ Issues were reported for the selected Markdown target(s).",
       "infra_failure": "❌ The `markdownlint-cli2` workflow failed before producing a detailed report. See the workflow logs.",
-      "details_fallback": "markdownlint-cli2 did not produce diagnostic output before the job failed."
+      "details_fallback": "markdownlint-cli2 did not produce diagnostic output before the job failed.",
+      "sarif": {
+        "enabled": true
+      }
     },
     {
       "name": "ruff",

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -31,7 +31,10 @@
       "success": "✅ No issues were reported for the selected Dockerfile or Containerfile target(s).",
       "failure": "❌ Issues were reported for the selected Dockerfile or Containerfile target(s).",
       "infra_failure": "❌ The `hadolint` workflow failed before producing a detailed report. See the workflow logs.",
-      "details_fallback": "hadolint did not produce diagnostic output before the job failed."
+      "details_fallback": "hadolint did not produce diagnostic output before the job failed.",
+      "sarif": {
+        "enabled": true
+      }
     },
     {
       "name": "dotenv-linter",

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -79,7 +79,10 @@
       "success": "✅ No issues were reported for the selected YAML target(s).",
       "failure": "❌ Issues were reported for the selected YAML target(s).",
       "infra_failure": "❌ The `yamlfmt` workflow failed before producing a detailed report. See the workflow logs.",
-      "details_fallback": "yamlfmt did not produce diagnostic output before the job failed."
+      "details_fallback": "yamlfmt did not produce diagnostic output before the job failed.",
+      "sarif": {
+        "enabled": true
+      }
     },
     {
       "name": "markdownlint-cli2",

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -43,7 +43,10 @@
       "success": "✅ No issues were reported for the selected .env file target(s).",
       "failure": "❌ Issues were reported for the selected .env file target(s).",
       "infra_failure": "❌ The `dotenv-linter` workflow failed before producing a detailed report. See the workflow logs.",
-      "details_fallback": "dotenv-linter did not produce diagnostic output before the job failed."
+      "details_fallback": "dotenv-linter did not produce diagnostic output before the job failed.",
+      "sarif": {
+        "enabled": true
+      }
     },
     {
       "name": "spectral",

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -188,7 +188,10 @@
       "success": "✅ No issues were reported for the selected shell script target(s).",
       "failure": "❌ Issues were reported for the selected shell script target(s).",
       "infra_failure": "❌ The `shellcheck` workflow failed before producing a detailed report. See the workflow logs.",
-      "details_fallback": "shellcheck did not produce diagnostic output before the job failed."
+      "details_fallback": "shellcheck did not produce diagnostic output before the job failed.",
+      "sarif": {
+        "enabled": true
+      }
     },
     {
       "name": "zizmor",

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -7,7 +7,10 @@
       "success": "✅ No issues were reported for the selected GitHub Actions workflow target(s).",
       "failure": "❌ Issues were reported for the selected GitHub Actions workflow target(s).",
       "infra_failure": "❌ The `actionlint` workflow failed before producing a detailed report. See the workflow logs.",
-      "details_fallback": "actionlint did not produce diagnostic output before the job failed."
+      "details_fallback": "actionlint did not produce diagnostic output before the job failed.",
+      "sarif": {
+        "enabled": true
+      }
     },
     {
       "name": "ghalint",

--- a/.github/scripts/linters/config.json
+++ b/.github/scripts/linters/config.json
@@ -164,7 +164,10 @@
       "success": "✅ No issues were reported for the selected JavaScript, TypeScript, or JSON/JSONC target(s).",
       "failure": "❌ Issues were reported for the selected JavaScript, TypeScript, or JSON/JSONC target(s).",
       "infra_failure": "❌ The `biome` workflow failed before producing a detailed report. See the workflow logs.",
-      "details_fallback": "biome did not produce diagnostic output before the job failed."
+      "details_fallback": "biome did not produce diagnostic output before the job failed.",
+      "sarif": {
+        "enabled": true
+      }
     },
     {
       "name": "editorconfig-checker",

--- a/.github/scripts/prepare-deselected-sarif.js
+++ b/.github/scripts/prepare-deselected-sarif.js
@@ -1,0 +1,115 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+function runFromEnv(env = process.env) {
+	const report = prepareDeselectedSarif({
+		configPath: requireEnv(env, "LINTER_CONFIG_PATH"),
+		outputRoot: requireEnv(env, "OUTPUT_ROOT"),
+		selectedLintersJson: env.SELECTED_LINTERS_JSON || "[]",
+	});
+
+	if (typeof env.GITHUB_OUTPUT === "string" && env.GITHUB_OUTPUT.length > 0) {
+		fs.appendFileSync(
+			env.GITHUB_OUTPUT,
+			`prepared=${String(report.prepared)}\n`,
+			"utf8",
+		);
+	}
+
+	return report;
+}
+
+function prepareDeselectedSarif({
+	configPath,
+	outputRoot,
+	selectedLintersJson,
+}) {
+	const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+	const linters = Array.isArray(config.linters) ? config.linters : [];
+	const selectedLinters = new Set(parseSelectedLinters(selectedLintersJson));
+
+	fs.mkdirSync(outputRoot, { recursive: true });
+
+	let prepared = 0;
+
+	for (const linter of linters) {
+		if (
+			!linter ||
+			typeof linter.name !== "string" ||
+			!linter.sarif ||
+			linter.sarif.enabled !== true ||
+			selectedLinters.has(linter.name)
+		) {
+			continue;
+		}
+
+		const outputPath = path.join(outputRoot, `empty-${linter.name}.sarif`);
+		fs.writeFileSync(
+			outputPath,
+			JSON.stringify(buildEmptySarif(linter), null, 2),
+			"utf8",
+		);
+		prepared += 1;
+	}
+
+	return { outputRoot, prepared };
+}
+
+function parseSelectedLinters(selectedLintersJson) {
+	const parsed = JSON.parse(selectedLintersJson);
+
+	if (!Array.isArray(parsed)) {
+		throw new Error("SELECTED_LINTERS_JSON must decode to an array");
+	}
+
+	for (const entry of parsed) {
+		if (typeof entry !== "string") {
+			throw new Error("SELECTED_LINTERS_JSON entries must be strings");
+		}
+	}
+
+	return parsed;
+}
+
+function buildEmptySarif(linter) {
+	const category = linter.sarif.category || `linter-service/${linter.name}`;
+	const toolName = linter.sarif.tool_name || `linter-service/${linter.name}`;
+
+	return {
+		$schema: "https://json.schemastore.org/sarif-2.1.0.json",
+		version: "2.1.0",
+		runs: [
+			{
+				automationDetails: {
+					id: category,
+				},
+				results: [],
+				tool: {
+					driver: {
+						informationUri: "https://github.com/chalharu/linter-service",
+						name: toolName,
+						rules: [],
+					},
+				},
+			},
+		],
+	};
+}
+
+function requireEnv(env, key) {
+	const value = env[key];
+
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(`${key} is required`);
+	}
+
+	return value;
+}
+
+if (require.main === module) {
+	runFromEnv();
+}
+
+module.exports = prepareDeselectedSarif;
+module.exports.buildEmptySarif = buildEmptySarif;
+module.exports.runFromEnv = runFromEnv;

--- a/.github/scripts/prepare-deselected-sarif.test.js
+++ b/.github/scripts/prepare-deselected-sarif.test.js
@@ -1,0 +1,108 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const prepareDeselectedSarif = require("./prepare-deselected-sarif.js");
+
+test("writes empty SARIF files for enabled deselected linters", () => {
+	const context = makeTempRepo("prepare-deselected-sarif-");
+	const configPath = path.join(context.tempDir, "config.json");
+	const outputRoot = path.join(context.tempDir, "sarif");
+
+	writeFile(
+		configPath,
+		JSON.stringify(
+			{
+				linters: [
+					{
+						name: "actionlint",
+						sarif: {
+							enabled: true,
+						},
+					},
+					{
+						name: "hadolint",
+						sarif: {
+							category: "custom/hadolint",
+							enabled: true,
+							tool_name: "custom-hadolint",
+						},
+					},
+					{
+						name: "ruff",
+					},
+				],
+			},
+			null,
+			2,
+		),
+	);
+
+	try {
+		const report = prepareDeselectedSarif({
+			configPath,
+			outputRoot,
+			selectedLintersJson: JSON.stringify(["hadolint"]),
+		});
+
+		assert.deepEqual(report, { outputRoot, prepared: 1 });
+
+		const fileNames = fs.readdirSync(outputRoot).sort();
+		assert.deepEqual(fileNames, ["empty-actionlint.sarif"]);
+
+		const sarif = JSON.parse(
+			fs.readFileSync(path.join(outputRoot, "empty-actionlint.sarif"), "utf8"),
+		);
+		assert.equal(
+			sarif.runs[0].automationDetails.id,
+			"linter-service/actionlint",
+		);
+		assert.equal(sarif.runs[0].tool.driver.name, "linter-service/actionlint");
+		assert.deepEqual(sarif.runs[0].results, []);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("returns without writing files when every enabled linter is selected", () => {
+	const context = makeTempRepo("prepare-deselected-sarif-none-");
+	const configPath = path.join(context.tempDir, "config.json");
+	const outputRoot = path.join(context.tempDir, "sarif");
+
+	writeFile(
+		configPath,
+		JSON.stringify(
+			{
+				linters: [
+					{
+						name: "actionlint",
+						sarif: {
+							enabled: true,
+						},
+					},
+				],
+			},
+			null,
+			2,
+		),
+	);
+
+	try {
+		const report = prepareDeselectedSarif({
+			configPath,
+			outputRoot,
+			selectedLintersJson: JSON.stringify(["actionlint"]),
+		});
+
+		assert.deepEqual(report, { outputRoot, prepared: 0 });
+		assert.deepEqual(fs.readdirSync(outputRoot), []);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.actionlint.test.js
+++ b/.github/scripts/render-linter-sarif.actionlint.test.js
@@ -1,0 +1,72 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const { runFromEnv } = require("./render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "linters/config.json");
+
+test("emits SARIF for actionlint workflow diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-actionlint-");
+
+	writeFile(
+		path.join(context.repoDir, ".github/workflows/ci.yml"),
+		"name: ci\non: push\njobs: {}\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		".github/workflows/ci.yml\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details:
+				'.github/workflows/ci.yml:12:5: unexpected key "permissions" for "workflow"',
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "actionlint",
+			OUTPUT_PATH: path.join(context.runnerTemp, "actionlint.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.equal(report.sarif.runs[0].results.length, 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			".github/workflows/ci.yml",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			12,
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startColumn,
+			5,
+		);
+		assert.match(
+			report.sarif.runs[0].results[0].message.text,
+			/unexpected key "permissions"/,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.biome.test.js
+++ b/.github/scripts/render-linter-sarif.biome.test.js
@@ -1,0 +1,65 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const { runFromEnv } = require("./render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "linters/config.json");
+const details = "src/app.ts:4:3: BIOME001 debug statements are not allowed";
+
+test("emits SARIF for biome diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-biome-");
+
+	writeFile(path.join(context.repoDir, "src/app.ts"), 'console.log("x")\n');
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"src/app.ts\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "biome",
+			OUTPUT_PATH: path.join(context.runnerTemp, "biome.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"src/app.ts",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			4,
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startColumn,
+			3,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.cargo-clippy.test.js
+++ b/.github/scripts/render-linter-sarif.cargo-clippy.test.js
@@ -1,0 +1,69 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const { runFromEnv } = require("./render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "linters/config.json");
+const details = "error: needless borrow\n  --> src/lib.rs:12:3\n";
+
+test("emits SARIF for cargo-clippy diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-cargo-clippy-");
+
+	writeFile(
+		path.join(context.repoDir, "Cargo.toml"),
+		'[package]\nname = "demo"\nversion = "0.1.0"\nedition = "2021"\n',
+	);
+	writeFile(path.join(context.repoDir, "src/lib.rs"), "pub fn demo() {}\n");
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"src/lib.rs\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "cargo-clippy",
+			OUTPUT_PATH: path.join(context.runnerTemp, "cargo-clippy.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"src/lib.rs",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			12,
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startColumn,
+			3,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.cargo-deny.test.js
+++ b/.github/scripts/render-linter-sarif.cargo-deny.test.js
@@ -1,0 +1,59 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const { runFromEnv } = require("./render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "linters/config.json");
+const details = "error[unlicensed]: crate is unlicensed";
+
+test("emits SARIF for cargo-deny diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-cargo-deny-");
+
+	writeFile(
+		path.join(context.repoDir, "Cargo.toml"),
+		'[package]\nname = "demo"\nversion = "0.1.0"\nedition = "2021"\n',
+	);
+	writeFile(path.join(context.repoDir, "Cargo.lock"), "version = 3\n");
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"Cargo.lock\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "cargo-deny",
+			OUTPUT_PATH: path.join(context.runnerTemp, "cargo-deny.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"Cargo.toml",
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.cargo-fmt.test.js
+++ b/.github/scripts/render-linter-sarif.cargo-fmt.test.js
@@ -1,0 +1,59 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const { runFromEnv } = require("./render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "linters/config.json");
+const details = "Diff in src/lib.rs at line 1:";
+
+test("emits SARIF for cargo-fmt diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-cargo-fmt-");
+
+	writeFile(
+		path.join(context.repoDir, "Cargo.toml"),
+		'[package]\nname = "demo"\nversion = "0.1.0"\nedition = "2021"\n',
+	);
+	writeFile(path.join(context.repoDir, "src/lib.rs"), "pub fn demo() {}\n");
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"src/lib.rs\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "cargo-fmt",
+			OUTPUT_PATH: path.join(context.runnerTemp, "cargo-fmt.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"src/lib.rs",
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.dotenv-linter.test.js
+++ b/.github/scripts/render-linter-sarif.dotenv-linter.test.js
@@ -1,0 +1,57 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const { runFromEnv } = require("./render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "linters/config.json");
+const details = ".env:1: duplicated name FOO";
+
+test("emits SARIF for dotenv-linter diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-dotenv-linter-");
+
+	writeFile(path.join(context.repoDir, ".env"), "FOO=bar\n");
+	writeFile(path.join(context.runnerTemp, "selected-files.txt"), ".env\n");
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "dotenv-linter",
+			OUTPUT_PATH: path.join(context.runnerTemp, "dotenv-linter.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			".env",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			1,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.editorconfig-checker.test.js
+++ b/.github/scripts/render-linter-sarif.editorconfig-checker.test.js
@@ -1,0 +1,57 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const { runFromEnv } = require("./render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "linters/config.json");
+const details = "README.md:2: wrong line endings";
+
+test("emits SARIF for editorconfig-checker diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-editorconfig-checker-");
+
+	writeFile(path.join(context.repoDir, "README.md"), "# title\r\n");
+	writeFile(path.join(context.runnerTemp, "selected-files.txt"), "README.md\n");
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "editorconfig-checker",
+			OUTPUT_PATH: path.join(context.runnerTemp, "editorconfig-checker.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"README.md",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			2,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.ghalint.test.js
+++ b/.github/scripts/render-linter-sarif.ghalint.test.js
@@ -1,0 +1,68 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const { runFromEnv } = require("./render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "linters/config.json");
+
+test("emits SARIF for ghalint diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-ghalint-");
+
+	writeFile(
+		path.join(context.repoDir, ".github/workflows/ci.yml"),
+		"name: ci\non: push\njobs: {}\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		".github/workflows/ci.yml\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details:
+				".github/workflows/ci.yml:8:3: job permissions should be explicit",
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "ghalint",
+			OUTPUT_PATH: path.join(context.runnerTemp, "ghalint.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			".github/workflows/ci.yml",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			8,
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startColumn,
+			3,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.hadolint.test.js
+++ b/.github/scripts/render-linter-sarif.hadolint.test.js
@@ -1,0 +1,63 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const { runFromEnv } = require("./render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "linters/config.json");
+const details = "Dockerfile:2 DL3008 Pin versions in apt get install.";
+
+test("emits SARIF for hadolint diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-hadolint-");
+
+	writeFile(
+		path.join(context.repoDir, "Dockerfile"),
+		"FROM ubuntu:latest\nRUN apt-get install curl\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"Dockerfile\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "hadolint",
+			OUTPUT_PATH: path.join(context.runnerTemp, "hadolint.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"Dockerfile",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			2,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.js
+++ b/.github/scripts/render-linter-sarif.js
@@ -1,0 +1,700 @@
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { collectProjectTargets } = require("./render-linter-report.js");
+
+const DETAILS_LIMIT = 8000;
+const MAX_FALLBACK_RESULTS = 25;
+const RULE_ID_PATTERN = /\b[A-Z][A-Z0-9_-]{1,15}\d{1,5}\b/u;
+
+function runFromEnv(env = process.env) {
+	const linterName = requireEnv(env, "LINTER_NAME");
+	const runnerTemp = requireEnv(env, "RUNNER_TEMP");
+	const report = renderSarif({
+		configPath: requireEnv(env, "LINTER_CONFIG_PATH"),
+		installOutcome: env.INSTALL_TOOL_OUTCOME ?? "",
+		linterName,
+		outputPath:
+			env.OUTPUT_PATH ||
+			path.join(runnerTemp, `linter-sarif-${linterName}.sarif`),
+		resultPath: requireEnv(env, "RESULT_PATH"),
+		runOutcome: env.RUN_LINTER_OUTCOME ?? "",
+		selectedFilesPath: requireEnv(env, "SELECTED_FILES_PATH"),
+		selectOutcome: env.SELECT_FILES_OUTCOME ?? "",
+		sourceRepositoryPath: requireEnv(env, "SOURCE_REPOSITORY_PATH"),
+	});
+
+	if (report.produced) {
+		fs.writeFileSync(
+			report.outputPath,
+			JSON.stringify(report.sarif, null, 2),
+			"utf8",
+		);
+	}
+
+	return report;
+}
+
+function renderSarif({
+	configPath,
+	installOutcome,
+	linterName,
+	outputPath,
+	resultPath,
+	runOutcome,
+	selectedFilesPath,
+	selectOutcome,
+	sourceRepositoryPath,
+}) {
+	const linterConfig = readLinterConfig(configPath, linterName);
+	const sarifConfig = readSarifConfig(linterConfig);
+	const selectedFiles = readSelectedFiles(selectedFilesPath);
+	const result = readResult(resultPath);
+
+	if (!sarifConfig || selectedFiles.length === 0) {
+		return { outputPath, produced: false, sarif: null };
+	}
+
+	if (
+		[selectOutcome, installOutcome, runOutcome].includes("failure") ||
+		!result ||
+		!Number.isInteger(result.exit_code)
+	) {
+		return { outputPath, produced: false, sarif: null };
+	}
+
+	const targetPaths = collectSarifTargetPaths({
+		linterName,
+		sarifConfig,
+		selectedFiles,
+		sourceRepositoryPath,
+	});
+	const details = resolveDiagnosticDetails(
+		result,
+		linterConfig.details_fallback,
+	);
+	const results =
+		result.exit_code === 0
+			? []
+			: buildSarifResults({
+					defaultLevel: sarifConfig.default_level || "warning",
+					details,
+					linterName,
+					sourceRepositoryPath,
+					targetPaths,
+				});
+	const rules = buildRuleDescriptors(results);
+	const category = sarifConfig.category || `linter-service/${linterName}`;
+	const toolName = sarifConfig.tool_name || `linter-service/${linterName}`;
+
+	return {
+		outputPath,
+		produced: true,
+		sarif: {
+			$schema: "https://json.schemastore.org/sarif-2.1.0.json",
+			version: "2.1.0",
+			runs: [
+				{
+					automationDetails: {
+						id: category,
+					},
+					results,
+					tool: {
+						driver: {
+							informationUri: "https://github.com/chalharu/linter-service",
+							name: toolName,
+							rules,
+						},
+					},
+				},
+			],
+		},
+	};
+}
+
+function requireEnv(env, key) {
+	const value = env[key];
+
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(`${key} is required`);
+	}
+
+	return value;
+}
+
+function readLinterConfig(configPath, linterName) {
+	const configData = JSON.parse(fs.readFileSync(configPath, "utf8"));
+	const linters = Array.isArray(configData.linters) ? configData.linters : [];
+	const config = linters.find(
+		(item) => item && typeof item.name === "string" && item.name === linterName,
+	);
+
+	if (!config) {
+		throw new Error(`unsupported linter: ${linterName}`);
+	}
+
+	return config;
+}
+
+function readSarifConfig(linterConfig) {
+	if (!linterConfig || typeof linterConfig !== "object") {
+		return null;
+	}
+
+	if (!linterConfig.sarif || typeof linterConfig.sarif !== "object") {
+		return null;
+	}
+
+	return linterConfig.sarif.enabled === true ? linterConfig.sarif : null;
+}
+
+function readSelectedFiles(selectedFilesPath) {
+	if (!fs.existsSync(selectedFilesPath)) {
+		return [];
+	}
+
+	return fs
+		.readFileSync(selectedFilesPath, "utf8")
+		.split(/\r?\n/u)
+		.map((line) => line.trim())
+		.filter(Boolean);
+}
+
+function readResult(resultPath) {
+	if (!fs.existsSync(resultPath)) {
+		return null;
+	}
+
+	try {
+		return JSON.parse(fs.readFileSync(resultPath, "utf8"));
+	} catch {
+		return null;
+	}
+}
+
+function resolveDiagnosticDetails(result, fallback) {
+	const details =
+		result && typeof result.details === "string" ? result.details.trim() : "";
+	const exitCode =
+		result && Number.isInteger(result.exit_code) ? result.exit_code : 0;
+
+	if (details.length > 0) {
+		return details.slice(0, DETAILS_LIMIT);
+	}
+
+	return exitCode === 0 ? "" : fallback;
+}
+
+function collectSarifTargetPaths({
+	linterName,
+	sarifConfig,
+	selectedFiles,
+	sourceRepositoryPath,
+}) {
+	if (sarifConfig.target_kind === "cargo-projects") {
+		const projects = collectProjectTargets(
+			linterName,
+			sourceRepositoryPath,
+			selectedFiles,
+		);
+		return projects.length > 0 ? projects : selectedFiles;
+	}
+
+	return selectedFiles;
+}
+
+function buildSarifResults({
+	defaultLevel,
+	details,
+	linterName,
+	sourceRepositoryPath,
+	targetPaths,
+}) {
+	const preciseResults = dedupeResults([
+		...parsePathDiagnostics({
+			defaultLevel,
+			details,
+			linterName,
+			sourceRepositoryPath,
+			targetPaths,
+		}),
+		...parseRustStyleDiagnostics({
+			defaultLevel,
+			details,
+			linterName,
+			sourceRepositoryPath,
+			targetPaths,
+		}),
+		...parseShellcheckStyleDiagnostics({
+			defaultLevel,
+			details,
+			linterName,
+			sourceRepositoryPath,
+			targetPaths,
+		}),
+	]);
+
+	if (preciseResults.length > 0) {
+		return preciseResults;
+	}
+
+	return buildFallbackResults({
+		defaultLevel,
+		details,
+		linterName,
+		sourceRepositoryPath,
+		targetPaths,
+	});
+}
+
+function parsePathDiagnostics({
+	defaultLevel,
+	details,
+	linterName,
+	sourceRepositoryPath,
+	targetPaths,
+}) {
+	const patterns = [
+		/^(?<path>.+?):(?<line>\d+):(?<column>\d+):\s*(?<message>.+)$/u,
+		/^(?<path>.+?):(?<line>\d+)\s+(?<rule>[A-Z][A-Z0-9_-]{1,15}\d{1,5})\s+(?<message>.+)$/u,
+		/^(?<path>.+?):(?<line>\d+):\s*(?<message>.+)$/u,
+	];
+	const results = [];
+
+	for (const rawLine of details.split(/\r?\n/u)) {
+		const line = rawLine.trim();
+
+		if (line.length === 0 || line.startsWith("==>") || line.startsWith("-->")) {
+			continue;
+		}
+
+		for (const pattern of patterns) {
+			const match = pattern.exec(line);
+
+			if (!match || !match.groups) {
+				continue;
+			}
+
+			const filePath = normalizeReportedPath(
+				sourceRepositoryPath,
+				match.groups.path,
+				targetPaths,
+			);
+
+			if (!filePath) {
+				continue;
+			}
+
+			results.push(
+				createResult({
+					column: parseInteger(match.groups.column),
+					defaultLevel,
+					filePath,
+					line: parseInteger(match.groups.line),
+					linterName,
+					message: match.groups.message.trim(),
+					ruleId:
+						match.groups.rule ||
+						extractRuleId(match.groups.message, linterName) ||
+						`${linterName}/diagnostic`,
+				}),
+			);
+			break;
+		}
+	}
+
+	return results;
+}
+
+function parseRustStyleDiagnostics({
+	defaultLevel,
+	details,
+	linterName,
+	sourceRepositoryPath,
+	targetPaths,
+}) {
+	let currentMessage = "";
+	const results = [];
+
+	for (const rawLine of details.split(/\r?\n/u)) {
+		const line = rawLine.trim();
+
+		if (/^(error|warning|note)(\[[^\]]+\])?:/iu.test(line)) {
+			currentMessage = line.replace(
+				/^(error|warning|note)(\[[^\]]+\])?:\s*/iu,
+				"",
+			);
+			continue;
+		}
+
+		const match = /^\s*-->\s+(?<path>.+?):(?<line>\d+):(?<column>\d+)/u.exec(
+			rawLine,
+		);
+
+		if (!match || !match.groups) {
+			continue;
+		}
+
+		const filePath = normalizeReportedPath(
+			sourceRepositoryPath,
+			match.groups.path,
+			targetPaths,
+		);
+
+		if (!filePath) {
+			continue;
+		}
+
+		results.push(
+			createResult({
+				column: parseInteger(match.groups.column),
+				defaultLevel,
+				filePath,
+				line: parseInteger(match.groups.line),
+				linterName,
+				message: currentMessage || summarizeDetails(details, linterName),
+				ruleId:
+					extractRuleId(currentMessage, linterName) ||
+					`${linterName}/diagnostic`,
+			}),
+		);
+	}
+
+	return results;
+}
+
+function parseShellcheckStyleDiagnostics({
+	defaultLevel,
+	details,
+	linterName,
+	sourceRepositoryPath,
+	targetPaths,
+}) {
+	const lines = details.split(/\r?\n/u);
+	const results = [];
+
+	for (let index = 0; index < lines.length; index += 1) {
+		const match = /^In (?<path>.+?) line (?<line>\d+):$/u.exec(
+			lines[index].trim(),
+		);
+
+		if (!match || !match.groups) {
+			continue;
+		}
+
+		const filePath = normalizeReportedPath(
+			sourceRepositoryPath,
+			match.groups.path,
+			targetPaths,
+		);
+
+		if (!filePath) {
+			continue;
+		}
+
+		const blockLines = lines
+			.slice(index + 1, index + 6)
+			.map((line) => line.trim());
+		const message =
+			blockLines.find(
+				(line) =>
+					line.length > 0 &&
+					!/^[\^~-]+$/u.test(line) &&
+					!/^For more information:/u.test(line),
+			) || summarizeDetails(details, linterName);
+		const ruleId =
+			extractRuleId(blockLines.join(" "), linterName) ||
+			`${linterName}/diagnostic`;
+
+		results.push(
+			createResult({
+				defaultLevel,
+				filePath,
+				line: parseInteger(match.groups.line),
+				linterName,
+				message,
+				ruleId,
+			}),
+		);
+	}
+
+	return results;
+}
+
+function buildFallbackResults({
+	defaultLevel,
+	details,
+	linterName,
+	sourceRepositoryPath,
+	targetPaths,
+}) {
+	const summaryMessage = summarizeDetails(details, linterName);
+	const mentionedPaths = targetPaths.filter((targetPath) =>
+		details.includes(targetPath),
+	);
+	const fallbackPaths =
+		mentionedPaths.length > 0
+			? mentionedPaths
+			: targetPaths.length > 0
+				? targetPaths
+				: [null];
+	const results = [];
+
+	for (const filePath of fallbackPaths.slice(0, MAX_FALLBACK_RESULTS)) {
+		results.push(
+			createResult({
+				defaultLevel,
+				filePath:
+					filePath &&
+					normalizeReportedPath(sourceRepositoryPath, filePath, targetPaths),
+				linterName,
+				message: summaryMessage,
+				ruleId:
+					extractRuleId(details, linterName) || `${linterName}/diagnostic`,
+			}),
+		);
+	}
+
+	return dedupeResults(results);
+}
+
+function createResult({
+	column,
+	defaultLevel,
+	filePath,
+	line,
+	linterName,
+	message,
+	ruleId,
+}) {
+	const sanitizedMessage = truncate(message, 1000);
+	const result = {
+		level: toSarifLevel(sanitizedMessage, defaultLevel),
+		message: {
+			text: sanitizedMessage,
+		},
+		partialFingerprints: buildPartialFingerprints({
+			column,
+			filePath,
+			line,
+			message: sanitizedMessage,
+			ruleId,
+		}),
+		ruleId,
+	};
+
+	if (filePath) {
+		result.locations = [
+			{
+				physicalLocation: {
+					artifactLocation: {
+						uri: filePath,
+					},
+					...(line
+						? {
+								region: {
+									startColumn: column || 1,
+									startLine: line,
+								},
+							}
+						: {}),
+				},
+			},
+		];
+	}
+
+	result.properties = {
+		linter_name: linterName,
+	};
+
+	return result;
+}
+
+function buildPartialFingerprints({ column, filePath, line, message, ruleId }) {
+	const fingerprint = crypto
+		.createHash("sha256")
+		.update(
+			[
+				ruleId,
+				filePath || "<no-location>",
+				String(line || 0),
+				String(column || 0),
+				message,
+			].join("|"),
+		)
+		.digest("hex");
+
+	return {
+		primaryLocationLineHash: fingerprint,
+	};
+}
+
+function dedupeResults(results) {
+	const seen = new Set();
+	const deduped = [];
+
+	for (const result of results) {
+		const location = result.locations?.[0]?.physicalLocation;
+		const region = location?.region;
+		const key = [
+			result.ruleId,
+			location?.artifactLocation?.uri || "",
+			String(region?.startLine || 0),
+			String(region?.startColumn || 0),
+			result.message?.text || "",
+		].join("|");
+
+		if (seen.has(key)) {
+			continue;
+		}
+
+		seen.add(key);
+		deduped.push(result);
+	}
+
+	return deduped;
+}
+
+function buildRuleDescriptors(results) {
+	const ruleIds = [
+		...new Set(results.map((result) => result.ruleId).filter(Boolean)),
+	];
+
+	return ruleIds.map((ruleId) => ({
+		id: ruleId,
+		name: ruleId,
+		shortDescription: {
+			text: ruleId,
+		},
+	}));
+}
+
+function parseInteger(value) {
+	if (typeof value !== "string" || value.length === 0) {
+		return null;
+	}
+
+	const parsed = Number(value);
+	return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function extractRuleId(text, linterName) {
+	if (typeof text !== "string") {
+		return null;
+	}
+
+	const match = text.match(RULE_ID_PATTERN);
+	return match ? match[0] : `${linterName}/diagnostic`;
+}
+
+function summarizeDetails(details, linterName) {
+	for (const rawLine of details.split(/\r?\n/u)) {
+		const line = rawLine.trim();
+
+		if (
+			line.length === 0 ||
+			line.startsWith("==>") ||
+			line.startsWith("-->") ||
+			line.startsWith("|") ||
+			/^[\^~-]+$/u.test(line) ||
+			/^For more information:/u.test(line)
+		) {
+			continue;
+		}
+
+		return truncate(line, 1000);
+	}
+
+	return `${linterName} reported issues.`;
+}
+
+function toSarifLevel(text, defaultLevel) {
+	if (/fatal|error|failed/iu.test(text)) {
+		return "error";
+	}
+
+	if (/warn|warning/iu.test(text)) {
+		return "warning";
+	}
+
+	if (/note|info/iu.test(text)) {
+		return "note";
+	}
+
+	return defaultLevel;
+}
+
+function truncate(text, maxLength) {
+	if (text.length <= maxLength) {
+		return text;
+	}
+
+	return `${text.slice(0, maxLength - 16)}... truncated ...`;
+}
+
+function normalizeReportedPath(
+	sourceRepositoryPath,
+	reportedPath,
+	targetPaths,
+) {
+	const normalized = normalizePath(String(reportedPath || "").trim()).replace(
+		/^\.\//u,
+		"",
+	);
+
+	if (normalized.length === 0) {
+		return null;
+	}
+
+	const candidatePaths = [...targetPaths].sort(
+		(left, right) => right.length - left.length,
+	);
+	for (const candidate of candidatePaths) {
+		if (normalized === candidate || normalized.endsWith(`/${candidate}`)) {
+			return candidate;
+		}
+	}
+
+	if (path.isAbsolute(reportedPath)) {
+		const relative = path.relative(
+			path.resolve(sourceRepositoryPath),
+			reportedPath,
+		);
+
+		if (!relative.startsWith("..") && !path.isAbsolute(relative)) {
+			return normalizePath(relative);
+		}
+	}
+
+	const resolved = path.resolve(sourceRepositoryPath, normalized);
+	const relative = path.relative(path.resolve(sourceRepositoryPath), resolved);
+
+	if (
+		!relative.startsWith("..") &&
+		!path.isAbsolute(relative) &&
+		fs.existsSync(resolved)
+	) {
+		return normalizePath(relative);
+	}
+
+	return null;
+}
+
+function normalizePath(filePath) {
+	return String(filePath || "").replace(/\\/gu, "/");
+}
+
+if (require.main === module) {
+	runFromEnv(process.env);
+}
+
+module.exports = {
+	buildSarifResults,
+	collectSarifTargetPaths,
+	createResult,
+	dedupeResults,
+	normalizeReportedPath,
+	renderSarif,
+	runFromEnv,
+};

--- a/.github/scripts/render-linter-sarif.js
+++ b/.github/scripts/render-linter-sarif.js
@@ -396,13 +396,18 @@ function parseShellcheckStyleDiagnostics({
 		const blockLines = lines
 			.slice(index + 1, index + 6)
 			.map((line) => line.trim());
+		const diagnosticLine = blockLines.find((line) =>
+			RULE_ID_PATTERN.test(line),
+		);
 		const message =
+			diagnosticLine?.replace(/^[\^~-]+\s*/u, "").trim() ||
 			blockLines.find(
 				(line) =>
 					line.length > 0 &&
 					!/^[\^~-]+$/u.test(line) &&
-					!/^For more information:/u.test(line),
-			) || summarizeDetails(details, linterName);
+					!line.startsWith("For more information:"),
+			) ||
+			summarizeDetails(details, linterName);
 		const ruleId =
 			extractRuleId(blockLines.join(" "), linterName) ||
 			`${linterName}/diagnostic`;
@@ -598,7 +603,7 @@ function summarizeDetails(details, linterName) {
 			line.startsWith("-->") ||
 			line.startsWith("|") ||
 			/^[\^~-]+$/u.test(line) ||
-			/^For more information:/u.test(line)
+			line.startsWith("For more information:")
 		) {
 			continue;
 		}

--- a/.github/scripts/render-linter-sarif.js
+++ b/.github/scripts/render-linter-sarif.js
@@ -615,15 +615,15 @@ function summarizeDetails(details, linterName) {
 }
 
 function toSarifLevel(text, defaultLevel) {
-	if (/fatal|error|failed/iu.test(text)) {
+	if (/\b(?:fatal|error|failed)\b/iu.test(text)) {
 		return "error";
 	}
 
-	if (/warn|warning/iu.test(text)) {
+	if (/\b(?:warn|warning)\b/iu.test(text)) {
 		return "warning";
 	}
 
-	if (/note|info/iu.test(text)) {
+	if (/\b(?:note|info)\b/iu.test(text)) {
 		return "note";
 	}
 

--- a/.github/scripts/render-linter-sarif.js
+++ b/.github/scripts/render-linter-sarif.js
@@ -272,7 +272,7 @@ function parsePathDiagnostics({
 		for (const pattern of patterns) {
 			const match = pattern.exec(line);
 
-			if (!match || !match.groups) {
+			if (!match?.groups) {
 				continue;
 			}
 
@@ -332,7 +332,7 @@ function parseRustStyleDiagnostics({
 			rawLine,
 		);
 
-		if (!match || !match.groups) {
+		if (!match?.groups) {
 			continue;
 		}
 
@@ -379,7 +379,7 @@ function parseShellcheckStyleDiagnostics({
 			lines[index].trim(),
 		);
 
-		if (!match || !match.groups) {
+		if (!match?.groups) {
 			continue;
 		}
 

--- a/.github/scripts/render-linter-sarif.markdownlint-cli2.test.js
+++ b/.github/scripts/render-linter-sarif.markdownlint-cli2.test.js
@@ -1,0 +1,58 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const { runFromEnv } = require("./render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "linters/config.json");
+const details =
+	"README.md:7: MD013/line-length Line length [Expected: 80; Actual: 120]";
+
+test("emits SARIF for markdownlint-cli2 diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-markdownlint-cli2-");
+
+	writeFile(path.join(context.repoDir, "README.md"), "# title\n");
+	writeFile(path.join(context.runnerTemp, "selected-files.txt"), "README.md\n");
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "markdownlint-cli2",
+			OUTPUT_PATH: path.join(context.runnerTemp, "markdownlint-cli2.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"README.md",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			7,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.ruff.test.js
+++ b/.github/scripts/render-linter-sarif.ruff.test.js
@@ -1,0 +1,65 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const { runFromEnv } = require("./render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "linters/config.json");
+const details = "src/app.py:12:3: RUF100 unused noqa directive";
+
+test("emits SARIF for ruff diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-ruff-");
+
+	writeFile(path.join(context.repoDir, "src/app.py"), 'print("x")\n');
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"src/app.py\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "ruff",
+			OUTPUT_PATH: path.join(context.runnerTemp, "ruff.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"src/app.py",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			12,
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startColumn,
+			3,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.shellcheck.test.js
+++ b/.github/scripts/render-linter-sarif.shellcheck.test.js
@@ -1,0 +1,58 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const { runFromEnv } = require("./render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "linters/config.json");
+const details =
+	"In script.sh line 3:\necho $foo\n     ^-- SC2086 (info): Double quote to prevent globbing and word splitting.\n";
+
+test("emits SARIF for shellcheck diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-shellcheck-");
+
+	writeFile(path.join(context.repoDir, "script.sh"), "echo $foo\n");
+	writeFile(path.join(context.runnerTemp, "selected-files.txt"), "script.sh\n");
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "shellcheck",
+			OUTPUT_PATH: path.join(context.runnerTemp, "shellcheck.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"script.sh",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			3,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.shellcheck.test.js
+++ b/.github/scripts/render-linter-sarif.shellcheck.test.js
@@ -52,6 +52,11 @@ test("emits SARIF for shellcheck diagnostics", () => {
 				.startLine,
 			3,
 		);
+		assert.match(
+			report.sarif.runs[0].results[0].message.text,
+			/Double quote to prevent globbing and word splitting/,
+		);
+		assert.equal(report.sarif.runs[0].results[0].ruleId, "SC2086");
 	} finally {
 		cleanupTempRepo(context.tempDir);
 	}

--- a/.github/scripts/render-linter-sarif.spectral.test.js
+++ b/.github/scripts/render-linter-sarif.spectral.test.js
@@ -1,0 +1,68 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const { runFromEnv } = require("./render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "linters/config.json");
+const details = "openapi.yaml:12:5: operation-description must be present";
+
+test("emits SARIF for spectral diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-spectral-");
+
+	writeFile(
+		path.join(context.repoDir, "openapi.yaml"),
+		"openapi: 3.0.0\npaths: {}\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"openapi.yaml\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "spectral",
+			OUTPUT_PATH: path.join(context.runnerTemp, "spectral.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"openapi.yaml",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			12,
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startColumn,
+			5,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.taplo.test.js
+++ b/.github/scripts/render-linter-sarif.taplo.test.js
@@ -1,0 +1,55 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const { runFromEnv } = require("./render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "linters/config.json");
+const details = "config.toml is not formatted correctly";
+
+test("emits SARIF for taplo diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-taplo-");
+
+	writeFile(path.join(context.repoDir, "config.toml"), "a=  1\n");
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"config.toml\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "taplo",
+			OUTPUT_PATH: path.join(context.runnerTemp, "taplo.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"config.toml",
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.test.js
+++ b/.github/scripts/render-linter-sarif.test.js
@@ -233,3 +233,61 @@ test("parses file line and column diagnostics into SARIF results", () => {
 		cleanupTempRepo(context.tempDir);
 	}
 });
+
+test("keeps substring matches from changing the default SARIF severity", () => {
+	const context = makeTempRepo("render-linter-sarif-severity-");
+	const configPath = path.join(context.tempDir, "config.json");
+
+	writeFile(path.join(context.repoDir, "src/app.py"), "print('bad')\n");
+	writeFile(
+		configPath,
+		JSON.stringify(
+			{
+				linters: [
+					{
+						name: "example",
+						details_fallback: "fallback",
+						sarif: {
+							enabled: true,
+						},
+					},
+				],
+			},
+			null,
+			2,
+		),
+	);
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"src/app.py\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details:
+				"src/app.py:8:3: F841 Local variable 'error_count' is assigned to but never used\nsrc/app.py:9:3: APP_INFO is not in alphabetical order",
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = renderSarif({
+			configPath,
+			installOutcome: "success",
+			linterName: "example",
+			outputPath: path.join(context.runnerTemp, "example.sarif"),
+			resultPath: path.join(context.runnerTemp, "linter-result.json"),
+			runOutcome: "success",
+			selectedFilesPath: path.join(context.runnerTemp, "selected-files.txt"),
+			selectOutcome: "success",
+			sourceRepositoryPath: context.repoDir,
+		});
+
+		assert.deepEqual(
+			report.sarif.runs[0].results.map((result) => result.level),
+			["warning", "warning"],
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.test.js
+++ b/.github/scripts/render-linter-sarif.test.js
@@ -1,0 +1,235 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const { renderSarif, runFromEnv } = require("./render-linter-sarif.js");
+
+test("does not emit SARIF when the linter has no SARIF config", () => {
+	const context = makeTempRepo("render-linter-sarif-disabled-");
+	const configPath = path.join(context.tempDir, "config.json");
+
+	writeFile(
+		configPath,
+		JSON.stringify(
+			{
+				linters: [
+					{
+						name: "example",
+						details_fallback: "fallback",
+					},
+				],
+			},
+			null,
+			2,
+		),
+	);
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"src/app.js\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({ details: "", exit_code: 0 }),
+	);
+
+	try {
+		const report = renderSarif({
+			configPath,
+			installOutcome: "success",
+			linterName: "example",
+			outputPath: path.join(context.runnerTemp, "example.sarif"),
+			resultPath: path.join(context.runnerTemp, "linter-result.json"),
+			runOutcome: "success",
+			selectedFilesPath: path.join(context.runnerTemp, "selected-files.txt"),
+			selectOutcome: "success",
+			sourceRepositoryPath: context.repoDir,
+		});
+
+		assert.equal(report.produced, false);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("emits empty SARIF when an enabled linter succeeds", () => {
+	const context = makeTempRepo("render-linter-sarif-success-");
+	const configPath = path.join(context.tempDir, "config.json");
+
+	writeFile(path.join(context.repoDir, "src/app.js"), "console.log('ok');\n");
+	writeFile(
+		configPath,
+		JSON.stringify(
+			{
+				linters: [
+					{
+						name: "example",
+						details_fallback: "fallback",
+						sarif: {
+							enabled: true,
+						},
+					},
+				],
+			},
+			null,
+			2,
+		),
+	);
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"src/app.js\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({ details: "", exit_code: 0 }),
+	);
+
+	try {
+		const report = runFromEnv({
+			EXIT_CODE: "0",
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "example",
+			OUTPUT_PATH: path.join(context.runnerTemp, "example.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		const sarif = JSON.parse(
+			fs.readFileSync(path.join(context.runnerTemp, "example.sarif"), "utf8"),
+		);
+		assert.equal(sarif.version, "2.1.0");
+		assert.deepEqual(sarif.runs[0].results, []);
+		assert.equal(sarif.runs[0].automationDetails.id, "linter-service/example");
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("does not emit SARIF when the linter run failed before producing a result", () => {
+	const context = makeTempRepo("render-linter-sarif-run-failed-");
+	const configPath = path.join(context.tempDir, "config.json");
+
+	writeFile(path.join(context.repoDir, "src/app.js"), "console.log('ok');\n");
+	writeFile(
+		configPath,
+		JSON.stringify(
+			{
+				linters: [
+					{
+						name: "example",
+						details_fallback: "fallback",
+						sarif: {
+							enabled: true,
+						},
+					},
+				],
+			},
+			null,
+			2,
+		),
+	);
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"src/app.js\n",
+	);
+
+	try {
+		const report = renderSarif({
+			configPath,
+			installOutcome: "success",
+			linterName: "example",
+			outputPath: path.join(context.runnerTemp, "example.sarif"),
+			resultPath: path.join(context.runnerTemp, "missing-result.json"),
+			runOutcome: "failure",
+			selectedFilesPath: path.join(context.runnerTemp, "selected-files.txt"),
+			selectOutcome: "success",
+			sourceRepositoryPath: context.repoDir,
+		});
+
+		assert.equal(report.produced, false);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("parses file line and column diagnostics into SARIF results", () => {
+	const context = makeTempRepo("render-linter-sarif-diagnostics-");
+	const configPath = path.join(context.tempDir, "config.json");
+
+	writeFile(path.join(context.repoDir, "src/app.js"), "console.log('bad');\n");
+	writeFile(
+		configPath,
+		JSON.stringify(
+			{
+				linters: [
+					{
+						name: "example",
+						details_fallback: "fallback",
+						sarif: {
+							enabled: true,
+						},
+					},
+				],
+			},
+			null,
+			2,
+		),
+	);
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"src/app.js\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details: "src/app.js:12:3: EX123 unexpected thing",
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = renderSarif({
+			configPath,
+			installOutcome: "success",
+			linterName: "example",
+			outputPath: path.join(context.runnerTemp, "example.sarif"),
+			resultPath: path.join(context.runnerTemp, "linter-result.json"),
+			runOutcome: "success",
+			selectedFilesPath: path.join(context.runnerTemp, "selected-files.txt"),
+			selectOutcome: "success",
+			sourceRepositoryPath: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.equal(report.sarif.runs[0].results.length, 1);
+		assert.equal(report.sarif.runs[0].results[0].ruleId, "EX123");
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"src/app.js",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			12,
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startColumn,
+			3,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.yamlfmt.test.js
+++ b/.github/scripts/render-linter-sarif.yamlfmt.test.js
@@ -1,0 +1,55 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const { runFromEnv } = require("./render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "linters/config.json");
+const details = "config.yaml is not properly formatted";
+
+test("emits SARIF for yamlfmt diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-yamlfmt-");
+
+	writeFile(path.join(context.repoDir, "config.yaml"), "a:  b\n");
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"config.yaml\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "yamlfmt",
+			OUTPUT_PATH: path.join(context.runnerTemp, "yamlfmt.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"config.yaml",
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.yamllint.test.js
+++ b/.github/scripts/render-linter-sarif.yamllint.test.js
@@ -1,0 +1,66 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const { runFromEnv } = require("./render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "linters/config.json");
+const details =
+	"config.yaml:3:7: [error] wrong indentation: expected 4 but found 2 (indentation)";
+
+test("emits SARIF for yamllint diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-yamllint-");
+
+	writeFile(path.join(context.repoDir, "config.yaml"), "a:\n  b: c\n");
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"config.yaml\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "yamllint",
+			OUTPUT_PATH: path.join(context.runnerTemp, "yamllint.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"config.yaml",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			3,
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startColumn,
+			7,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.zizmor.test.js
+++ b/.github/scripts/render-linter-sarif.zizmor.test.js
@@ -1,0 +1,68 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const { runFromEnv } = require("./render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "linters/config.json");
+const details = ".github/workflows/ci.yml:14:5: unpinned action reference";
+
+test("emits SARIF for zizmor diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-zizmor-");
+
+	writeFile(
+		path.join(context.repoDir, ".github/workflows/ci.yml"),
+		"name: ci\non: push\njobs: {}\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		".github/workflows/ci.yml\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "zizmor",
+			OUTPUT_PATH: path.join(context.runnerTemp, "zizmor.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			".github/workflows/ci.yml",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			14,
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startColumn,
+			5,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/upload-sarif.js
+++ b/.github/scripts/upload-sarif.js
@@ -2,6 +2,9 @@ const fs = require("node:fs");
 const path = require("node:path");
 const zlib = require("node:zlib");
 
+const DEFAULT_POLL_ATTEMPTS = 15;
+const DEFAULT_POLL_INTERVAL_MS = 2000;
+
 module.exports = async function uploadSarif({ github, env }) {
 	const rootPath = requireEnv(env, "SARIF_ROOT");
 
@@ -12,11 +15,22 @@ module.exports = async function uploadSarif({ github, env }) {
 	const owner = requireEnv(env, "SARIF_OWNER");
 	const repo = requireEnv(env, "SARIF_REPO");
 	const commitSha = requireEnv(env, "SARIF_HEAD_SHA");
-	const ref = normalizeRef(requireEnv(env, "SARIF_REF"));
+	const ref = resolveSarifRef(env);
+	const pollAttempts = readPositiveIntegerEnv(
+		env,
+		"SARIF_POLL_ATTEMPTS",
+		DEFAULT_POLL_ATTEMPTS,
+	);
+	const pollIntervalMs = readPositiveIntegerEnv(
+		env,
+		"SARIF_POLL_INTERVAL_MS",
+		DEFAULT_POLL_INTERVAL_MS,
+	);
 	const files = fs
 		.readdirSync(rootPath)
 		.filter((fileName) => fileName.endsWith(".sarif"))
 		.sort();
+	const pendingUploads = [];
 	let skipped = 0;
 	let uploaded = 0;
 
@@ -25,14 +39,33 @@ module.exports = async function uploadSarif({ github, env }) {
 		const sarifText = fs.readFileSync(sarifPath, "utf8");
 
 		try {
-			await github.request("POST /repos/{owner}/{repo}/code-scanning/sarifs", {
-				commit_sha: commitSha,
-				owner,
-				ref,
-				repo,
-				sarif: gzipAndEncodeSarif(sarifText),
+			const response = await github.request(
+				"POST /repos/{owner}/{repo}/code-scanning/sarifs",
+				{
+					commit_sha: commitSha,
+					owner,
+					ref,
+					repo,
+					sarif: gzipAndEncodeSarif(sarifText),
+				},
+			);
+			const uploadId = extractSarifUploadId(response);
+
+			if (uploadId === null) {
+				throw new Error(
+					`GitHub did not return a SARIF upload id for ${fileName}`,
+				);
+			}
+
+			if (response?.data?.processing_status === "complete") {
+				uploaded += 1;
+				continue;
+			}
+
+			pendingUploads.push({
+				fileName,
+				uploadId,
 			});
-			uploaded += 1;
 		} catch (error) {
 			if (isUnsupportedCodeScanningError(error)) {
 				console.warn(
@@ -44,6 +77,17 @@ module.exports = async function uploadSarif({ github, env }) {
 
 			throw error;
 		}
+	}
+
+	if (pendingUploads.length > 0) {
+		uploaded += await waitForPendingUploads({
+			github,
+			owner,
+			pollAttempts,
+			pollIntervalMs,
+			pendingUploads,
+			repo,
+		});
 	}
 
 	return { skipped, uploaded };
@@ -59,8 +103,135 @@ function requireEnv(env, key) {
 	return value;
 }
 
+function readPositiveIntegerEnv(env, key, fallbackValue) {
+	const raw = env[key];
+
+	if (raw === undefined || raw === null || raw === "") {
+		return fallbackValue;
+	}
+
+	if (!/^[1-9]\d*$/u.test(String(raw))) {
+		throw new Error(`${key} must be a positive integer`);
+	}
+
+	return Number(raw);
+}
+
+function resolveSarifRef(env) {
+	const prNumber = env.SARIF_PR_NUMBER;
+
+	if (typeof prNumber === "string" && prNumber.length > 0) {
+		if (!/^[1-9]\d*$/u.test(prNumber)) {
+			throw new Error("SARIF_PR_NUMBER must be a positive integer");
+		}
+
+		return `refs/pull/${prNumber}/head`;
+	}
+
+	return normalizeRef(requireEnv(env, "SARIF_REF"));
+}
+
 function normalizeRef(value) {
 	return value.startsWith("refs/") ? value : `refs/heads/${value}`;
+}
+
+function extractSarifUploadId(response) {
+	const id = response?.data?.id ?? response?.data?.sarif_id;
+
+	if (typeof id === "number" && Number.isFinite(id)) {
+		return String(id);
+	}
+
+	return typeof id === "string" && id.length > 0 ? id : null;
+}
+
+async function waitForPendingUploads({
+	github,
+	owner,
+	pendingUploads,
+	pollAttempts,
+	pollIntervalMs,
+	repo,
+}) {
+	const pendingById = new Map(
+		pendingUploads.map((upload) => [upload.uploadId, upload.fileName]),
+	);
+	let completed = 0;
+
+	for (let attempt = 1; attempt <= pollAttempts; attempt += 1) {
+		for (const [uploadId, fileName] of pendingById.entries()) {
+			const response = await github.request(
+				"GET /repos/{owner}/{repo}/code-scanning/sarifs/{sarif_id}",
+				{
+					owner,
+					repo,
+					sarif_id: uploadId,
+				},
+			);
+			const status = String(response?.data?.processing_status || "");
+
+			if (status === "complete") {
+				pendingById.delete(uploadId);
+				completed += 1;
+				continue;
+			}
+
+			if (status === "failed") {
+				throw new Error(
+					buildProcessingFailureMessage(fileName, uploadId, response),
+				);
+			}
+		}
+
+		if (pendingById.size === 0) {
+			return completed;
+		}
+
+		if (attempt < pollAttempts) {
+			await delay(pollIntervalMs);
+		}
+	}
+
+	const pendingFiles = [...pendingById.values()].join(", ");
+	throw new Error(
+		`Timed out waiting for GitHub to finish processing SARIF upload(s): ${pendingFiles}`,
+	);
+}
+
+function buildProcessingFailureMessage(fileName, uploadId, response) {
+	const errors = Array.isArray(response?.data?.errors)
+		? response.data.errors
+		: [];
+	const details = errors
+		.map((error) => {
+			if (typeof error === "string") {
+				return error;
+			}
+
+			if (typeof error?.message === "string") {
+				return error.message;
+			}
+
+			if (typeof error?.description === "string") {
+				return error.description;
+			}
+
+			return "";
+		})
+		.filter(Boolean)
+		.join("; ");
+
+	if (details.length > 0) {
+		return `GitHub failed to process ${fileName} (upload ${uploadId}): ${details}`;
+	}
+
+	return `GitHub failed to process ${fileName} (upload ${uploadId})`;
+}
+
+function delay(milliseconds) {
+	return new Promise((resolve) => {
+		setTimeout(resolve, milliseconds);
+	});
 }
 
 function gzipAndEncodeSarif(sarifText) {
@@ -93,3 +264,4 @@ function extractErrorMessage(error) {
 module.exports.gzipAndEncodeSarif = gzipAndEncodeSarif;
 module.exports.isUnsupportedCodeScanningError = isUnsupportedCodeScanningError;
 module.exports.normalizeRef = normalizeRef;
+module.exports.resolveSarifRef = resolveSarifRef;

--- a/.github/scripts/upload-sarif.js
+++ b/.github/scripts/upload-sarif.js
@@ -1,0 +1,95 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const zlib = require("node:zlib");
+
+module.exports = async function uploadSarif({ github, env }) {
+	const rootPath = requireEnv(env, "SARIF_ROOT");
+
+	if (!fs.existsSync(rootPath)) {
+		return { skipped: 0, uploaded: 0 };
+	}
+
+	const owner = requireEnv(env, "SARIF_OWNER");
+	const repo = requireEnv(env, "SARIF_REPO");
+	const commitSha = requireEnv(env, "SARIF_HEAD_SHA");
+	const ref = normalizeRef(requireEnv(env, "SARIF_REF"));
+	const files = fs
+		.readdirSync(rootPath)
+		.filter((fileName) => fileName.endsWith(".sarif"))
+		.sort();
+	let skipped = 0;
+	let uploaded = 0;
+
+	for (const fileName of files) {
+		const sarifPath = path.join(rootPath, fileName);
+		const sarifText = fs.readFileSync(sarifPath, "utf8");
+
+		try {
+			await github.request("POST /repos/{owner}/{repo}/code-scanning/sarifs", {
+				commit_sha: commitSha,
+				owner,
+				ref,
+				repo,
+				sarif: gzipAndEncodeSarif(sarifText),
+			});
+			uploaded += 1;
+		} catch (error) {
+			if (isUnsupportedCodeScanningError(error)) {
+				console.warn(
+					`Skipping SARIF upload for ${owner}/${repo}: ${extractErrorMessage(error)}`,
+				);
+				skipped += 1;
+				continue;
+			}
+
+			throw error;
+		}
+	}
+
+	return { skipped, uploaded };
+};
+
+function requireEnv(env, key) {
+	const value = env[key];
+
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(`${key} is required`);
+	}
+
+	return value;
+}
+
+function normalizeRef(value) {
+	return value.startsWith("refs/") ? value : `refs/heads/${value}`;
+}
+
+function gzipAndEncodeSarif(sarifText) {
+	return zlib.gzipSync(Buffer.from(sarifText, "utf8")).toString("base64");
+}
+
+function isUnsupportedCodeScanningError(error) {
+	const message = extractErrorMessage(error);
+
+	return (
+		(error?.status === 403 || error?.status === 422) &&
+		/GitHub Code Security|GitHub Advanced Security|code scanning.*enabled/iu.test(
+			message,
+		)
+	);
+}
+
+function extractErrorMessage(error) {
+	if (typeof error?.response?.data?.message === "string") {
+		return error.response.data.message;
+	}
+
+	if (typeof error?.message === "string") {
+		return error.message;
+	}
+
+	return "Unknown code scanning upload error";
+}
+
+module.exports.gzipAndEncodeSarif = gzipAndEncodeSarif;
+module.exports.isUnsupportedCodeScanningError = isUnsupportedCodeScanningError;
+module.exports.normalizeRef = normalizeRef;

--- a/.github/scripts/upload-sarif.test.js
+++ b/.github/scripts/upload-sarif.test.js
@@ -1,0 +1,169 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const zlib = require("node:zlib");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("./linters/cargo-linter-test-lib.js");
+const uploadSarif = require("./upload-sarif.js");
+
+test("uploads each SARIF file with gzip+base64 payload", async () => {
+	const context = makeTempRepo("upload-sarif-success-");
+	const sarifRoot = path.join(context.tempDir, "sarif");
+	const calls = [];
+
+	fs.mkdirSync(sarifRoot, { recursive: true });
+	writeFile(
+		path.join(sarifRoot, "example.sarif"),
+		JSON.stringify({
+			version: "2.1.0",
+			runs: [
+				{
+					automationDetails: { id: "linter-service/example" },
+					results: [],
+					tool: { driver: { name: "linter-service/example" } },
+				},
+			],
+		}),
+	);
+
+	try {
+		const outcome = await uploadSarif({
+			env: {
+				SARIF_HEAD_SHA: "abc123",
+				SARIF_OWNER: "octo",
+				SARIF_REF: "feature/test",
+				SARIF_REPO: "demo",
+				SARIF_ROOT: sarifRoot,
+			},
+			github: {
+				request: async (route, params) => {
+					calls.push({ params, route });
+					return { data: { id: "1" } };
+				},
+			},
+		});
+
+		assert.deepEqual(outcome, { skipped: 0, uploaded: 1 });
+		assert.equal(calls.length, 1);
+		assert.equal(
+			calls[0].route,
+			"POST /repos/{owner}/{repo}/code-scanning/sarifs",
+		);
+		assert.equal(calls[0].params.owner, "octo");
+		assert.equal(calls[0].params.repo, "demo");
+		assert.equal(calls[0].params.commit_sha, "abc123");
+		assert.equal(calls[0].params.ref, "refs/heads/feature/test");
+
+		const decoded = zlib
+			.gunzipSync(Buffer.from(calls[0].params.sarif, "base64"))
+			.toString("utf8");
+		assert.match(decoded, /"version":"2\.1\.0"/);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("returns success when there are no SARIF files to upload", async () => {
+	const context = makeTempRepo("upload-sarif-empty-");
+	const sarifRoot = path.join(context.tempDir, "sarif");
+
+	fs.mkdirSync(sarifRoot, { recursive: true });
+
+	try {
+		const outcome = await uploadSarif({
+			env: {
+				SARIF_HEAD_SHA: "abc123",
+				SARIF_OWNER: "octo",
+				SARIF_REF: "feature/test",
+				SARIF_REPO: "demo",
+				SARIF_ROOT: sarifRoot,
+			},
+			github: {
+				request: async () => {
+					throw new Error("request should not be called");
+				},
+			},
+		});
+
+		assert.deepEqual(outcome, { skipped: 0, uploaded: 0 });
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("soft-skips repositories where code scanning is unavailable", async () => {
+	const context = makeTempRepo("upload-sarif-skip-");
+	const sarifRoot = path.join(context.tempDir, "sarif");
+
+	fs.mkdirSync(sarifRoot, { recursive: true });
+	writeFile(
+		path.join(sarifRoot, "example.sarif"),
+		'{"version":"2.1.0","runs":[]}',
+	);
+
+	try {
+		const outcome = await uploadSarif({
+			env: {
+				SARIF_HEAD_SHA: "abc123",
+				SARIF_OWNER: "octo",
+				SARIF_REF: "feature/test",
+				SARIF_REPO: "demo",
+				SARIF_ROOT: sarifRoot,
+			},
+			github: {
+				request: async () => {
+					const error = new Error(
+						"GitHub Code Security or GitHub Advanced Security must be enabled for this repository to use code scanning",
+					);
+					error.status = 403;
+					error.response = { data: { message: error.message } };
+					throw error;
+				},
+			},
+		});
+
+		assert.deepEqual(outcome, { skipped: 1, uploaded: 0 });
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("rethrows unexpected upload errors", async () => {
+	const context = makeTempRepo("upload-sarif-error-");
+	const sarifRoot = path.join(context.tempDir, "sarif");
+
+	fs.mkdirSync(sarifRoot, { recursive: true });
+	writeFile(
+		path.join(sarifRoot, "example.sarif"),
+		'{"version":"2.1.0","runs":[]}',
+	);
+
+	try {
+		await assert.rejects(() =>
+			uploadSarif({
+				env: {
+					SARIF_HEAD_SHA: "abc123",
+					SARIF_OWNER: "octo",
+					SARIF_REF: "feature/test",
+					SARIF_REPO: "demo",
+					SARIF_ROOT: sarifRoot,
+				},
+				github: {
+					request: async () => {
+						const error = new Error("Resource not accessible by integration");
+						error.status = 403;
+						error.response = { data: { message: error.message } };
+						throw error;
+					},
+				},
+			}),
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/upload-sarif.test.js
+++ b/.github/scripts/upload-sarif.test.js
@@ -11,7 +11,7 @@ const {
 } = require("./linters/cargo-linter-test-lib.js");
 const uploadSarif = require("./upload-sarif.js");
 
-test("uploads each SARIF file with gzip+base64 payload", async () => {
+test("uploads each SARIF file, uses the PR ref, and waits for completion", async () => {
 	const context = makeTempRepo("upload-sarif-success-");
 	const sarifRoot = path.join(context.tempDir, "sarif");
 	const calls = [];
@@ -36,28 +36,40 @@ test("uploads each SARIF file with gzip+base64 payload", async () => {
 			env: {
 				SARIF_HEAD_SHA: "abc123",
 				SARIF_OWNER: "octo",
-				SARIF_REF: "feature/test",
+				SARIF_POLL_ATTEMPTS: "2",
+				SARIF_POLL_INTERVAL_MS: "1",
+				SARIF_PR_NUMBER: "42",
 				SARIF_REPO: "demo",
 				SARIF_ROOT: sarifRoot,
 			},
 			github: {
 				request: async (route, params) => {
 					calls.push({ params, route });
-					return { data: { id: "1" } };
+
+					if (route === "POST /repos/{owner}/{repo}/code-scanning/sarifs") {
+						return { data: { id: "1", processing_status: "pending" } };
+					}
+
+					return { data: { processing_status: "complete" } };
 				},
 			},
 		});
 
 		assert.deepEqual(outcome, { skipped: 0, uploaded: 1 });
-		assert.equal(calls.length, 1);
+		assert.equal(calls.length, 2);
 		assert.equal(
 			calls[0].route,
 			"POST /repos/{owner}/{repo}/code-scanning/sarifs",
 		);
+		assert.equal(
+			calls[1].route,
+			"GET /repos/{owner}/{repo}/code-scanning/sarifs/{sarif_id}",
+		);
 		assert.equal(calls[0].params.owner, "octo");
 		assert.equal(calls[0].params.repo, "demo");
 		assert.equal(calls[0].params.commit_sha, "abc123");
-		assert.equal(calls[0].params.ref, "refs/heads/feature/test");
+		assert.equal(calls[0].params.ref, "refs/pull/42/head");
+		assert.equal(calls[1].params.sarif_id, "1");
 
 		const decoded = zlib
 			.gunzipSync(Buffer.from(calls[0].params.sarif, "base64"))
@@ -128,6 +140,51 @@ test("soft-skips repositories where code scanning is unavailable", async () => {
 		});
 
 		assert.deepEqual(outcome, { skipped: 1, uploaded: 0 });
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("fails when GitHub reports SARIF processing errors", async () => {
+	const context = makeTempRepo("upload-sarif-processing-failed-");
+	const sarifRoot = path.join(context.tempDir, "sarif");
+
+	fs.mkdirSync(sarifRoot, { recursive: true });
+	writeFile(
+		path.join(sarifRoot, "example.sarif"),
+		'{"version":"2.1.0","runs":[]}',
+	);
+
+	try {
+		await assert.rejects(
+			() =>
+				uploadSarif({
+					env: {
+						SARIF_HEAD_SHA: "abc123",
+						SARIF_OWNER: "octo",
+						SARIF_POLL_ATTEMPTS: "1",
+						SARIF_POLL_INTERVAL_MS: "1",
+						SARIF_PR_NUMBER: "42",
+						SARIF_REPO: "demo",
+						SARIF_ROOT: sarifRoot,
+					},
+					github: {
+						request: async (route) => {
+							if (route === "POST /repos/{owner}/{repo}/code-scanning/sarifs") {
+								return { data: { id: "1", processing_status: "pending" } };
+							}
+
+							return {
+								data: {
+									errors: [{ message: "invalid SARIF" }],
+									processing_status: "failed",
+								},
+							};
+						},
+					},
+				}),
+			/invalid SARIF/,
+		);
 	} finally {
 		cleanupTempRepo(context.tempDir);
 	}

--- a/.github/workflows/lint-common.yml
+++ b/.github/workflows/lint-common.yml
@@ -1,5 +1,4 @@
 name: Lint Common
-
 on:
   workflow_call:
     inputs:
@@ -11,9 +10,7 @@ on:
         required: true
       CHECKER_PRIVATE_KEY:
         required: true
-
 permissions: {}
-
 jobs:
   run-linter:
     permissions:
@@ -31,14 +28,12 @@ jobs:
         with:
           name: detect-targets-context
           path: ${{ runner.temp }}/detect-targets-context
-
       - name: Check out linter-service repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: linter-service
           persist-credentials: false
           ref: ${{ github.sha }}
-
       - name: Derive artifact passphrase
         env:
           CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
@@ -46,7 +41,6 @@ jobs:
           passphrase="$(bash "$LINTER_SERVICE_PATH/.github/scripts/artifact-passphrase.sh")"
           echo "::add-mask::$passphrase"
           echo "ARTIFACT_PASSPHRASE=$passphrase" >> "$GITHUB_ENV"
-
       - name: Decrypt dispatch context artifact
         run: |
           encrypted_path="$RUNNER_TEMP/detect-targets-context/detect-targets-context.json.enc"
@@ -56,7 +50,6 @@ jobs:
             "$encrypted_path" \
             "$decrypted_path"
           rm -f "$encrypted_path"
-
       - name: Mask repository metadata
         env:
           CONTEXT_PATH: ${{ runner.temp }}/detect-targets-context/detect-targets-context.json
@@ -67,7 +60,6 @@ jobs:
             source_owner \
             source_repo \
             source_head_sha
-
       - name: Decode repository metadata
         id: decode_context
         env:
@@ -79,7 +71,6 @@ jobs:
             source_head_sha=source-head-sha \
             source_owner=source-owner \
             source_repo=source-repo
-
       - name: Get source repository checker token
         id: get_source_token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
@@ -89,7 +80,6 @@ jobs:
           permission-contents: read
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_context.outputs.source-repo }}
-
       - name: Check out source repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -98,7 +88,6 @@ jobs:
           ref: ${{ steps.decode_context.outputs.source-head-sha }}
           repository: ${{ steps.decode_context.outputs.source-owner }}/${{ steps.decode_context.outputs.source-repo }}
           token: ${{ steps.get_source_token.outputs.token }}
-
       - name: Select lint target files
         id: select_files
         env:
@@ -128,7 +117,6 @@ jobs:
 
           count=$(wc -l < "$RUNNER_TEMP/selected-files.txt" | tr -d ' ')
           echo "count=$count" >> "$GITHUB_OUTPUT"
-
       - name: Install linter tool
         id: install_tool
         if: ${{ steps.select_files.outputs.count != '0' }}
@@ -138,7 +126,6 @@ jobs:
             cd "$LINTER_SERVICE_PATH" || exit 1
             bash "$script_path" install
           )
-
       - name: Run linter
         id: run_linter
         if: ${{ steps.select_files.outputs.count != '0' }}
@@ -167,7 +154,6 @@ jobs:
           with output_path.open("a", encoding="utf-8") as fh:
               fh.write(f"exit_code={exit_code}\n")
           PY
-
       - name: Prepare linter report
         id: prepare_report
         if: ${{ always() }}
@@ -181,7 +167,6 @@ jobs:
           SELECT_FILES_OUTCOME: ${{ steps.select_files.outcome }}
         run: |
           node "$LINTER_SERVICE_PATH/.github/scripts/render-linter-report.js"
-
       - name: Prepare linter SARIF
         id: prepare_sarif
         if: ${{ always() }}
@@ -195,7 +180,6 @@ jobs:
           SELECT_FILES_OUTCOME: ${{ steps.select_files.outcome }}
         run: |
           node "$LINTER_SERVICE_PATH/.github/scripts/render-linter-sarif.js"
-
       - name: Encrypt linter summary artifact
         id: encrypt_summary
         if: ${{ always() }}
@@ -207,7 +191,6 @@ jobs:
             "$input_path" \
             "$output_path"
           rm -f "$input_path"
-
       - name: Upload linter summary artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -216,7 +199,6 @@ jobs:
           path: ${{ runner.temp }}/linter-summary-${{ inputs.linter-name }}.json.enc
           if-no-files-found: warn
           retention-days: 1
-
       - name: Encrypt linter SARIF artifact
         id: encrypt_sarif
         if: ${{ always() }}
@@ -231,7 +213,6 @@ jobs:
             "$input_path" \
             "$output_path"
           rm -f "$input_path"
-
       - name: Upload linter SARIF artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/lint-common.yml
+++ b/.github/workflows/lint-common.yml
@@ -182,6 +182,20 @@ jobs:
         run: |
           node "$LINTER_SERVICE_PATH/.github/scripts/render-linter-report.js"
 
+      - name: Prepare linter SARIF
+        id: prepare_sarif
+        if: ${{ always() }}
+        env:
+          INSTALL_TOOL_OUTCOME: ${{ steps.install_tool.outcome }}
+          LINTER_NAME: ${{ inputs.linter-name }}
+          OUTPUT_PATH: ${{ runner.temp }}/linter-sarif-${{ inputs.linter-name }}.sarif
+          RESULT_PATH: ${{ runner.temp }}/linter-result.json
+          RUN_LINTER_OUTCOME: ${{ steps.run_linter.outcome }}
+          SELECTED_FILES_PATH: ${{ runner.temp }}/selected-files.txt
+          SELECT_FILES_OUTCOME: ${{ steps.select_files.outcome }}
+        run: |
+          node "$LINTER_SERVICE_PATH/.github/scripts/render-linter-sarif.js"
+
       - name: Encrypt linter summary artifact
         id: encrypt_summary
         if: ${{ always() }}
@@ -200,5 +214,29 @@ jobs:
         with:
           name: linter-summary-${{ inputs.linter-name }}
           path: ${{ runner.temp }}/linter-summary-${{ inputs.linter-name }}.json.enc
+          if-no-files-found: warn
+          retention-days: 1
+
+      - name: Encrypt linter SARIF artifact
+        id: encrypt_sarif
+        if: ${{ always() }}
+        run: |
+          input_path="$RUNNER_TEMP/linter-sarif-$LINTER_NAME.sarif"
+          if [ ! -f "$input_path" ]; then
+            exit 0
+          fi
+          output_path="$RUNNER_TEMP/linter-sarif-$LINTER_NAME.sarif.enc"
+          bash "$LINTER_SERVICE_PATH/.github/scripts/secure-artifact.sh" \
+            encrypt \
+            "$input_path" \
+            "$output_path"
+          rm -f "$input_path"
+
+      - name: Upload linter SARIF artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: linter-sarif-${{ inputs.linter-name }}
+          path: ${{ runner.temp }}/linter-sarif-${{ inputs.linter-name }}.sarif.enc
           if-no-files-found: warn
           retention-days: 1

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -1,5 +1,4 @@
 name: Repository Dispatch
-
 on:
   pull_request:
     types:
@@ -11,13 +10,10 @@ on:
   repository_dispatch:
     types:
       - github_app_webhook
-
 concurrency:
   group: ${{ format('repository-dispatch-{0}-{1}', github.event_name == 'pull_request' && github.repository || github.event.client_payload.repository.full_name || github.repository, github.event_name == 'pull_request' && github.event.pull_request.number || github.event.client_payload.pull_request.number || github.run_id) }}
   cancel-in-progress: false
-
 permissions: {}
-
 jobs:
   detect-targets:
     permissions:
@@ -55,7 +51,6 @@ jobs:
             echo "PULL_REQUEST_NUMBER must be a positive integer" >&2
             exit 1
           }
-
       - name: Mask repository metadata
         run: |
           echo "::add-mask::$PR_REPOSITORY_OWNER"
@@ -64,14 +59,12 @@ jobs:
           if [ -n "$SOURCE_HEAD_SHA" ]; then
             echo "::add-mask::$SOURCE_HEAD_SHA"
           fi
-
       - name: Check out linter-service repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: linter-service
           persist-credentials: false
           ref: ${{ github.sha }}
-
       - name: Build linter definitions
         id: build_linter_definitions
         env:
@@ -115,7 +108,6 @@ jobs:
           with github_output.open("a", encoding="utf-8") as fh:
               fh.write(f"path={output_path}\n")
           PY
-
       - name: Get checker token
         id: get_checker_token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
@@ -125,7 +117,6 @@ jobs:
           permission-pull-requests: read
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ env.PR_REPOSITORY_NAME }}
-
       - name: Collect pull request context
         id: collect
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -305,14 +296,12 @@ jobs:
             core.setOutput("pull-request-number", String(pullNumber));
             core.setOutput("selected-linters-json", JSON.stringify(selectedLinters));
             core.setOutput("skip-reason", "");
-
       - name: Report routing status
         env:
           SELECTED_LINTERS_JSON: ${{ steps.collect.outputs.selected-linters-json }}
         run: |
           echo "Routing targets resolved."
           echo "Selected linters: ${SELECTED_LINTERS_JSON}"
-
       - name: Derive artifact passphrase
         env:
           CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
@@ -321,7 +310,6 @@ jobs:
           passphrase="$(bash "$LINTER_SERVICE_PATH/.github/scripts/artifact-passphrase.sh")"
           echo "::add-mask::$passphrase"
           echo "ARTIFACT_PASSPHRASE=$passphrase" >> "$GITHUB_ENV"
-
       - name: Encrypt dispatch context artifact
         env:
           CONTEXT_PATH: ${{ steps.collect.outputs.context-path }}
@@ -333,7 +321,6 @@ jobs:
             "$CONTEXT_PATH" \
             "$encrypted_path"
           rm -f "$CONTEXT_PATH"
-
       - name: Upload dispatch context artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -341,7 +328,6 @@ jobs:
           path: ${{ runner.temp }}/detect-targets-context.json.enc
           if-no-files-found: error
           retention-days: 1
-
   notify-processing-started:
     needs: detect-targets
     if: ${{ needs.detect-targets.outputs.selected-linters-json != '[]' }}
@@ -355,14 +341,12 @@ jobs:
         with:
           name: detect-targets-context
           path: ${{ runner.temp }}/detect-targets-context
-
       - name: Check out linter-service repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: linter-service
           persist-credentials: false
           ref: ${{ github.sha }}
-
       - name: Derive artifact passphrase
         env:
           CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
@@ -371,7 +355,6 @@ jobs:
           passphrase="$(bash "$LINTER_SERVICE_PATH/.github/scripts/artifact-passphrase.sh")"
           echo "::add-mask::$passphrase"
           echo "ARTIFACT_PASSPHRASE=$passphrase" >> "$GITHUB_ENV"
-
       - name: Decrypt dispatch context artifact
         env:
           LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
@@ -383,7 +366,6 @@ jobs:
             "$encrypted_path" \
             "$decrypted_path"
           rm -f "$encrypted_path"
-
       - name: Mask repository metadata
         env:
           CONTEXT_PATH: ${{ runner.temp }}/detect-targets-context/detect-targets-context.json
@@ -395,7 +377,6 @@ jobs:
             source_owner \
             source_repo \
             source_head_sha
-
       - name: Decode source repository context
         id: decode_source_context
         env:
@@ -410,7 +391,6 @@ jobs:
             source_head_sha=source-head-sha \
             source_owner=source-owner \
             source_repo=source-repo
-
       - name: Get source repository checker token
         id: get_source_token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
@@ -420,7 +400,6 @@ jobs:
           permission-checks: write
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_source_context.outputs.source-repo }}
-
       - name: Notify processing start
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
@@ -450,7 +429,6 @@ jobs:
               `${process.env.LINTER_SERVICE_PATH}/.github/scripts/upsert-check-run.js`,
             );
             await upsertCheckRun({ github, env: process.env });
-
   run-linters:
     name: ${{ matrix.linter }}
     needs:
@@ -469,7 +447,6 @@ jobs:
     secrets:
       CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
       CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
-
   publish-results:
     needs:
       - detect-targets
@@ -486,14 +463,12 @@ jobs:
         with:
           name: detect-targets-context
           path: ${{ runner.temp }}/detect-targets-context
-
       - name: Check out linter-service repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: linter-service
           persist-credentials: false
           ref: ${{ github.sha }}
-
       - name: Derive artifact passphrase
         env:
           CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
@@ -502,7 +477,6 @@ jobs:
           passphrase="$(bash "$LINTER_SERVICE_PATH/.github/scripts/artifact-passphrase.sh")"
           echo "::add-mask::$passphrase"
           echo "ARTIFACT_PASSPHRASE=$passphrase" >> "$GITHUB_ENV"
-
       - name: Decrypt dispatch context artifact
         env:
           LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
@@ -514,7 +488,6 @@ jobs:
             "$encrypted_path" \
             "$decrypted_path"
           rm -f "$encrypted_path"
-
       - name: Download linter summary artifacts
         if: ${{ always() }}
         continue-on-error: true
@@ -523,7 +496,6 @@ jobs:
           pattern: linter-summary-*
           merge-multiple: true
           path: ${{ runner.temp }}/linter-summaries
-
       - name: Download linter SARIF artifacts
         if: ${{ always() }}
         continue-on-error: true
@@ -532,7 +504,6 @@ jobs:
           pattern: linter-sarif-*
           merge-multiple: true
           path: ${{ runner.temp }}/linter-sarifs
-
       - name: Mask repository metadata
         env:
           CONTEXT_PATH: ${{ runner.temp }}/detect-targets-context/detect-targets-context.json
@@ -546,7 +517,6 @@ jobs:
             source_head_sha \
             source_owner \
             source_repo
-
       - name: Decode repository context
         id: decode_repository_context
         env:
@@ -564,7 +534,6 @@ jobs:
             source_head_sha=source-head-sha \
             source_owner=source-owner \
             source_repo=source-repo
-
       - name: Get PR repository checker token
         id: get_pr_token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
@@ -575,7 +544,6 @@ jobs:
           permission-security-events: write
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_repository_context.outputs.pr-repo }}
-
       - name: Get source repository checker token
         id: get_source_token
         if: ${{ needs.detect-targets.outputs.selected-linters-json != '[]' }}
@@ -586,7 +554,6 @@ jobs:
           permission-checks: write
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_repository_context.outputs.source-repo }}
-
       - name: Decrypt linter summary artifacts
         id: decrypt_summaries
         if: ${{ always() }}
@@ -613,7 +580,6 @@ jobs:
           done
 
           exit "$failures"
-
       - name: Decrypt linter SARIF artifacts
         id: decrypt_sarifs
         if: ${{ always() }}
@@ -640,7 +606,6 @@ jobs:
           done
 
           exit "$failures"
-
       - name: Prepare deselected SARIF placeholders
         if: ${{ always() }}
         env:
@@ -650,7 +615,6 @@ jobs:
           SELECTED_LINTERS_JSON: ${{ needs.detect-targets.outputs.selected-linters-json }}
         run: |
           node "$LINTER_SERVICE_PATH/.github/scripts/prepare-deselected-sarif.js"
-
       - name: Prepare combined report
         id: prepare_report
         if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' }}
@@ -736,7 +700,6 @@ jobs:
               fh.write(f"overall_conclusion={overall_conclusion}\n")
               fh.write(f"overall_summary={overall_summary}\n")
           PY
-
       - name: Upsert combined PR comment
         if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -754,7 +717,6 @@ jobs:
               `${process.env.LINTER_SERVICE_PATH}/.github/scripts/upsert-pr-comment.js`,
             );
             await upsertPullRequestComment({ github, env: process.env });
-
       - name: Upload SARIF artifacts
         id: upload_sarif
         if: ${{ always() }}
@@ -774,7 +736,6 @@ jobs:
               `${process.env.LINTER_SERVICE_PATH}/.github/scripts/upload-sarif.js`,
             );
             await uploadSarif({ github, env: process.env });
-
       - name: Prepare final processing summary
         id: prepare_final_summary
         if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' }}
@@ -810,7 +771,6 @@ jobs:
               fh.write(f"summary={summary}\n")
               fh.write(f"title={title}\n")
           PY
-
       - name: Finalize processing check run
         if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -839,7 +799,6 @@ jobs:
               `${process.env.LINTER_SERVICE_PATH}/.github/scripts/upsert-check-run.js`,
             );
             await upsertCheckRun({ github, env: process.env });
-
       - name: Fail workflow when lint reports issues
         if: ${{ needs.detect-targets.outputs.selected-linters-json != '[]' && steps.prepare_report.outputs.overall_conclusion != 'success' }}
         env:
@@ -847,13 +806,11 @@ jobs:
         run: |
           echo "$SUMMARY" >&2
           exit 1
-
       - name: Fail workflow when deselected SARIF upload fails
         if: ${{ needs.detect-targets.outputs.selected-linters-json == '[]' && steps.upload_sarif.outcome == 'failure' }}
         run: |
           echo "SARIF upload failed while clearing deselected linter results. See the workflow logs." >&2
           exit 1
-
   no-linters-needed:
     needs: detect-targets
     if: ${{ needs.detect-targets.outputs.selected-linters-json == '[]' }}

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -32,6 +32,7 @@ jobs:
       PR_REPOSITORY_NAME: ${{ github.event_name == 'pull_request' && github.event.repository.name || github.event.client_payload.repository.name }}
       PR_REPOSITORY_OWNER: ${{ github.event_name == 'pull_request' && github.event.repository.owner.login || github.event.client_payload.repository.owner.login }}
       PULL_REQUEST_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.client_payload.pull_request.number }}
+      SOURCE_HEAD_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.event.client_payload.pull_request.head.ref }}
       SOURCE_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.client_payload.pull_request.head.sha }}
     steps:
       - name: Validate pull request metadata
@@ -194,6 +195,7 @@ jobs:
                 processing_check_name: "linter-service",
                 selected_linters: [],
                 skip_reason: skipReason,
+                source_head_ref: process.env.SOURCE_HEAD_REF || "",
                 source_head_sha: sourceHeadShaFromPayload,
                 source_owner: owner,
                 source_repo: repo,
@@ -218,6 +220,7 @@ jobs:
                 processing_check_name: "linter-service",
                 selected_linters: [],
                 skip_reason: skipReason,
+                source_head_ref: process.env.SOURCE_HEAD_REF || "",
                 source_head_sha: sourceHeadShaFromPayload,
                 source_owner: owner,
                 source_repo: repo,
@@ -250,6 +253,7 @@ jobs:
               .map((file) => file.filename);
 
             const sourceOwner = pull.head.repo?.owner?.login ?? owner;
+            const sourceHeadRef = pull.head.ref ?? process.env.SOURCE_HEAD_REF ?? "";
             const sourceRepo = pull.head.repo?.name ?? repo;
             const sourceHeadSha = sourceHeadShaFromPayload || pull.head.sha;
 
@@ -293,6 +297,7 @@ jobs:
               processing_check_name: "linter-service",
               selected_linters: selectedLinters,
               skip_reason: "",
+              source_head_ref: sourceHeadRef,
               source_head_sha: sourceHeadSha,
               source_owner: sourceOwner,
               source_repo: sourceRepo,
@@ -519,6 +524,15 @@ jobs:
           merge-multiple: true
           path: ${{ runner.temp }}/linter-summaries
 
+      - name: Download linter SARIF artifacts
+        if: ${{ always() }}
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: linter-sarif-*
+          merge-multiple: true
+          path: ${{ runner.temp }}/linter-sarifs
+
       - name: Mask repository metadata
         env:
           CONTEXT_PATH: ${{ runner.temp }}/detect-targets-context/detect-targets-context.json
@@ -546,6 +560,7 @@ jobs:
             pr_repo=pr-repo \
             processing_check_external_id=processing-check-external-id \
             processing_check_name=processing-check-name \
+            source_head_ref=source-head-ref \
             source_head_sha=source-head-sha \
             source_owner=source-owner \
             source_repo=source-repo
@@ -567,6 +582,7 @@ jobs:
           app-id: ${{ secrets.CHECKER_APP_ID }}
           owner: ${{ steps.decode_repository_context.outputs.source-owner }}
           permission-checks: write
+          permission-security-events: write
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_repository_context.outputs.source-repo }}
 
@@ -586,6 +602,33 @@ jobs:
 
           for encrypted_path in "${encrypted_files[@]}"; do
             decrypted_path="$RUNNER_TEMP/linter-summaries-decrypted/$(basename "${encrypted_path%.enc}")"
+            if ! bash "$LINTER_SERVICE_PATH/.github/scripts/secure-artifact.sh" \
+              decrypt \
+              "$encrypted_path" \
+              "$decrypted_path"; then
+              echo "::warning::Failed to decrypt $(basename "$encrypted_path")"
+              failures=1
+            fi
+          done
+
+          exit "$failures"
+
+      - name: Decrypt linter SARIF artifacts
+        id: decrypt_sarifs
+        if: ${{ always() }}
+        env:
+          LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
+        run: |
+          shopt -s nullglob
+          failures=0
+          mkdir -p "$RUNNER_TEMP/linter-sarifs-decrypted"
+          encrypted_files=("$RUNNER_TEMP"/linter-sarifs/*.enc)
+          if [ "${#encrypted_files[@]}" -eq 0 ]; then
+            exit 0
+          fi
+
+          for encrypted_path in "${encrypted_files[@]}"; do
+            decrypted_path="$RUNNER_TEMP/linter-sarifs-decrypted/$(basename "${encrypted_path%.enc}")"
             if ! bash "$LINTER_SERVICE_PATH/.github/scripts/secure-artifact.sh" \
               decrypt \
               "$encrypted_path" \
@@ -701,22 +744,78 @@ jobs:
             );
             await upsertPullRequestComment({ github, env: process.env });
 
+      - name: Upload SARIF artifacts
+        id: upload_sarif
+        if: ${{ always() }}
+        continue-on-error: true
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
+          SARIF_HEAD_SHA: ${{ steps.decode_repository_context.outputs.source-head-sha }}
+          SARIF_OWNER: ${{ steps.decode_repository_context.outputs.source-owner }}
+          SARIF_REF: ${{ steps.decode_repository_context.outputs.source-head-ref }}
+          SARIF_REPO: ${{ steps.decode_repository_context.outputs.source-repo }}
+          SARIF_ROOT: ${{ runner.temp }}/linter-sarifs-decrypted
+        with:
+          github-token: ${{ steps.get_source_token.outputs.token }}
+          script: |
+            const uploadSarif = require(
+              `${process.env.LINTER_SERVICE_PATH}/.github/scripts/upload-sarif.js`,
+            );
+            await uploadSarif({ github, env: process.env });
+
+      - name: Prepare final processing summary
+        id: prepare_final_summary
+        if: ${{ always() }}
+        env:
+          OVERALL_CONCLUSION: ${{ steps.prepare_report.outcome == 'success' && steps.prepare_report.outputs.overall_conclusion || 'failure' }}
+          OVERALL_SUMMARY: ${{ steps.prepare_report.outcome == 'success' && steps.prepare_report.outputs.overall_summary || 'The linter-service workflow failed to generate a combined report.' }}
+          UPLOAD_SARIF_OUTCOME: ${{ steps.upload_sarif.outcome }}
+        run: |
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          overall_conclusion = os.environ["OVERALL_CONCLUSION"]
+          overall_summary = os.environ["OVERALL_SUMMARY"]
+          upload_sarif_outcome = os.environ.get("UPLOAD_SARIF_OUTCOME", "")
+
+          if upload_sarif_outcome == "failure":
+              conclusion = "failure"
+              summary = f"{overall_summary} SARIF upload failed; see the workflow logs."
+          else:
+              conclusion = overall_conclusion
+              summary = overall_summary
+
+          title = (
+              "linter-service completed"
+              if conclusion == "success"
+              else "linter-service found issues"
+          )
+
+          output_path = Path(os.environ["GITHUB_OUTPUT"])
+          with output_path.open("a", encoding="utf-8") as fh:
+              fh.write(f"conclusion={conclusion}\n")
+              fh.write(f"summary={summary}\n")
+              fh.write(f"title={title}\n")
+          PY
+
       - name: Finalize processing check run
         if: ${{ always() }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
-          CHECK_RUN_CONCLUSION: ${{ steps.prepare_report.outcome == 'success' && steps.prepare_report.outputs.overall_conclusion || 'failure' }}
+          CHECK_RUN_CONCLUSION: ${{ steps.prepare_final_summary.outputs.conclusion || 'failure' }}
           CHECK_RUN_EXTERNAL_ID: ${{ steps.decode_repository_context.outputs.processing-check-external-id }}
           CHECK_RUN_HEAD_SHA: ${{ steps.decode_repository_context.outputs.source-head-sha }}
           CHECK_RUN_NAME: ${{ steps.decode_repository_context.outputs.processing-check-name }}
-          CHECK_RUN_OUTPUT_SUMMARY: ${{ steps.prepare_report.outcome == 'success' && steps.prepare_report.outputs.overall_summary || 'The linter-service workflow failed to generate a combined report.' }}
-          CHECK_RUN_OUTPUT_TITLE: ${{ (steps.prepare_report.outcome == 'success' && steps.prepare_report.outputs.overall_conclusion || 'failure') == 'success' && format('{0} completed', steps.decode_repository_context.outputs.processing-check-name) || format('{0} found issues', steps.decode_repository_context.outputs.processing-check-name) }}
+          CHECK_RUN_OUTPUT_SUMMARY: ${{ steps.prepare_final_summary.outputs.summary || 'The linter-service workflow failed to generate a combined report.' }}
+          CHECK_RUN_OUTPUT_TITLE: ${{ steps.prepare_final_summary.outputs.title || 'linter-service found issues' }}
           CHECK_RUN_OWNER: ${{ steps.decode_repository_context.outputs.source-owner }}
           CHECK_RUN_REPO: ${{ steps.decode_repository_context.outputs.source-repo }}
           CHECK_RUN_STATUS: completed
           LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
-          OVERALL_CONCLUSION: ${{ steps.prepare_report.outcome == 'success' && steps.prepare_report.outputs.overall_conclusion || 'failure' }}
-          OVERALL_SUMMARY: ${{ steps.prepare_report.outcome == 'success' && steps.prepare_report.outputs.overall_summary || 'The linter-service workflow failed to generate a combined report.' }}
+          OVERALL_CONCLUSION: ${{ steps.prepare_final_summary.outputs.conclusion || 'failure' }}
+          OVERALL_SUMMARY: ${{ steps.prepare_final_summary.outputs.summary || 'The linter-service workflow failed to generate a combined report.' }}
           PROCESSING_CHECK_EXTERNAL_ID: ${{ steps.decode_repository_context.outputs.processing-check-external-id }}
           PROCESSING_CHECK_NAME: ${{ steps.decode_repository_context.outputs.processing-check-name }}
           SOURCE_HEAD_SHA: ${{ steps.decode_repository_context.outputs.source-head-sha }}
@@ -731,9 +830,9 @@ jobs:
             await upsertCheckRun({ github, env: process.env });
 
       - name: Fail workflow when lint reports issues
-        if: ${{ steps.prepare_report.outputs.overall_conclusion != 'success' }}
+        if: ${{ steps.prepare_final_summary.outputs.conclusion != 'success' }}
         run: |
-          echo "One or more linters reported issues." >&2
+          echo "${{ steps.prepare_final_summary.outputs.summary }}" >&2
           exit 1
 
   no-linters-needed:

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -475,7 +475,7 @@ jobs:
       - detect-targets
       - notify-processing-started
       - run-linters
-    if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' }}
+    if: ${{ always() && needs.detect-targets.outputs.skip-reason == '' }}
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -572,17 +572,18 @@ jobs:
           app-id: ${{ secrets.CHECKER_APP_ID }}
           owner: ${{ steps.decode_repository_context.outputs.pr-owner }}
           permission-pull-requests: write
+          permission-security-events: write
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_repository_context.outputs.pr-repo }}
 
       - name: Get source repository checker token
         id: get_source_token
+        if: ${{ needs.detect-targets.outputs.selected-linters-json != '[]' }}
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ secrets.CHECKER_APP_ID }}
           owner: ${{ steps.decode_repository_context.outputs.source-owner }}
           permission-checks: write
-          permission-security-events: write
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_repository_context.outputs.source-repo }}
 
@@ -640,9 +641,19 @@ jobs:
 
           exit "$failures"
 
+      - name: Prepare deselected SARIF placeholders
+        if: ${{ always() }}
+        env:
+          LINTER_CONFIG_PATH: ${{ github.workspace }}/linter-service/.github/scripts/linters/config.json
+          LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
+          OUTPUT_ROOT: ${{ runner.temp }}/linter-sarifs-decrypted
+          SELECTED_LINTERS_JSON: ${{ needs.detect-targets.outputs.selected-linters-json }}
+        run: |
+          node "$LINTER_SERVICE_PATH/.github/scripts/prepare-deselected-sarif.js"
+
       - name: Prepare combined report
         id: prepare_report
-        if: ${{ always() }}
+        if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' }}
         env:
           DECRYPT_SUMMARIES_OUTCOME: ${{ steps.decrypt_summaries.outcome }}
           LINTER_SUMMARY_PATH: ${{ runner.temp }}/linter-summaries-decrypted
@@ -727,7 +738,7 @@ jobs:
           PY
 
       - name: Upsert combined PR comment
-        if: ${{ always() }}
+        if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           COMMENT_FILE: ${{ runner.temp }}/combined-linter-comment.md
@@ -752,12 +763,12 @@ jobs:
         env:
           LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
           SARIF_HEAD_SHA: ${{ steps.decode_repository_context.outputs.source-head-sha }}
-          SARIF_OWNER: ${{ steps.decode_repository_context.outputs.source-owner }}
-          SARIF_REF: ${{ steps.decode_repository_context.outputs.source-head-ref }}
-          SARIF_REPO: ${{ steps.decode_repository_context.outputs.source-repo }}
+          SARIF_OWNER: ${{ steps.decode_repository_context.outputs.pr-owner }}
+          SARIF_PR_NUMBER: ${{ needs.detect-targets.outputs.pull-request-number }}
+          SARIF_REPO: ${{ steps.decode_repository_context.outputs.pr-repo }}
           SARIF_ROOT: ${{ runner.temp }}/linter-sarifs-decrypted
         with:
-          github-token: ${{ steps.get_source_token.outputs.token }}
+          github-token: ${{ steps.get_pr_token.outputs.token }}
           script: |
             const uploadSarif = require(
               `${process.env.LINTER_SERVICE_PATH}/.github/scripts/upload-sarif.js`,
@@ -766,7 +777,7 @@ jobs:
 
       - name: Prepare final processing summary
         id: prepare_final_summary
-        if: ${{ always() }}
+        if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' }}
         env:
           OVERALL_CONCLUSION: ${{ steps.prepare_report.outcome == 'success' && steps.prepare_report.outputs.overall_conclusion || 'failure' }}
           OVERALL_SUMMARY: ${{ steps.prepare_report.outcome == 'success' && steps.prepare_report.outputs.overall_summary || 'The linter-service workflow failed to generate a combined report.' }}
@@ -780,18 +791,18 @@ jobs:
           overall_summary = os.environ["OVERALL_SUMMARY"]
           upload_sarif_outcome = os.environ.get("UPLOAD_SARIF_OUTCOME", "")
 
-          if upload_sarif_outcome == "failure":
-              conclusion = "failure"
-              summary = f"{overall_summary} SARIF upload failed; see the workflow logs."
-          else:
-              conclusion = overall_conclusion
-              summary = overall_summary
-
+          conclusion = overall_conclusion
+          summary = overall_summary
           title = (
               "linter-service completed"
               if conclusion == "success"
               else "linter-service found issues"
           )
+
+          if upload_sarif_outcome == "failure":
+              summary = f"{overall_summary} Warning: SARIF upload failed; see the workflow logs."
+              if conclusion == "success":
+                  title = "linter-service completed with warnings"
 
           output_path = Path(os.environ["GITHUB_OUTPUT"])
           with output_path.open("a", encoding="utf-8") as fh:
@@ -801,7 +812,7 @@ jobs:
           PY
 
       - name: Finalize processing check run
-        if: ${{ always() }}
+        if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           CHECK_RUN_CONCLUSION: ${{ steps.prepare_final_summary.outputs.conclusion || 'failure' }}
@@ -830,9 +841,17 @@ jobs:
             await upsertCheckRun({ github, env: process.env });
 
       - name: Fail workflow when lint reports issues
-        if: ${{ steps.prepare_final_summary.outputs.conclusion != 'success' }}
+        if: ${{ needs.detect-targets.outputs.selected-linters-json != '[]' && steps.prepare_report.outputs.overall_conclusion != 'success' }}
+        env:
+          SUMMARY: ${{ steps.prepare_final_summary.outputs.summary }}
         run: |
-          echo "${{ steps.prepare_final_summary.outputs.summary }}" >&2
+          echo "$SUMMARY" >&2
+          exit 1
+
+      - name: Fail workflow when deselected SARIF upload fails
+        if: ${{ needs.detect-targets.outputs.selected-linters-json == '[]' && steps.upload_sarif.outcome == 'failure' }}
+        run: |
+          echo "SARIF upload failed while clearing deselected linter results. See the workflow logs." >&2
           exit 1
 
   no-linters-needed:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -8,17 +8,18 @@ rules:
         - CHECKER_APP_ID
         - CHECKER_PRIVATE_KEY
     ignore:
-      - lint-common.yml:44
-      - lint-common.yml:87
-      - lint-common.yml:90
-      - repository-dispatch.yml:122
-      - repository-dispatch.yml:125
-      - repository-dispatch.yml:313
-      - repository-dispatch.yml:363
-      - repository-dispatch.yml:413
-      - repository-dispatch.yml:416
-      - repository-dispatch.yml:494
-      - repository-dispatch.yml:557
-      - repository-dispatch.yml:560
-      - repository-dispatch.yml:567
-      - repository-dispatch.yml:570
+      - lint-common.yml:39
+      - lint-common.yml:78
+      - lint-common.yml:81
+      - repository-dispatch.yml:115
+      - repository-dispatch.yml:118
+      - repository-dispatch.yml:307
+      - repository-dispatch.yml:352
+      - repository-dispatch.yml:398
+      - repository-dispatch.yml:401
+      - repository-dispatch.yml:449
+      - repository-dispatch.yml:474
+      - repository-dispatch.yml:541
+      - repository-dispatch.yml:545
+      - repository-dispatch.yml:552
+      - repository-dispatch.yml:555


### PR DESCRIPTION
## Summary
- add shared SARIF generation and upload support for the shared linter workflows
- enable SARIF for each shared linter with one commit per linter plus dedicated regression tests
- address review findings by uploading against the base-repository PR ref, polling GitHub SARIF processing, clearing deselected-linter SARIF categories, and tightening severity parsing
- add a repo-local `.github/linters.json` override so JS test-file commits use the intended Biome/Oxlint hook pipeline in this repository

## Testing
- `node --test .github/scripts/*.test.js .github/scripts/linters/*.test.js`
