### PR TITLE
fix: correct cargo-deny SARIF locations

### DIFF
--- a/.github/scripts/render-linter-sarif.cargo-deny.test.js
+++ b/.github/scripts/render-linter-sarif.cargo-deny.test.js
@@ -57,3 +57,79 @@ test("emits SARIF for cargo-deny diagnostics", () => {
 		cleanupTempRepo(context.tempDir);
 	}
 });
+
+test("maps cargo-deny snippet diagnostics from the temp workspace back to deny.toml", () => {
+	const context = makeTempRepo("render-linter-sarif-cargo-deny-snippet-");
+	const copiedSourceRoot = path.join(
+		context.runnerTemp,
+		"cargo-deny-workspace/source",
+	);
+	const copiedDenyPath = path.join(copiedSourceRoot, "deny.toml");
+	const snippetDetails = [
+		`error[rejected]: failed to parse config from ${copiedDenyPath}`,
+		"",
+		`  ┌─ ${copiedDenyPath}:5:9`,
+		"  │",
+		'5 │ allow = ["MIT" "Apache-2.0"]',
+		"  │         ^ missing comma",
+	].join("\n");
+
+	writeFile(
+		path.join(context.repoDir, "Cargo.toml"),
+		'[package]\nname = "demo"\nversion = "0.1.0"\nedition = "2021"\n',
+	);
+	writeFile(
+		path.join(context.repoDir, "deny.toml"),
+		[
+			"[licenses]",
+			"version = 2",
+			"unused = true",
+			"exceptions = []",
+			'allow = ["MIT", "Apache-2.0"]',
+			"",
+		].join("\n"),
+	);
+	writeFile(path.join(context.runnerTemp, "selected-files.txt"), "deny.toml\n");
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details: snippetDetails,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "cargo-deny",
+			OUTPUT_PATH: path.join(context.runnerTemp, "cargo-deny.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.equal(report.sarif.runs[0].results.length, 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"deny.toml",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			5,
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startColumn,
+			9,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/.github/scripts/render-linter-sarif.js
+++ b/.github/scripts/render-linter-sarif.js
@@ -19,6 +19,7 @@ function runFromEnv(env = process.env) {
 			env.OUTPUT_PATH ||
 			path.join(runnerTemp, `linter-sarif-${linterName}.sarif`),
 		resultPath: requireEnv(env, "RESULT_PATH"),
+		runnerTemp,
 		runOutcome: env.RUN_LINTER_OUTCOME ?? "",
 		selectedFilesPath: requireEnv(env, "SELECTED_FILES_PATH"),
 		selectOutcome: env.SELECT_FILES_OUTCOME ?? "",
@@ -42,6 +43,7 @@ function renderSarif({
 	linterName,
 	outputPath,
 	resultPath,
+	runnerTemp,
 	runOutcome,
 	selectedFilesPath,
 	selectOutcome,
@@ -74,6 +76,11 @@ function renderSarif({
 		result,
 		linterConfig.details_fallback,
 	);
+	const reportedPathRoots = buildReportedPathRoots({
+		linterName,
+		runnerTemp,
+		sourceRepositoryPath,
+	});
 	const results =
 		result.exit_code === 0
 			? []
@@ -81,6 +88,7 @@ function renderSarif({
 					defaultLevel: sarifConfig.default_level || "warning",
 					details,
 					linterName,
+					reportedPathRoots,
 					sourceRepositoryPath,
 					targetPaths,
 				});
@@ -204,10 +212,25 @@ function collectSarifTargetPaths({
 	return selectedFiles;
 }
 
+function buildReportedPathRoots({
+	linterName,
+	runnerTemp,
+	sourceRepositoryPath,
+}) {
+	const roots = [path.resolve(sourceRepositoryPath)];
+
+	if (typeof runnerTemp === "string" && runnerTemp.length > 0) {
+		roots.push(path.resolve(runnerTemp, `${linterName}-workspace/source`));
+	}
+
+	return [...new Set(roots)];
+}
+
 function buildSarifResults({
 	defaultLevel,
 	details,
 	linterName,
+	reportedPathRoots,
 	sourceRepositoryPath,
 	targetPaths,
 }) {
@@ -216,6 +239,7 @@ function buildSarifResults({
 			defaultLevel,
 			details,
 			linterName,
+			reportedPathRoots,
 			sourceRepositoryPath,
 			targetPaths,
 		}),
@@ -223,6 +247,15 @@ function buildSarifResults({
 			defaultLevel,
 			details,
 			linterName,
+			reportedPathRoots,
+			sourceRepositoryPath,
+			targetPaths,
+		}),
+		...parseSnippetStyleDiagnostics({
+			defaultLevel,
+			details,
+			linterName,
+			reportedPathRoots,
 			sourceRepositoryPath,
 			targetPaths,
 		}),
@@ -230,6 +263,7 @@ function buildSarifResults({
 			defaultLevel,
 			details,
 			linterName,
+			reportedPathRoots,
 			sourceRepositoryPath,
 			targetPaths,
 		}),
@@ -243,6 +277,7 @@ function buildSarifResults({
 		defaultLevel,
 		details,
 		linterName,
+		reportedPathRoots,
 		sourceRepositoryPath,
 		targetPaths,
 	});
@@ -252,6 +287,7 @@ function parsePathDiagnostics({
 	defaultLevel,
 	details,
 	linterName,
+	reportedPathRoots,
 	sourceRepositoryPath,
 	targetPaths,
 }) {
@@ -280,6 +316,7 @@ function parsePathDiagnostics({
 				sourceRepositoryPath,
 				match.groups.path,
 				targetPaths,
+				reportedPathRoots,
 			);
 
 			if (!filePath) {
@@ -311,6 +348,7 @@ function parseRustStyleDiagnostics({
 	defaultLevel,
 	details,
 	linterName,
+	reportedPathRoots,
 	sourceRepositoryPath,
 	targetPaths,
 }) {
@@ -340,6 +378,67 @@ function parseRustStyleDiagnostics({
 			sourceRepositoryPath,
 			match.groups.path,
 			targetPaths,
+			reportedPathRoots,
+		);
+
+		if (!filePath) {
+			continue;
+		}
+
+		results.push(
+			createResult({
+				column: parseInteger(match.groups.column),
+				defaultLevel,
+				filePath,
+				line: parseInteger(match.groups.line),
+				linterName,
+				message: currentMessage || summarizeDetails(details, linterName),
+				ruleId:
+					extractRuleId(currentMessage, linterName) ||
+					`${linterName}/diagnostic`,
+			}),
+		);
+	}
+
+	return results;
+}
+
+function parseSnippetStyleDiagnostics({
+	defaultLevel,
+	details,
+	linterName,
+	reportedPathRoots,
+	sourceRepositoryPath,
+	targetPaths,
+}) {
+	let currentMessage = "";
+	const results = [];
+
+	for (const rawLine of details.split(/\r?\n/u)) {
+		const line = rawLine.trim();
+
+		if (/^(error|warning|note)(\[[^\]]+\])?:/iu.test(line)) {
+			currentMessage = line.replace(
+				/^(error|warning|note)(\[[^\]]+\])?:\s*/iu,
+				"",
+			);
+			continue;
+		}
+
+		const match =
+			/^\s*[│|]?\s*[┌╭]─\s+(?<path>.+?):(?<line>\d+):(?<column>\d+)/u.exec(
+				rawLine,
+			);
+
+		if (!match?.groups) {
+			continue;
+		}
+
+		const filePath = normalizeReportedPath(
+			sourceRepositoryPath,
+			match.groups.path,
+			targetPaths,
+			reportedPathRoots,
 		);
 
 		if (!filePath) {
@@ -368,6 +467,7 @@ function parseShellcheckStyleDiagnostics({
 	defaultLevel,
 	details,
 	linterName,
+	reportedPathRoots,
 	sourceRepositoryPath,
 	targetPaths,
 }) {
@@ -387,6 +487,7 @@ function parseShellcheckStyleDiagnostics({
 			sourceRepositoryPath,
 			match.groups.path,
 			targetPaths,
+			reportedPathRoots,
 		);
 
 		if (!filePath) {
@@ -431,6 +532,7 @@ function buildFallbackResults({
 	defaultLevel,
 	details,
 	linterName,
+	reportedPathRoots,
 	sourceRepositoryPath,
 	targetPaths,
 }) {
@@ -452,7 +554,12 @@ function buildFallbackResults({
 				defaultLevel,
 				filePath:
 					filePath &&
-					normalizeReportedPath(sourceRepositoryPath, filePath, targetPaths),
+					normalizeReportedPath(
+						sourceRepositoryPath,
+						filePath,
+						targetPaths,
+						reportedPathRoots,
+					),
 				linterName,
 				message: summaryMessage,
 				ruleId:
@@ -642,7 +749,12 @@ function normalizeReportedPath(
 	sourceRepositoryPath,
 	reportedPath,
 	targetPaths,
+	reportedPathRoots = [],
 ) {
+	const absolutePathRoots =
+		reportedPathRoots.length > 0
+			? reportedPathRoots
+			: [path.resolve(sourceRepositoryPath)];
 	const normalized = normalizePath(String(reportedPath || "").trim()).replace(
 		/^\.\//u,
 		"",
@@ -662,13 +774,17 @@ function normalizeReportedPath(
 	}
 
 	if (path.isAbsolute(reportedPath)) {
-		const relative = path.relative(
-			path.resolve(sourceRepositoryPath),
-			reportedPath,
-		);
+		for (const rootPath of absolutePathRoots) {
+			const relative = path.relative(rootPath, reportedPath);
+			const repoResolved = path.resolve(sourceRepositoryPath, relative);
 
-		if (!relative.startsWith("..") && !path.isAbsolute(relative)) {
-			return normalizePath(relative);
+			if (
+				!relative.startsWith("..") &&
+				!path.isAbsolute(relative) &&
+				fs.existsSync(repoResolved)
+			) {
+				return normalizePath(relative);
+			}
 		}
 	}
 

--- a/.github/scripts/render-linter-sarif.test.js
+++ b/.github/scripts/render-linter-sarif.test.js
@@ -8,7 +8,11 @@ const {
 	makeTempRepo,
 	writeFile,
 } = require("./linters/cargo-linter-test-lib.js");
-const { renderSarif, runFromEnv } = require("./render-linter-sarif.js");
+const {
+	normalizeReportedPath,
+	renderSarif,
+	runFromEnv,
+} = require("./render-linter-sarif.js");
 
 test("does not emit SARIF when the linter has no SARIF config", () => {
 	const context = makeTempRepo("render-linter-sarif-disabled-");
@@ -229,6 +233,28 @@ test("parses file line and column diagnostics into SARIF results", () => {
 				.startColumn,
 			3,
 		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("does not remap temp-worktree absolute paths for generated files missing from the repository", () => {
+	const context = makeTempRepo("render-linter-sarif-temp-worktree-path-");
+
+	writeFile(path.join(context.repoDir, "src/lib.rs"), "pub fn demo() {}\n");
+
+	try {
+		const resolved = normalizeReportedPath(
+			context.repoDir,
+			path.join(
+				context.runnerTemp,
+				"cargo-clippy-workspace/source/target/debug/build/demo/out/generated.rs",
+			),
+			["src/lib.rs"],
+			[path.join(context.runnerTemp, "cargo-clippy-workspace/source")],
+		);
+
+		assert.equal(resolved, null);
 	} finally {
 		cleanupTempRepo(context.tempDir);
 	}


### PR DESCRIPTION
## Summary
- parse cargo-deny snippet-style diagnostics into SARIF line and column locations
- remap temp-worktree absolute paths back to repository files only when the repo path actually exists
- add regression coverage for cargo-deny temp-worktree locations and generated-file remapping

## Validation
- `node --test .github/scripts/*.test.js .github/scripts/linters/*.test.js`
- `git diff --check`