### PR TITLE
fix(cargo-deny): use structured output for SARIF

### DIFF
--- a/.github/scripts/cargo-deny-result.js
+++ b/.github/scripts/cargo-deny-result.js
@@ -1,0 +1,280 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ADVISORY_WARNING_KINDS = new Set(["notice", "unmaintained", "unsound"]);
+
+function parseJsonLines(text) {
+	const items = [];
+	const rawLines = [];
+
+	for (const rawLine of String(text || "").split(/\r?\n/u)) {
+		const line = rawLine.trim();
+
+		if (line.length === 0) {
+			continue;
+		}
+
+		try {
+			items.push(JSON.parse(line));
+		} catch {
+			rawLines.push(rawLine);
+		}
+	}
+
+	return { items, rawLines };
+}
+
+function isCargoDenyAdvisoryLikeDiagnostic(diagnostic) {
+	const fields = diagnostic?.fields;
+	const code =
+		fields && typeof fields.code === "string" ? fields.code.toLowerCase() : "";
+
+	return (
+		Boolean(fields?.advisory) ||
+		code === "vulnerability" ||
+		ADVISORY_WARNING_KINDS.has(code)
+	);
+}
+
+function isCargoDenyConfigLikeDiagnostic(diagnostic) {
+	const fields = diagnostic?.fields;
+	const code =
+		fields && typeof fields.code === "string" ? fields.code.toLowerCase() : "";
+	const notes = Array.isArray(fields?.notes) ? fields.notes : [];
+	const haystack = [fields?.message, code, ...notes].join("\n");
+
+	return /config|deny\.toml|failed to parse/i.test(haystack);
+}
+
+function guessCargoDenyDisplayPath(run, diagnostic) {
+	if (run.config_path && isCargoDenyConfigLikeDiagnostic(diagnostic)) {
+		return run.config_path;
+	}
+
+	return run.manifest_path || run.config_path || "";
+}
+
+function formatCargoDenyAuditReport(report) {
+	const lines = [];
+	const vulnerabilities = Array.isArray(report?.vulnerabilities)
+		? report.vulnerabilities
+		: [];
+	const warnings =
+		report && typeof report.warnings === "object" && report.warnings
+			? report.warnings
+			: {};
+
+	for (const entry of vulnerabilities) {
+		const advisory = entry?.advisory || {};
+		const packageInfo = entry?.package || {};
+		const title = advisory.title || advisory.id || "cargo-deny advisory";
+		const id = advisory.id || "vulnerability";
+		const packageLabel = [packageInfo.name, packageInfo.version]
+			.filter(Boolean)
+			.join(" ");
+
+		lines.push(
+			`error[${id}]: ${packageLabel ? `${packageLabel} - ` : ""}${title}`,
+		);
+	}
+
+	for (const kind of Object.keys(warnings).sort()) {
+		for (const entry of Array.isArray(warnings[kind]) ? warnings[kind] : []) {
+			const advisory = entry?.advisory || {};
+			const packageInfo = entry?.package || {};
+			const title = advisory.title || advisory.id || kind;
+			const id = advisory.id || kind;
+			const packageLabel = [packageInfo.name, packageInfo.version]
+				.filter(Boolean)
+				.join(" ");
+
+			lines.push(
+				`warning[${id}]: ${packageLabel ? `${packageLabel} - ` : ""}${title}`,
+			);
+		}
+	}
+
+	return lines;
+}
+
+function formatCargoDenyDiagnostic(run, diagnostic) {
+	const fields = diagnostic?.fields || {};
+	const severity =
+		typeof fields.severity === "string" && fields.severity.length > 0
+			? fields.severity.toLowerCase()
+			: "error";
+	const code =
+		typeof fields.code === "string" && fields.code.length > 0
+			? `[${fields.code}]`
+			: "";
+	const message =
+		typeof fields.message === "string" && fields.message.length > 0
+			? fields.message
+			: "cargo-deny reported an issue";
+	const labels = Array.isArray(fields.labels) ? fields.labels : [];
+	const notes = Array.isArray(fields.notes) ? fields.notes : [];
+	const displayPath = guessCargoDenyDisplayPath(run, diagnostic);
+	const lines = [`${severity}${code}: ${message}`];
+
+	for (const label of labels) {
+		const line = Number.isInteger(label?.line) ? label.line : 1;
+		const column = Number.isInteger(label?.column) ? label.column : 1;
+		const labelMessage =
+			typeof label?.message === "string" && label.message.length > 0
+				? label.message
+				: typeof label?.span === "string" && label.span.length > 0
+					? label.span
+					: message;
+
+		if (displayPath) {
+			lines.push(`${displayPath}:${line}:${column}: ${labelMessage}`);
+		} else {
+			lines.push(labelMessage);
+		}
+	}
+
+	for (const note of notes) {
+		lines.push(`note: ${note}`);
+	}
+
+	return lines;
+}
+
+function normalizeCargoDenyRun(run) {
+	const stdoutText = String(run?.stdout || "");
+	const stderrText = String(run?.stderr || "");
+	const stdoutParsed = parseJsonLines(stdoutText);
+	const stderrParsed = parseJsonLines(stderrText);
+
+	return {
+		command: String(run?.command || "").trim(),
+		manifest_path: String(run?.manifest_path || "").trim(),
+		config_path: String(run?.config_path || "").trim() || null,
+		exit_code: Number.isInteger(run?.exit_code)
+			? run.exit_code
+			: Number.parseInt(String(run?.exit_code || "0"), 10) || 0,
+		audit_reports: stdoutParsed.items.filter(
+			(item) => item && typeof item === "object",
+		),
+		diagnostics: stderrParsed.items.filter(
+			(item) => item && item.type === "diagnostic" && item.fields,
+		),
+		stdout_raw_lines: stdoutParsed.rawLines,
+		stderr_raw_lines: stderrParsed.rawLines,
+	};
+}
+
+function renderCargoDenyRunDetails(run) {
+	const lines = [];
+
+	if (run.command) {
+		lines.push(`==> ${run.command}`);
+	}
+
+	const auditLines = run.audit_reports.flatMap(formatCargoDenyAuditReport);
+	const filteredDiagnostics =
+		run.audit_reports.length > 0
+			? run.diagnostics.filter(
+					(diagnostic) => !isCargoDenyAdvisoryLikeDiagnostic(diagnostic),
+				)
+			: run.diagnostics;
+
+	for (const line of auditLines) {
+		lines.push(line);
+	}
+
+	for (const diagnostic of filteredDiagnostics) {
+		lines.push(...formatCargoDenyDiagnostic(run, diagnostic));
+	}
+
+	for (const rawLine of [...run.stdout_raw_lines, ...run.stderr_raw_lines]) {
+		lines.push(rawLine);
+	}
+
+	return lines;
+}
+
+function readTextFile(filePath) {
+	if (!fs.existsSync(filePath)) {
+		return "";
+	}
+
+	return fs.readFileSync(filePath, "utf8");
+}
+
+function readCargoDenyRunEntries(entriesDir) {
+	const entryNames = fs
+		.readdirSync(entriesDir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.sort();
+
+	return entryNames.map((entryName) => {
+		const entryDir = path.join(entriesDir, entryName);
+
+		return {
+			command: readTextFile(path.join(entryDir, "command.txt")).trim(),
+			config_path: readTextFile(path.join(entryDir, "config_path.txt")).trim(),
+			exit_code: readTextFile(path.join(entryDir, "exit_code.txt")).trim(),
+			manifest_path: readTextFile(
+				path.join(entryDir, "manifest_path.txt"),
+			).trim(),
+			stderr: readTextFile(path.join(entryDir, "stderr.txt")),
+			stdout: readTextFile(path.join(entryDir, "stdout.txt")),
+		};
+	});
+}
+
+function buildCargoDenyResult({ entriesDir, exitCode, runs = null }) {
+	const normalizedRuns = (runs || readCargoDenyRunEntries(entriesDir)).map(
+		normalizeCargoDenyRun,
+	);
+	const details = normalizedRuns
+		.flatMap((run) => [...renderCargoDenyRunDetails(run), ""])
+		.join("\n")
+		.trim();
+
+	return {
+		cargo_deny_runs: normalizedRuns.map(
+			({
+				command,
+				manifest_path,
+				config_path,
+				exit_code: runExitCode,
+				audit_reports,
+				diagnostics,
+			}) => ({
+				command,
+				manifest_path,
+				config_path,
+				exit_code: runExitCode,
+				audit_reports,
+				diagnostics,
+			}),
+		),
+		details,
+		exit_code: Number.parseInt(String(exitCode), 10) || 0,
+	};
+}
+
+if (require.main === module) {
+	const [entriesDir, exitCodeRaw] = process.argv.slice(2);
+
+	if (!entriesDir || typeof exitCodeRaw !== "string") {
+		throw new Error("usage: cargo-deny-result.js <entries-dir> <exit-code>");
+	}
+
+	process.stdout.write(
+		`${JSON.stringify(
+			buildCargoDenyResult({ entriesDir, exitCode: exitCodeRaw }),
+		)}\n`,
+	);
+}
+
+module.exports = {
+	buildCargoDenyResult,
+	guessCargoDenyDisplayPath,
+	isCargoDenyAdvisoryLikeDiagnostic,
+	isCargoDenyConfigLikeDiagnostic,
+	parseJsonLines,
+};

--- a/.github/scripts/cargo-deny-result.test.js
+++ b/.github/scripts/cargo-deny-result.test.js
@@ -1,0 +1,70 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { buildCargoDenyResult } = require("./cargo-deny-result.js");
+
+test("buildCargoDenyResult renders advisory and config diagnostics from structured output", () => {
+	const result = buildCargoDenyResult({
+		exitCode: 1,
+		runs: [
+			{
+				command:
+					"cargo-deny --format json --color never --log-level warn --all-features --manifest-path Cargo.toml check --audit-compatible-output --config deny.toml",
+				config_path: "deny.toml",
+				exit_code: 1,
+				manifest_path: "Cargo.toml",
+				stderr: [
+					JSON.stringify({
+						type: "diagnostic",
+						fields: {
+							code: "rejected",
+							labels: [
+								{
+									column: 9,
+									line: 5,
+									message: "missing comma",
+									span: 'allow = ["MIT" "Apache-2.0"]',
+								},
+							],
+							message: "failed to parse config",
+							notes: [],
+							severity: "error",
+						},
+					}),
+				].join("\n"),
+				stdout: JSON.stringify({
+					lockfile: { "dependency-count": 1 },
+					settings: {},
+					vulnerabilities: [
+						{
+							advisory: {
+								id: "RUSTSEC-2024-0001",
+								title: "Critical vulnerability",
+							},
+							package: {
+								name: "demo",
+								version: "0.1.0",
+							},
+						},
+					],
+					warnings: {},
+				}),
+			},
+		],
+	});
+
+	assert.equal(result.exit_code, 1);
+	assert.equal(result.cargo_deny_runs.length, 1);
+	assert.equal(result.cargo_deny_runs[0].audit_reports.length, 1);
+	assert.equal(result.cargo_deny_runs[0].diagnostics.length, 1);
+	assert.match(
+		result.details,
+		/==> cargo-deny --format json --color never --log-level warn --all-features --manifest-path Cargo\.toml check --audit-compatible-output --config deny\.toml/,
+	);
+	assert.match(
+		result.details,
+		/error\[RUSTSEC-2024-0001\]: demo 0\.1\.0 - Critical vulnerability/,
+	);
+	assert.match(result.details, /error\[rejected\]: failed to parse config/);
+	assert.match(result.details, /deny\.toml:5:9: missing comma/);
+});

--- a/.github/scripts/linters/cargo-deny.sh
+++ b/.github/scripts/linters/cargo-deny.sh
@@ -210,7 +210,9 @@ EOF
     : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
     cargo_deny_prepare_env
     output_file="$RUNNER_TEMP/linter-output.txt"
+    result_json_file="$RUNNER_TEMP/cargo-deny-result.json"
     manifest_list_file="$RUNNER_TEMP/cargo-deny-manifests.txt"
+    run_entries_dir="$RUNNER_TEMP/cargo-deny-runs"
     manifests=()
     relevant_dirs=()
     unsupported_config=""
@@ -246,41 +248,70 @@ EOF
 
     run_cargo_deny() {
       local failure=0
-      local current_manifest config_path
+      local current_manifest config_path command_line run_dir run_exit
+      local run_index=0
 
       cd "$source_root"
       export HOME="$CARGO_HOME"
+      rm -rf "$run_entries_dir"
+      mkdir -p "$run_entries_dir"
 
       for current_manifest in "${manifests[@]}"; do
+        run_index=$((run_index + 1))
+        run_dir=$(printf '%s/%04d' "$run_entries_dir" "$run_index")
+        mkdir -p "$run_dir"
+        config_path=""
+
         if config_path=$(cargo_deny_find_config "$current_manifest"); then
-          printf '==> cargo-deny --color never --log-level warn --all-features --manifest-path %s check --config %s\n' "$current_manifest" "$config_path"
-          if ! cargo-deny \
+          command_line="cargo-deny --format json --color never --log-level warn --all-features --manifest-path $current_manifest check --audit-compatible-output --config $config_path"
+          set +e
+          cargo-deny \
+            --format json \
             --color never \
             --log-level warn \
             --all-features \
             --manifest-path "$current_manifest" \
             check \
-            --config "$config_path"; then
-            failure=1
-          fi
+            --audit-compatible-output \
+            --config "$config_path" >"$run_dir/stdout.txt" 2>"$run_dir/stderr.txt"
+          run_exit=$?
+          set -e
         else
-          printf '==> cargo-deny --color never --log-level warn --all-features --manifest-path %s check\n' "$current_manifest"
-          if ! cargo-deny \
+          command_line="cargo-deny --format json --color never --log-level warn --all-features --manifest-path $current_manifest check --audit-compatible-output"
+          set +e
+          cargo-deny \
+            --format json \
             --color never \
             --log-level warn \
             --all-features \
             --manifest-path "$current_manifest" \
-            check; then
-            failure=1
-          fi
+            check \
+            --audit-compatible-output >"$run_dir/stdout.txt" 2>"$run_dir/stderr.txt"
+          run_exit=$?
+          set -e
         fi
-        echo
+
+        printf '%s\n' "$command_line" > "$run_dir/command.txt"
+        printf '%s\n' "$current_manifest" > "$run_dir/manifest_path.txt"
+        printf '%s\n' "$config_path" > "$run_dir/config_path.txt"
+        printf '%s\n' "$run_exit" > "$run_dir/exit_code.txt"
+
+        if [ "$run_exit" -ne 0 ]; then
+          failure=1
+        fi
       done
 
       return "$failure"
     }
 
-    linter_lib::run_and_emit_json "$output_file" run_cargo_deny
+    if run_cargo_deny; then
+      exit_code=0
+    else
+      exit_code=1
+    fi
+
+    node "$script_dir/../cargo-deny-result.js" "$run_entries_dir" "$exit_code" > "$result_json_file"
+    cat "$result_json_file"
     ;;
   *)
     echo "usage: $0 {patterns|install|run}" >&2

--- a/.github/scripts/linters/cargo-deny.test.js
+++ b/.github/scripts/linters/cargo-deny.test.js
@@ -134,15 +134,25 @@ if [ "\${1-}" = "--version" ]; then
   exit 0
 fi
 manifest=""
+config=""
+audit_mode=0
 args=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --manifest-path|--config)
+    --manifest-path|--config|--format)
       if [ "$1" = "--manifest-path" ]; then
         manifest="$2"
       fi
+      if [ "$1" = "--config" ]; then
+        config="$2"
+      fi
       args+=("$1" "$2")
       shift 2
+      ;;
+    --audit-compatible-output)
+      audit_mode=1
+      args+=("$1")
+      shift
       ;;
     *)
       args+=("$1")
@@ -151,11 +161,69 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 printf '%s\\n' "\${args[*]}" >> "$CARGO_DENY_ARGS_LOG"
-printf 'checked %s\\n' "$manifest"
+if [ "$audit_mode" -eq 1 ] && {
+  [ -n "\${AUDIT_REPORT_MANIFEST:-}" ] && [ "$manifest" = "$AUDIT_REPORT_MANIFEST" ] || \
+  [ -n "\${FAIL_MANIFEST:-}" ] && [ "$manifest" = "$FAIL_MANIFEST" ];
+}; then
+  node - "$manifest" <<'NODE'
+const manifest = process.argv[2];
+const packageName =
+  manifest === "Cargo.toml"
+    ? "root"
+    : manifest.slice(0, -"/Cargo.toml".length);
+process.stdout.write(
+  JSON.stringify({
+    settings: {},
+    lockfile: { "dependency-count": 1 },
+    vulnerabilities: [
+      {
+        advisory: {
+          id: "RUSTSEC-2024-0001",
+          title: "issue in " + manifest,
+        },
+        package: {
+          name: packageName,
+          version: "0.1.0",
+        },
+      },
+    ],
+    warnings: {},
+  }),
+);
+process.stdout.write("\\n");
+NODE
+fi
 if [ -n "\${FAIL_MANIFEST:-}" ] && [ "$manifest" = "$FAIL_MANIFEST" ]; then
-  printf 'issue in %s\\n' "$manifest" >&2
+  if [ "$audit_mode" -eq 1 ]; then
+    node - "$manifest" "$config" <<'NODE'
+const [manifest, config] = process.argv.slice(2);
+process.stderr.write(
+  JSON.stringify({
+    type: "diagnostic",
+    fields: {
+      code: "rejected",
+      labels: [
+        {
+          column: 1,
+          line: 1,
+          message: "simulated cargo-deny issue",
+          span: config || manifest,
+        },
+      ],
+      message: "issue in " + manifest,
+      notes: [],
+      severity: "error",
+    },
+  }),
+);
+process.stderr.write("\\n");
+NODE
+  else
+    printf 'issue in %s\\n' "$manifest" >&2
+  fi
   exit 1
 fi
+printf 'checked %s\\n' "$manifest" >&2
 `,
 	);
 }
@@ -276,17 +344,21 @@ edition = "2021"
 		const result = JSON.parse(output);
 
 		assert.equal(result.exit_code, 0);
+		assert.deepEqual(
+			result.cargo_deny_runs.map((run) => run.manifest_path),
+			["Cargo.toml", "crates/member/Cargo.toml"],
+		);
 		assert.deepEqual(fs.readFileSync(argsLog, "utf8").trim().split("\n"), [
-			"--color never --log-level warn --all-features --manifest-path Cargo.toml check --config deny.toml",
-			"--color never --log-level warn --all-features --manifest-path crates/member/Cargo.toml check --config crates/member/deny.toml",
+			"--format json --color never --log-level warn --all-features --manifest-path Cargo.toml check --audit-compatible-output --config deny.toml",
+			"--format json --color never --log-level warn --all-features --manifest-path crates/member/Cargo.toml check --audit-compatible-output --config crates/member/deny.toml",
 		]);
 		assert.match(
 			result.details,
-			/cargo-deny --color never --log-level warn --all-features --manifest-path Cargo\.toml check --config deny\.toml/,
+			/cargo-deny --format json --color never --log-level warn --all-features --manifest-path Cargo\.toml check --audit-compatible-output --config deny\.toml/,
 		);
 		assert.match(
 			result.details,
-			/cargo-deny --color never --log-level warn --all-features --manifest-path crates\/member\/Cargo\.toml check --config crates\/member\/deny\.toml/,
+			/cargo-deny --format json --color never --log-level warn --all-features --manifest-path crates\/member\/Cargo\.toml check --audit-compatible-output --config crates\/member\/deny\.toml/,
 		);
 	} finally {
 		cleanupTempRepo(context.tempDir);
@@ -322,12 +394,13 @@ edition = "2021"
 		const result = JSON.parse(output);
 
 		assert.equal(result.exit_code, 0);
+		assert.equal(result.cargo_deny_runs.length, 1);
 		assert.deepEqual(fs.readFileSync(argsLog, "utf8").trim().split("\n"), [
-			"--color never --log-level warn --all-features --manifest-path crates/member/Cargo.toml check --config deny.toml",
+			"--format json --color never --log-level warn --all-features --manifest-path crates/member/Cargo.toml check --audit-compatible-output --config deny.toml",
 		]);
 		assert.match(
 			result.details,
-			/cargo-deny --color never --log-level warn --all-features --manifest-path crates\/member\/Cargo\.toml check --config deny\.toml/,
+			/cargo-deny --format json --color never --log-level warn --all-features --manifest-path crates\/member\/Cargo\.toml check --audit-compatible-output --config deny\.toml/,
 		);
 	} finally {
 		cleanupTempRepo(context.tempDir);
@@ -365,6 +438,7 @@ edition = "2021"
 				cwd: context.repoDir,
 				encoding: "utf8",
 				env: createEnv(context, {
+					AUDIT_REPORT_MANIFEST: "Cargo.toml",
 					CARGO_DENY_ARGS_LOG: argsLog,
 					FAIL_MANIFEST: "Cargo.toml",
 				}),
@@ -373,14 +447,27 @@ edition = "2021"
 		const result = JSON.parse(output);
 
 		assert.equal(result.exit_code, 1);
+		assert.equal(result.cargo_deny_runs.length, 2);
+		assert.equal(
+			result.cargo_deny_runs[0].audit_reports[0].vulnerabilities[0].advisory.id,
+			"RUSTSEC-2024-0001",
+		);
+		assert.equal(
+			result.cargo_deny_runs[0].diagnostics[0].fields.code,
+			"rejected",
+		);
 		assert.deepEqual(fs.readFileSync(argsLog, "utf8").trim().split("\n"), [
-			"--color never --log-level warn --all-features --manifest-path Cargo.toml check",
-			"--color never --log-level warn --all-features --manifest-path crates/member/Cargo.toml check",
+			"--format json --color never --log-level warn --all-features --manifest-path Cargo.toml check --audit-compatible-output",
+			"--format json --color never --log-level warn --all-features --manifest-path crates/member/Cargo.toml check --audit-compatible-output",
 		]);
-		assert.match(result.details, /issue in Cargo\.toml/);
 		assert.match(
 			result.details,
-			/cargo-deny --color never --log-level warn --all-features --manifest-path crates\/member\/Cargo\.toml check/,
+			/error\[RUSTSEC-2024-0001\]: root 0\.1\.0 - issue in Cargo\.toml/,
+		);
+		assert.match(result.details, /error\[rejected\]: issue in Cargo\.toml/);
+		assert.match(
+			result.details,
+			/cargo-deny --format json --color never --log-level warn --all-features --manifest-path crates\/member\/Cargo\.toml check --audit-compatible-output/,
 		);
 	} finally {
 		cleanupTempRepo(context.tempDir);

--- a/.github/scripts/render-linter-sarif.cargo-deny.test.js
+++ b/.github/scripts/render-linter-sarif.cargo-deny.test.js
@@ -48,10 +48,291 @@ test("emits SARIF for cargo-deny diagnostics", () => {
 
 		assert.equal(report.produced, true);
 		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(report.sarif.runs[0].results[0].ruleId, "unlicensed");
 		assert.equal(
 			report.sarif.runs[0].results[0].locations[0].physicalLocation
 				.artifactLocation.uri,
 			"Cargo.toml",
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("emits SARIF for cargo-deny audit-compatible advisories", () => {
+	const context = makeTempRepo("render-linter-sarif-cargo-deny-audit-");
+
+	writeFile(
+		path.join(context.repoDir, "Cargo.toml"),
+		'[package]\nname = "demo"\nversion = "0.1.0"\nedition = "2021"\n',
+	);
+	writeFile(path.join(context.repoDir, "Cargo.lock"), "version = 3\n");
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"Cargo.lock\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			cargo_deny_runs: [
+				{
+					audit_reports: [
+						{
+							lockfile: { "dependency-count": 1 },
+							settings: {},
+							vulnerabilities: [
+								{
+									advisory: {
+										id: "RUSTSEC-2024-0001",
+										title: "Critical vulnerability",
+									},
+									package: {
+										name: "demo",
+										version: "0.1.0",
+									},
+								},
+							],
+							warnings: {},
+						},
+					],
+					command:
+						"cargo-deny --format json --color never --log-level warn --all-features --manifest-path Cargo.toml check --audit-compatible-output",
+					config_path: null,
+					diagnostics: [
+						{
+							fields: {
+								advisory: {
+									id: "RUSTSEC-2024-0001",
+								},
+								code: "vulnerability",
+								labels: [
+									{
+										column: 1,
+										line: 4,
+										message: "security vulnerability detected",
+										span: "demo 0.1.0",
+									},
+								],
+								message: "Critical vulnerability",
+								notes: ["ID: RUSTSEC-2024-0001"],
+								severity: "error",
+							},
+							type: "diagnostic",
+						},
+					],
+					exit_code: 1,
+					manifest_path: "Cargo.toml",
+				},
+			],
+			details: "",
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "cargo-deny",
+			OUTPUT_PATH: path.join(context.runnerTemp, "cargo-deny.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.equal(report.sarif.runs[0].results.length, 1);
+		assert.equal(report.sarif.runs[0].results[0].ruleId, "RUSTSEC-2024-0001");
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"Cargo.toml",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			1,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("emits SARIF for cargo-deny structured config diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-cargo-deny-config-");
+
+	writeFile(
+		path.join(context.repoDir, "Cargo.toml"),
+		'[package]\nname = "demo"\nversion = "0.1.0"\nedition = "2021"\n',
+	);
+	writeFile(
+		path.join(context.repoDir, "deny.toml"),
+		[
+			"[licenses]",
+			"version = 2",
+			"unused = true",
+			"exceptions = []",
+			'allow = ["MIT", "Apache-2.0"]',
+			"",
+		].join("\n"),
+	);
+	writeFile(path.join(context.runnerTemp, "selected-files.txt"), "deny.toml\n");
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			cargo_deny_runs: [
+				{
+					audit_reports: [],
+					command:
+						"cargo-deny --format json --color never --log-level warn --all-features --manifest-path Cargo.toml check --audit-compatible-output --config deny.toml",
+					config_path: "deny.toml",
+					diagnostics: [
+						{
+							fields: {
+								code: "rejected",
+								labels: [
+									{
+										column: 9,
+										line: 5,
+										message: "missing comma",
+										span: 'allow = ["MIT" "Apache-2.0"]',
+									},
+								],
+								message: "failed to parse config",
+								notes: [],
+								severity: "error",
+							},
+							type: "diagnostic",
+						},
+					],
+					exit_code: 1,
+					manifest_path: "Cargo.toml",
+				},
+			],
+			details: "",
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "cargo-deny",
+			OUTPUT_PATH: path.join(context.runnerTemp, "cargo-deny.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.equal(report.sarif.runs[0].results.length, 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"deny.toml",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			5,
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startColumn,
+			9,
+		);
+		assert.equal(report.sarif.runs[0].results[0].ruleId, "cargo-deny/rejected");
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("keeps only the primary cargo-deny snippet location and preserves advisory IDs", () => {
+	const context = makeTempRepo("render-linter-sarif-cargo-deny-advisory-");
+	const copiedSourceRoot = path.join(
+		context.runnerTemp,
+		"cargo-deny-workspace/source",
+	);
+	const copiedLockPath = path.join(copiedSourceRoot, "Cargo.lock");
+	const copiedDenyPath = path.join(copiedSourceRoot, "deny.toml");
+	const advisoryDetails = [
+		"error[RUSTSEC-2024-0001]: crate `demo 0.1.0` is vulnerable",
+		"",
+		`  ┌─ ${copiedLockPath}:50:1`,
+		"  │",
+		'50 │ name = "demo"',
+		"  │ ^ vulnerable crate entry",
+		"  │",
+		`  ┌─ ${copiedDenyPath}:10:5`,
+		"  │",
+		"10 │ ignore = []",
+		"   │     ^ advisory is not ignored here",
+	].join("\n");
+
+	writeFile(
+		path.join(context.repoDir, "Cargo.toml"),
+		'[package]\nname = "demo"\nversion = "0.1.0"\nedition = "2021"\n',
+	);
+	writeFile(
+		path.join(context.repoDir, "Cargo.lock"),
+		Array.from({ length: 60 }, (_, index) => `line ${index + 1}`).join("\n") +
+			"\n",
+	);
+	writeFile(
+		path.join(context.repoDir, "deny.toml"),
+		Array.from({ length: 12 }, (_, index) => `line ${index + 1}`).join("\n") +
+			"\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"Cargo.lock\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details: advisoryDetails,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "cargo-deny",
+			OUTPUT_PATH: path.join(context.runnerTemp, "cargo-deny.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.equal(report.sarif.runs[0].results.length, 1);
+		assert.equal(report.sarif.runs[0].results[0].ruleId, "RUSTSEC-2024-0001");
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"Cargo.lock",
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startLine,
+			50,
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.startColumn,
+			1,
 		);
 	} finally {
 		cleanupTempRepo(context.tempDir);

--- a/.github/scripts/render-linter-sarif.js
+++ b/.github/scripts/render-linter-sarif.js
@@ -2,6 +2,10 @@ const crypto = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
 
+const {
+	isCargoDenyAdvisoryLikeDiagnostic,
+	isCargoDenyConfigLikeDiagnostic,
+} = require("./cargo-deny-result.js");
 const { collectProjectTargets } = require("./render-linter-report.js");
 
 const DETAILS_LIMIT = 8000;
@@ -76,6 +80,10 @@ function renderSarif({
 		result,
 		linterConfig.details_fallback,
 	);
+	const cargoDenyRuns =
+		linterName === "cargo-deny" && Array.isArray(result?.cargo_deny_runs)
+			? result.cargo_deny_runs
+			: [];
 	const reportedPathRoots = buildReportedPathRoots({
 		linterName,
 		runnerTemp,
@@ -86,6 +94,7 @@ function renderSarif({
 			? []
 			: buildSarifResults({
 					defaultLevel: sarifConfig.default_level || "warning",
+					cargoDenyRuns,
 					details,
 					linterName,
 					reportedPathRoots,
@@ -227,6 +236,7 @@ function buildReportedPathRoots({
 }
 
 function buildSarifResults({
+	cargoDenyRuns,
 	defaultLevel,
 	details,
 	linterName,
@@ -234,6 +244,19 @@ function buildSarifResults({
 	sourceRepositoryPath,
 	targetPaths,
 }) {
+	const structuredCargoDenyResults = parseCargoDenyStructuredResults({
+		cargoDenyRuns,
+		defaultLevel,
+		linterName,
+		reportedPathRoots,
+		sourceRepositoryPath,
+		targetPaths,
+	});
+
+	if (structuredCargoDenyResults.length > 0) {
+		return structuredCargoDenyResults;
+	}
+
 	const preciseResults = dedupeResults([
 		...parsePathDiagnostics({
 			defaultLevel,
@@ -281,6 +304,254 @@ function buildSarifResults({
 		sourceRepositoryPath,
 		targetPaths,
 	});
+}
+
+function parseCargoDenyStructuredResults({
+	cargoDenyRuns,
+	defaultLevel,
+	linterName,
+	reportedPathRoots,
+	sourceRepositoryPath,
+	targetPaths,
+}) {
+	if (linterName !== "cargo-deny" || cargoDenyRuns.length === 0) {
+		return [];
+	}
+
+	const results = [];
+
+	for (const run of cargoDenyRuns) {
+		const advisoryResults = parseCargoDenyAuditReportResults({
+			defaultLevel,
+			linterName,
+			reportedPathRoots,
+			run,
+			sourceRepositoryPath,
+			targetPaths,
+		});
+		const diagnosticResults = parseCargoDenyJsonDiagnostics({
+			defaultLevel,
+			linterName,
+			reportedPathRoots,
+			run,
+			skipAdvisories: advisoryResults.length > 0,
+			sourceRepositoryPath,
+			targetPaths,
+		});
+
+		results.push(...advisoryResults, ...diagnosticResults);
+	}
+
+	return dedupeResults(results);
+}
+
+function parseCargoDenyAuditReportResults({
+	defaultLevel,
+	linterName,
+	reportedPathRoots,
+	run,
+	sourceRepositoryPath,
+	targetPaths,
+}) {
+	const results = [];
+	const auditReports = Array.isArray(run?.audit_reports)
+		? run.audit_reports
+		: [];
+	const manifestPath = normalizeCargoDenyStructuredPath(
+		sourceRepositoryPath,
+		run?.manifest_path,
+		targetPaths,
+		reportedPathRoots,
+	);
+	const defaultFilePath =
+		manifestPath ||
+		normalizeCargoDenyStructuredPath(
+			sourceRepositoryPath,
+			run?.config_path,
+			targetPaths,
+			reportedPathRoots,
+		);
+
+	for (const report of auditReports) {
+		for (const vulnerability of Array.isArray(report?.vulnerabilities)
+			? report.vulnerabilities
+			: []) {
+			const advisory = vulnerability?.advisory || {};
+			const packageInfo = vulnerability?.package || {};
+			const packageLabel = [packageInfo.name, packageInfo.version]
+				.filter(Boolean)
+				.join(" ");
+			const title = advisory.title || advisory.id || "cargo-deny advisory";
+
+			results.push(
+				createResult({
+					column: defaultFilePath ? 1 : null,
+					defaultLevel,
+					filePath: defaultFilePath,
+					line: defaultFilePath ? 1 : null,
+					linterName,
+					message: packageLabel ? `${packageLabel}: ${title}` : title,
+					ruleId: advisory.id || "cargo-deny/advisory",
+				}),
+			);
+		}
+
+		for (const [kind, entries] of Object.entries(
+			report && typeof report.warnings === "object" && report.warnings
+				? report.warnings
+				: {},
+		)) {
+			for (const warning of Array.isArray(entries) ? entries : []) {
+				const advisory = warning?.advisory || {};
+				const packageInfo = warning?.package || {};
+				const packageLabel = [packageInfo.name, packageInfo.version]
+					.filter(Boolean)
+					.join(" ");
+				const title = advisory.title || advisory.id || kind;
+
+				results.push(
+					createResult({
+						column: defaultFilePath ? 1 : null,
+						defaultLevel,
+						filePath: defaultFilePath,
+						line: defaultFilePath ? 1 : null,
+						linterName,
+						message: packageLabel ? `${packageLabel}: ${title}` : title,
+						ruleId: advisory.id || `cargo-deny/${kind}`,
+					}),
+				);
+			}
+		}
+	}
+
+	return results;
+}
+
+function parseCargoDenyJsonDiagnostics({
+	defaultLevel,
+	linterName,
+	reportedPathRoots,
+	run,
+	skipAdvisories,
+	sourceRepositoryPath,
+	targetPaths,
+}) {
+	const results = [];
+	const diagnostics = Array.isArray(run?.diagnostics) ? run.diagnostics : [];
+	const manifestPath = normalizeCargoDenyStructuredPath(
+		sourceRepositoryPath,
+		run?.manifest_path,
+		targetPaths,
+		reportedPathRoots,
+	);
+	const configPath = normalizeCargoDenyStructuredPath(
+		sourceRepositoryPath,
+		run?.config_path,
+		targetPaths,
+		reportedPathRoots,
+	);
+
+	for (const diagnostic of diagnostics) {
+		if (skipAdvisories && isCargoDenyAdvisoryLikeDiagnostic(diagnostic)) {
+			continue;
+		}
+
+		const fields = diagnostic?.fields || {};
+		const label = Array.isArray(fields.labels) ? fields.labels[0] : null;
+		const filePath =
+			configPath && isCargoDenyConfigLikeDiagnostic(diagnostic)
+				? configPath
+				: manifestPath || configPath;
+		const useLabelRegion = filePath === configPath && label;
+		const line = filePath
+			? useLabelRegion
+				? parseInteger(label?.line)
+				: 1
+			: null;
+		const column = filePath
+			? useLabelRegion
+				? parseInteger(label?.column)
+				: 1
+			: null;
+
+		results.push(
+			createResult({
+				column,
+				defaultLevel:
+					typeof fields.severity === "string"
+						? toSarifLevel(fields.severity, defaultLevel)
+						: defaultLevel,
+				filePath,
+				line,
+				linterName,
+				message:
+					typeof fields.message === "string" && fields.message.length > 0
+						? fields.message
+						: summarizeCargoDenyDiagnostic(diagnostic),
+				ruleId: resolveCargoDenyRuleId(fields, linterName),
+			}),
+		);
+	}
+
+	return results;
+}
+
+function normalizeCargoDenyStructuredPath(
+	sourceRepositoryPath,
+	reportedPath,
+	targetPaths,
+	reportedPathRoots,
+) {
+	if (typeof reportedPath !== "string" || reportedPath.trim().length === 0) {
+		return null;
+	}
+
+	return normalizeReportedPath(
+		sourceRepositoryPath,
+		reportedPath,
+		targetPaths,
+		reportedPathRoots,
+	);
+}
+
+function resolveCargoDenyRuleId(fields, linterName) {
+	if (
+		typeof fields?.advisory?.id === "string" &&
+		fields.advisory.id.length > 0
+	) {
+		return fields.advisory.id;
+	}
+
+	if (typeof fields?.code === "string" && fields.code.length > 0) {
+		return `cargo-deny/${fields.code}`;
+	}
+
+	if (Array.isArray(fields?.notes)) {
+		for (const note of fields.notes) {
+			const match = /^ID:\s*(.+)$/u.exec(String(note || "").trim());
+
+			if (match?.[1]) {
+				return match[1];
+			}
+		}
+	}
+
+	return `${linterName}/diagnostic`;
+}
+
+function summarizeCargoDenyDiagnostic(diagnostic) {
+	const fields = diagnostic?.fields || {};
+	const label = Array.isArray(fields.labels) ? fields.labels[0] : null;
+
+	if (typeof label?.message === "string" && label.message.length > 0) {
+		return label.message;
+	}
+
+	if (typeof label?.span === "string" && label.span.length > 0) {
+		return label.span;
+	}
+
+	return "cargo-deny reported an issue";
 }
 
 function parsePathDiagnostics({
@@ -353,16 +624,23 @@ function parseRustStyleDiagnostics({
 	targetPaths,
 }) {
 	let currentMessage = "";
+	let currentRuleId = null;
+	let emittedForCurrentDiagnostic = false;
 	const results = [];
 
 	for (const rawLine of details.split(/\r?\n/u)) {
 		const line = rawLine.trim();
 
-		if (/^(error|warning|note)(\[[^\]]+\])?:/iu.test(line)) {
-			currentMessage = line.replace(
-				/^(error|warning|note)(\[[^\]]+\])?:\s*/iu,
-				"",
-			);
+		const header = parseDiagnosticHeader(line);
+
+		if (header) {
+			if (header.kind === "note") {
+				continue;
+			}
+
+			currentMessage = header.message;
+			currentRuleId = header.ruleId;
+			emittedForCurrentDiagnostic = false;
 			continue;
 		}
 
@@ -370,7 +648,7 @@ function parseRustStyleDiagnostics({
 			rawLine,
 		);
 
-		if (!match?.groups) {
+		if (!match?.groups || emittedForCurrentDiagnostic) {
 			continue;
 		}
 
@@ -385,6 +663,7 @@ function parseRustStyleDiagnostics({
 			continue;
 		}
 
+		emittedForCurrentDiagnostic = true;
 		results.push(
 			createResult({
 				column: parseInteger(match.groups.column),
@@ -393,9 +672,11 @@ function parseRustStyleDiagnostics({
 				line: parseInteger(match.groups.line),
 				linterName,
 				message: currentMessage || summarizeDetails(details, linterName),
-				ruleId:
-					extractRuleId(currentMessage, linterName) ||
-					`${linterName}/diagnostic`,
+				ruleId: resolveDiagnosticRuleId(
+					currentRuleId,
+					currentMessage,
+					linterName,
+				),
 			}),
 		);
 	}
@@ -412,16 +693,23 @@ function parseSnippetStyleDiagnostics({
 	targetPaths,
 }) {
 	let currentMessage = "";
+	let currentRuleId = null;
+	let emittedForCurrentDiagnostic = false;
 	const results = [];
 
 	for (const rawLine of details.split(/\r?\n/u)) {
 		const line = rawLine.trim();
 
-		if (/^(error|warning|note)(\[[^\]]+\])?:/iu.test(line)) {
-			currentMessage = line.replace(
-				/^(error|warning|note)(\[[^\]]+\])?:\s*/iu,
-				"",
-			);
+		const header = parseDiagnosticHeader(line);
+
+		if (header) {
+			if (header.kind === "note") {
+				continue;
+			}
+
+			currentMessage = header.message;
+			currentRuleId = header.ruleId;
+			emittedForCurrentDiagnostic = false;
 			continue;
 		}
 
@@ -430,7 +718,7 @@ function parseSnippetStyleDiagnostics({
 				rawLine,
 			);
 
-		if (!match?.groups) {
+		if (!match?.groups || emittedForCurrentDiagnostic) {
 			continue;
 		}
 
@@ -445,6 +733,7 @@ function parseSnippetStyleDiagnostics({
 			continue;
 		}
 
+		emittedForCurrentDiagnostic = true;
 		results.push(
 			createResult({
 				column: parseInteger(match.groups.column),
@@ -453,9 +742,11 @@ function parseSnippetStyleDiagnostics({
 				line: parseInteger(match.groups.line),
 				linterName,
 				message: currentMessage || summarizeDetails(details, linterName),
-				ruleId:
-					extractRuleId(currentMessage, linterName) ||
-					`${linterName}/diagnostic`,
+				ruleId: resolveDiagnosticRuleId(
+					currentRuleId,
+					currentMessage,
+					linterName,
+				),
 			}),
 		);
 	}
@@ -682,7 +973,28 @@ function buildRuleDescriptors(results) {
 	}));
 }
 
+function parseDiagnosticHeader(rawLine) {
+	const match =
+		/^(?<kind>error|warning|note)(?:\[(?<ruleId>[^\]]+)\])?:\s*(?<message>.*)$/iu.exec(
+			String(rawLine || "").trim(),
+		);
+
+	if (!match?.groups) {
+		return null;
+	}
+
+	return {
+		kind: match.groups.kind.toLowerCase(),
+		message: match.groups.message.trim(),
+		ruleId: match.groups.ruleId ? match.groups.ruleId.trim() : null,
+	};
+}
+
 function parseInteger(value) {
+	if (typeof value === "number") {
+		return Number.isInteger(value) && value > 0 ? value : null;
+	}
+
 	if (typeof value !== "string" || value.length === 0) {
 		return null;
 	}
@@ -691,9 +1003,24 @@ function parseInteger(value) {
 	return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
+function resolveDiagnosticRuleId(headerRuleId, text, linterName) {
+	if (typeof headerRuleId === "string" && headerRuleId.trim().length > 0) {
+		return headerRuleId.trim();
+	}
+
+	return extractRuleId(text, linterName) || `${linterName}/diagnostic`;
+}
+
 function extractRuleId(text, linterName) {
 	if (typeof text !== "string") {
 		return null;
+	}
+
+	const headerMatch =
+		/(?:^|\b)(?:error|warning|note)\[(?<ruleId>[^\]]+)\]:/iu.exec(text);
+
+	if (headerMatch?.groups?.ruleId) {
+		return headerMatch.groups.ruleId.trim();
 	}
 
 	const match = text.match(RULE_ID_PATTERN);


### PR DESCRIPTION
## Summary
- run cargo-deny with `--format json --audit-compatible-output` and capture per-manifest stdout/stderr
- build structured `cargo_deny_runs` for PR details and SARIF generation
- add regression coverage for structured advisories, config diagnostics, and wrapper behavior

## Testing
- node --test .github/scripts/*.test.js .github/scripts/linters/*.test.js
- git diff --check