### PR TITLE
fix: format ci workflow for yamlfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,11 @@
 name: CI
-
 on:
   pull_request:
   push:
     branches:
       - main
-
 permissions:
   contents: read
-
 jobs:
   validate-worker:
     runs-on: ubuntu-latest
@@ -18,18 +15,15 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           cache: npm
           cache-dependency-path: worker/package-lock.json
           node-version: 24
-
       - name: Install worker dependencies
         working-directory: worker
         run: npm ci
-
       - name: Run worker validation
         working-directory: worker
         run: npm run check


### PR DESCRIPTION
## Summary
- format `.github/workflows/ci.yml` to match the repository yamlfmt output
- keep the CI workflow behavior unchanged

## Validation
- repo yamlfmt lint for `.github/workflows/ci.yml`
- `git diff --check`