### PR TITLE
fix: format cleanup workflow for yamlfmt

### DIFF
--- a/.github/workflows/cleanup-workflow-runs.yml
+++ b/.github/workflows/cleanup-workflow-runs.yml
@@ -1,16 +1,12 @@
 name: Cleanup Workflow Runs
-
 on:
   workflow_dispatch:
   schedule:
     - cron: '17 */6 * * *'
-
 concurrency:
   group: ${{ format('cleanup-workflow-runs-{0}', github.repository) }}
   cancel-in-progress: false
-
 permissions: {}
-
 jobs:
   cleanup:
     permissions:
@@ -23,7 +19,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-
       - name: Delete workflow runs older than 24 hours
         id: cleanup_runs
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7


### PR DESCRIPTION
## Summary
- format `.github/workflows/cleanup-workflow-runs.yml` to match the repository yamlfmt output
- keep the cleanup workflow behavior unchanged

## Validation
- repo yamlfmt lint for `.github/workflows/cleanup-workflow-runs.yml`
- `node --test .github/scripts/cleanup-workflow-runs.test.js`
- `git diff --check`