### PR TITLE
fix(yamlfmt): add SARIF line locations

### DIFF
--- a/.github/scripts/linters/yamlfmt.sh
+++ b/.github/scripts/linters/yamlfmt.sh
@@ -19,6 +19,65 @@ yamlfmt_find_config() {
   return 1
 }
 
+yamlfmt_first_difference_line() {
+  local original_path=$1
+  local formatted_path=$2
+  local line_number
+
+  line_number=$(
+    diff -U0 "$original_path" "$formatted_path" 2>/dev/null |
+      sed -n 's/^@@ -\([0-9]\+\)\(,[0-9]\+\)\? +[0-9]\+\(,[0-9]\+\)\? @@.*/\1/p' |
+      head -n 1
+  )
+
+  if [ -z "$line_number" ] || [ "$line_number" -le 0 ]; then
+    printf '1\n'
+    return 0
+  fi
+
+  printf '%s\n' "$line_number"
+}
+
+yamlfmt_collect_line_summaries() {
+  local yamlfmt_config=$1
+  shift
+
+  local scratch_dir="$RUNNER_TEMP/yamlfmt-line-summaries"
+  local selected_path formatted_copy copy_path display_path line_number
+
+  rm -rf "$scratch_dir"
+  mkdir -p "$scratch_dir"
+
+  for selected_path in "$@"; do
+    if [ ! -f "$selected_path" ]; then
+      continue
+    fi
+
+    display_path="${selected_path#./}"
+    copy_path="$display_path"
+    if [ "${selected_path#/}" != "$selected_path" ]; then
+      copy_path="absolute/${selected_path#/}"
+    fi
+
+    formatted_copy="$scratch_dir/$copy_path"
+    mkdir -p "$(dirname "$formatted_copy")"
+    cp "$selected_path" "$formatted_copy"
+
+    if ! yamlfmt -conf "$yamlfmt_config" "$formatted_copy" >/dev/null 2>&1; then
+      continue
+    fi
+
+    if cmp -s "$selected_path" "$formatted_copy"; then
+      continue
+    fi
+
+    line_number=$(yamlfmt_first_difference_line "$selected_path" "$formatted_copy")
+    printf '%s:%s: yamlfmt would reformat this file\n' "$display_path" "$line_number"
+  done
+
+  rm -rf "$scratch_dir"
+}
+
 mode=${1-}
 if [ "$#" -gt 0 ]; then
   shift
@@ -57,6 +116,8 @@ EOF
   run)
     : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
     output_file="$RUNNER_TEMP/linter-output.txt"
+    enriched_output_file="$RUNNER_TEMP/yamlfmt-output-enriched.txt"
+    summary_file="$RUNNER_TEMP/yamlfmt-line-summary.txt"
     yamlfmt_config=""
 
     if ! yamlfmt_config="$(yamlfmt_find_config)"; then
@@ -67,12 +128,28 @@ formatter:
 EOF
     fi
 
-    linter_lib::run_and_emit_json \
-      "$output_file" \
-      yamlfmt \
+    set +e
+    yamlfmt \
       -lint \
       -conf "$yamlfmt_config" \
-      "$@"
+      "$@" >"$output_file" 2>&1
+    exit_code=$?
+    set -e
+
+    if [ "$exit_code" -ne 0 ]; then
+      yamlfmt_collect_line_summaries "$yamlfmt_config" "$@" > "$summary_file"
+      if [ -s "$summary_file" ]; then
+        cat "$summary_file" > "$enriched_output_file"
+        if [ -s "$output_file" ]; then
+          printf '\n' >> "$enriched_output_file"
+          cat "$output_file" >> "$enriched_output_file"
+        fi
+        mv "$enriched_output_file" "$output_file"
+      fi
+      rm -f "$summary_file" "$enriched_output_file"
+    fi
+
+    linter_lib::emit_json_result "$exit_code" "$output_file"
     ;;
   *)
     echo "usage: $0 {patterns|install|run}" >&2

--- a/.github/scripts/linters/yamlfmt.test.js
+++ b/.github/scripts/linters/yamlfmt.test.js
@@ -93,7 +93,26 @@ if [ "\${1-}" = "-version" ]; then
   echo "yamlfmt version 0.0.0"
   exit 0
 fi
-printf '%s\\n' "$*" >> "$YAMLFMT_ARGS_LOG"
+lint_mode=0
+if [ "\${1-}" = "-lint" ]; then
+  lint_mode=1
+fi
+if [ "$lint_mode" -eq 1 ]; then
+  printf '%s\\n' "$*" >> "$YAMLFMT_ARGS_LOG"
+fi
+if [ "$lint_mode" -eq 0 ]; then
+  for arg in "$@"; do
+    if [ -f "$arg" ]; then
+      node - "$arg" <<'NODE'
+const fs = require("node:fs");
+const filePath = process.argv[2];
+const content = fs.readFileSync(filePath, "utf8");
+fs.writeFileSync(filePath, content.replace(/:  /g, ": "), "utf8");
+NODE
+    fi
+  done
+  exit 0
+fi
 printf 'linted %s\\n' "$*"
 for arg in "$@"; do
   if [ -n "\${FAIL_TARGET:-}" ] && [ "$arg" = "$FAIL_TARGET" ]; then
@@ -247,7 +266,20 @@ test("yamlfmt.sh reports yamlfmt failures for selected files", () => {
 		"formatter:\n  type: basic\n",
 	);
 	writeFile(path.join(context.repoDir, "valid.yaml"), "foo: bar\n");
-	writeFile(path.join(context.repoDir, "needs-format.yml"), "bar: baz\n");
+	writeFile(
+		path.join(context.repoDir, "needs-format.yml"),
+		[
+			"service:",
+			"  name: demo",
+			"  metadata:",
+			"    owner: platform",
+			"    labels:",
+			"      env: dev",
+			"      team:  core",
+			"  enabled: true",
+			"",
+		].join("\n"),
+	);
 
 	try {
 		const output = execFileSync(
@@ -268,6 +300,10 @@ test("yamlfmt.sh reports yamlfmt failures for selected files", () => {
 		assert.equal(
 			fs.readFileSync(argsLog, "utf8").trim(),
 			"-lint -conf .yamlfmt.yml valid.yaml needs-format.yml",
+		);
+		assert.match(
+			result.details,
+			/needs-format\.yml:7: yamlfmt would reformat this file/,
 		);
 		assert.match(result.details, /issue in needs-format\.yml/);
 	} finally {

--- a/.github/scripts/render-linter-sarif.yamlfmt.test.js
+++ b/.github/scripts/render-linter-sarif.yamlfmt.test.js
@@ -10,12 +10,24 @@ const {
 const { runFromEnv } = require("./render-linter-sarif.js");
 
 const configPath = path.join(__dirname, "linters/config.json");
-const details = "config.yaml is not properly formatted";
+const details = "config.yaml:7: yamlfmt would reformat this file";
 
 test("emits SARIF for yamlfmt diagnostics", () => {
 	const context = makeTempRepo("render-linter-sarif-yamlfmt-");
 
-	writeFile(path.join(context.repoDir, "config.yaml"), "a:  b\n");
+	writeFile(
+		path.join(context.repoDir, "config.yaml"),
+		[
+			"service:",
+			"  name: demo",
+			"  metadata:",
+			"    owner: platform",
+			"    labels:",
+			"      env: dev",
+			"      team:  core",
+			"",
+		].join("\n"),
+	);
 	writeFile(
 		path.join(context.runnerTemp, "selected-files.txt"),
 		"config.yaml\n",
@@ -48,6 +60,11 @@ test("emits SARIF for yamlfmt diagnostics", () => {
 			report.sarif.runs[0].results[0].locations[0].physicalLocation
 				.artifactLocation.uri,
 			"config.yaml",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			7,
 		);
 	} finally {
 		cleanupTempRepo(context.tempDir);


### PR DESCRIPTION
## Summary
- compute the first changed line for yamlfmt failures from a formatted temp copy
- prepend `path:line:` summaries so the existing SARIF parser records actionable locations
- add multiline regression coverage for the wrapper and SARIF rendering
