### PR TITLE
fix(cargo): normalize workspace manifests

### DIFF
--- a/.github/scripts/linter-library.sh
+++ b/.github/scripts/linter-library.sh
@@ -86,6 +86,58 @@ linter_lib::find_cargo_manifest() {
   return 1
 }
 
+linter_lib::workspace_manifest_from_metadata() {
+  local source_root=$1
+
+  node -e '
+const fs = require("node:fs");
+const path = require("node:path");
+
+const sourceRoot = process.argv[1];
+const data = JSON.parse(fs.readFileSync(0, "utf8"));
+
+if (typeof data.workspace_root !== "string" || data.workspace_root.length === 0) {
+  process.exit(1);
+}
+
+const manifestPath = path.join(data.workspace_root, "Cargo.toml");
+const relativePath = path.relative(sourceRoot, manifestPath);
+
+if (relativePath.length === 0) {
+  process.stdout.write("Cargo.toml");
+  process.exit(0);
+}
+
+if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+  process.exit(1);
+}
+
+process.stdout.write(relativePath.split(path.sep).join("/"));
+  ' "$source_root"
+}
+
+linter_lib::resolve_cargo_workspace_manifest() {
+  local source_root=$1
+  local manifest_path=$2
+  shift 2
+
+  local metadata_json relative_manifest
+
+  if ! metadata_json="$("$@" metadata --format-version 1 --no-deps --manifest-path "$manifest_path" 2>/dev/null)"; then
+    printf '%s\n' "$manifest_path"
+    return 0
+  fi
+
+  if ! relative_manifest="$(
+    printf '%s' "$metadata_json" | linter_lib::workspace_manifest_from_metadata "$source_root"
+  )"; then
+    printf '%s\n' "$manifest_path"
+    return 0
+  fi
+
+  printf '%s\n' "$relative_manifest"
+}
+
 linter_lib::collect_cargo_manifests() {
   local output_file=$1
   local tool_name=$2

--- a/.github/scripts/linters/cargo-clippy.sh
+++ b/.github/scripts/linters/cargo-clippy.sh
@@ -65,6 +65,7 @@ EOF
     cargo_clippy_require_docker
     output_file="$RUNNER_TEMP/linter-output.txt"
     manifests=()
+    normalized_manifests=()
     relevant_dirs=()
     unsupported_config=""
     if ! linter_lib::collect_cargo_manifests "$output_file" "Cargo clippy" manifests "$@"; then
@@ -137,6 +138,41 @@ EOF
       --env HOME=/cargo-home
     )
 
+    metadata_docker_run_common=(
+      --rm
+      --cap-drop ALL
+      --security-opt no-new-privileges
+      --read-only
+      --tmpfs /tmp
+      --user "$user_id:$group_id"
+      --workdir /work
+      --mount "type=bind,src=$source_root,dst=/work"
+    )
+
+    cargo_clippy_resolve_workspace_manifest() {
+      local manifest_path=$1
+
+      linter_lib::resolve_cargo_workspace_manifest /work "$manifest_path" \
+        docker run "${metadata_docker_run_common[@]}" --network=none "$image_ref" cargo
+    }
+
+    cargo_clippy_normalize_manifests() {
+      local -A seen_manifests=()
+      local manifest_path normalized_manifest
+
+      for manifest_path in "${manifests[@]}"; do
+        normalized_manifest=$(cargo_clippy_resolve_workspace_manifest "$manifest_path")
+        if [ -n "${seen_manifests[$normalized_manifest]+x}" ]; then
+          continue
+        fi
+
+        seen_manifests["$normalized_manifest"]=1
+        printf '%s\n' "$normalized_manifest"
+      done
+    }
+
+    mapfile -t normalized_manifests < <(cargo_clippy_normalize_manifests)
+
     run_cargo_clippy() {
       local failure=0
       local current_manifest
@@ -164,7 +200,7 @@ EOF
             fi
             echo
           done
-        ' sh "${manifests[@]}"; then
+        ' sh "${normalized_manifests[@]}"; then
         return 1
       fi
 
@@ -177,7 +213,7 @@ EOF
         done < "$fetch_failures_path"
       fi
 
-      for current_manifest in "${manifests[@]}"; do
+      for current_manifest in "${normalized_manifests[@]}"; do
         if [ -n "${failed_fetches[$current_manifest]+x}" ]; then
           printf '==> skip cargo clippy --manifest-path %s because cargo fetch failed\n\n' "$current_manifest"
           continue

--- a/.github/scripts/linters/cargo-clippy.test.js
+++ b/.github/scripts/linters/cargo-clippy.test.js
@@ -47,6 +47,7 @@ case "$command" in
     manifest=""
     prev=""
     is_clippy=0
+    is_metadata=0
     is_rustup_seed=0
     has_rustup_runtime_mount=0
     option_with_value=""
@@ -102,6 +103,9 @@ case "$command" in
       if [ "$prev" = "--manifest-path" ]; then
         manifest="$arg"
       fi
+      if [ "$prev" = "cargo" ] && [ "$arg" = "metadata" ]; then
+        is_metadata=1
+      fi
       if [ "$prev" = "cargo" ] && [ "$arg" = "clippy" ]; then
         is_clippy=1
       fi
@@ -117,17 +121,48 @@ case "$command" in
       : > "$RUSTUP_STATE_FILE"
       exit 0
     fi
-    if [ -n "$work_mount_src" ]; then
+    if [ "$is_metadata" -ne 1 ] && [ -n "$work_mount_src" ]; then
       if [ -e "$work_mount_src/.git" ]; then
         printf 'present\\n' >> "$WORKTREE_GIT_LOG"
       else
         printf 'absent\\n' >> "$WORKTREE_GIT_LOG"
       fi
     fi
-    if [ -n "\${REQUIRE_WRITABLE_RUSTUP_HOME:-}" ] && { [ "$has_rustup_runtime_mount" -ne 1 ] || [ ! -f "$RUSTUP_STATE_FILE" ]; }; then
+    if [ "$is_metadata" -ne 1 ] && [ -n "\${REQUIRE_WRITABLE_RUSTUP_HOME:-}" ] && { [ "$has_rustup_runtime_mount" -ne 1 ] || [ ! -f "$RUSTUP_STATE_FILE" ]; }; then
       printf 'info: syncing channel updates for 1.94-x86_64-unknown-linux-gnu\\n' >&2
       printf 'error: could not create temp file /usr/local/rustup/tmp/test_file: Read-only file system (os error 30)\\n' >&2
       exit 1
+    fi
+    if [ "$is_metadata" -eq 1 ]; then
+      if [ -z "$manifest" ]; then
+        echo "missing --manifest-path" >&2
+        exit 1
+      fi
+      current_dir="$work_mount_src/$(dirname "$manifest")"
+      workspace_dir="$current_dir"
+      search_dir="$current_dir"
+      while :; do
+        candidate="$search_dir/Cargo.toml"
+        if [ -f "$candidate" ] && grep -Eq '^\\[workspace\\]' "$candidate"; then
+          workspace_dir="$search_dir"
+          break
+        fi
+        if [ "$search_dir" = "$work_mount_src" ] || [ "$search_dir" = "/" ]; then
+          break
+        fi
+        search_dir=$(dirname "$search_dir")
+      done
+      node - "$work_mount_src" "$workspace_dir" <<'NODE'
+const path = require("node:path");
+const [sourceRoot, workspaceDir] = process.argv.slice(2);
+const relativeDir = path.relative(sourceRoot, workspaceDir);
+const workspaceRoot =
+  relativeDir.length === 0
+    ? "/work"
+    : path.posix.join("/work", ...relativeDir.split(path.sep));
+process.stdout.write(JSON.stringify({ workspace_root: workspaceRoot }));
+NODE
+      exit 0
     fi
     if [ -n "$batch_mode" ]; then
       batch_manifests=()
@@ -507,6 +542,82 @@ edition = "2021"
 		assert.deepEqual(
 			fs.readFileSync(tooling.dockerManifestLog, "utf8").trim().split("\n"),
 			["crates/member/Cargo.toml"],
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("cargo-clippy.sh collapses workspace members to a single workspace-root run", () => {
+	const context = makeTempRepo("cargo-clippy-workspace-root-");
+	const tooling = setupDockerTooling(context);
+
+	writeFile(
+		path.join(context.repoDir, "Cargo.toml"),
+		`[package]
+name = "root"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+members = ["crates/member"]
+resolver = "2"
+`,
+	);
+	writeFile(path.join(context.repoDir, "src/lib.rs"), "pub fn root_lib() {}\n");
+	writeFile(
+		path.join(context.repoDir, "crates/member/Cargo.toml"),
+		`[package]
+name = "member"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(
+		path.join(context.repoDir, "crates/member/src/lib.rs"),
+		"pub fn member_lib() {}\n",
+	);
+
+	try {
+		const output = execFileSync(
+			"bash",
+			[scriptPath, "run", "src/lib.rs", "crates/member/src/lib.rs"],
+			{
+				cwd: context.repoDir,
+				encoding: "utf8",
+				env: {
+					...process.env,
+					...tooling.env,
+					PATH: `${context.binDir}:${process.env.PATH}`,
+					RUNNER_TEMP: context.runnerTemp,
+				},
+			},
+		);
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 0);
+		assert.deepEqual(
+			fs
+				.readFileSync(tooling.dockerFetchManifestLog, "utf8")
+				.trim()
+				.split("\n"),
+			["Cargo.toml"],
+		);
+		assert.deepEqual(
+			fs.readFileSync(tooling.dockerManifestLog, "utf8").trim().split("\n"),
+			["Cargo.toml"],
+		);
+		assert.match(
+			result.details,
+			/docker run cargo fetch --manifest-path Cargo\.toml/,
+		);
+		assert.match(
+			result.details,
+			/docker run cargo clippy --manifest-path Cargo\.toml --all-targets -- -D warnings/,
+		);
+		assert.doesNotMatch(
+			result.details,
+			/crates\/member\/Cargo\.toml --all-targets -- -D warnings/,
 		);
 	} finally {
 		cleanupTempRepo(context.tempDir);

--- a/.github/scripts/linters/cargo-deny.sh
+++ b/.github/scripts/linters/cargo-deny.sh
@@ -152,48 +152,11 @@ cargo_deny_collect_manifests() {
 cargo_deny_resolve_workspace_manifest() {
   local source_root=$1
   local manifest_path=$2
-  local metadata_json relative_manifest
 
-  if ! metadata_json="$(
+  (
     cd "$source_root" &&
-      cargo metadata --format-version 1 --no-deps --manifest-path "$manifest_path" 2>/dev/null
-  )"; then
-    printf '%s\n' "$manifest_path"
-    return 0
-  fi
-
-  if ! relative_manifest="$(
-    printf '%s' "$metadata_json" | node -e '
-const fs = require("node:fs");
-const path = require("node:path");
-
-const sourceRoot = process.argv[1];
-const data = JSON.parse(fs.readFileSync(0, "utf8"));
-
-if (typeof data.workspace_root !== "string" || data.workspace_root.length === 0) {
-  process.exit(1);
-}
-
-const manifestPath = path.join(data.workspace_root, "Cargo.toml");
-const relativePath = path.relative(sourceRoot, manifestPath);
-
-if (relativePath.length === 0) {
-  process.stdout.write("Cargo.toml");
-  process.exit(0);
-}
-
-if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
-  process.exit(1);
-}
-
-process.stdout.write(relativePath.split(path.sep).join("/"));
-    ' "$source_root"
-  )"; then
-    printf '%s\n' "$manifest_path"
-    return 0
-  fi
-
-  printf '%s\n' "$relative_manifest"
+      linter_lib::resolve_cargo_workspace_manifest "$source_root" "$manifest_path" cargo
+  )
 }
 
 cargo_deny_collect_run_targets() {

--- a/.github/scripts/linters/cargo-fmt.sh
+++ b/.github/scripts/linters/cargo-fmt.sh
@@ -21,6 +21,34 @@ cargo_fmt_persist_env() {
   fi
 }
 
+cargo_fmt_resolve_workspace_manifest() {
+  local source_root=$1
+  local manifest_path=$2
+
+  (
+    cd "$source_root" &&
+      linter_lib::resolve_cargo_workspace_manifest "$source_root" "$manifest_path" cargo
+  )
+}
+
+cargo_fmt_normalize_manifests() {
+  local source_root=$1
+  shift
+
+  local -A seen_manifests=()
+  local manifest_path normalized_manifest
+
+  for manifest_path in "$@"; do
+    normalized_manifest=$(cargo_fmt_resolve_workspace_manifest "$source_root" "$manifest_path")
+    if [ -n "${seen_manifests[$normalized_manifest]+x}" ]; then
+      continue
+    fi
+
+    seen_manifests["$normalized_manifest"]=1
+    printf '%s\n' "$normalized_manifest"
+  done
+}
+
 mode=${1-}
 if [ "$#" -gt 0 ]; then
   shift
@@ -65,11 +93,13 @@ EOF
     : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
     cargo_fmt_prepare_env
     output_file="$RUNNER_TEMP/linter-output.txt"
+    repo_root=$(pwd -P)
     manifests=()
     if ! linter_lib::collect_cargo_manifests "$output_file" "Cargo fmt" manifests "$@"; then
       linter_lib::emit_json_result 1 "$output_file"
       exit 0
     fi
+    mapfile -t manifests < <(cargo_fmt_normalize_manifests "$repo_root" "${manifests[@]}")
 
     run_cargo_fmt() {
       local failure=0

--- a/.github/scripts/linters/cargo-fmt.test.js
+++ b/.github/scripts/linters/cargo-fmt.test.js
@@ -1,10 +1,16 @@
+const test = require("node:test");
 const {
 	assert,
+	cleanupTempRepo,
 	defineCommonCargoManifestTests,
 	fs,
+	makeTempRepo,
 	path,
 	writeExecutable,
+	writeFile,
 } = require("./cargo-linter-test-lib");
+
+const { execFileSync } = require("node:child_process");
 
 const scriptPath = path.join(__dirname, "cargo-fmt.sh");
 
@@ -13,6 +19,54 @@ function createCargoStub(binDir) {
 		path.join(binDir, "cargo"),
 		`#!/usr/bin/env bash
 set -euo pipefail
+if [ "\${1-}" = "fmt" ] && [ "\${2-}" = "--version" ]; then
+  echo "cargo-fmt 0.0.0"
+  exit 0
+fi
+if [ "\${1-}" = "metadata" ]; then
+  shift
+  manifest=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --manifest-path|--format-version)
+        if [ "$1" = "--manifest-path" ]; then
+          manifest="$2"
+        fi
+        shift 2
+        ;;
+      --no-deps)
+        shift
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  if [ -z "$manifest" ]; then
+    echo "missing --manifest-path" >&2
+    exit 1
+  fi
+  current_dir=$(dirname "$manifest")
+  workspace_dir="$current_dir"
+  search_dir="$current_dir"
+  while :; do
+    candidate="$search_dir/Cargo.toml"
+    if [ -f "$candidate" ] && grep -Eq '^\\[workspace\\]' "$candidate"; then
+      workspace_dir="$search_dir"
+      break
+    fi
+    if [ "$search_dir" = "." ] || [ "$search_dir" = "/" ]; then
+      break
+    fi
+    search_dir=$(dirname "$search_dir")
+  done
+  workspace_root=$(cd "$workspace_dir" && pwd)
+  node - "$workspace_root" <<'NODE'
+const [workspaceRoot] = process.argv.slice(2);
+process.stdout.write(JSON.stringify({ workspace_root: workspaceRoot }));
+NODE
+  exit 0
+fi
 manifest=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -88,4 +142,67 @@ defineCommonCargoManifestTests({
 			/cargo fmt --check --manifest-path crates\/member\/Cargo\.toml/,
 		);
 	},
+});
+
+test("cargo-fmt.sh collapses workspace members to a single workspace-root check", () => {
+	const context = makeTempRepo("cargo-fmt-workspace-root-");
+	const cargoManifestLog = path.join(context.tempDir, "cargo-manifests.log");
+
+	createCargoStub(context.binDir);
+	writeFile(
+		path.join(context.repoDir, "Cargo.toml"),
+		`[package]
+name = "root"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+members = ["crates/member"]
+resolver = "2"
+`,
+	);
+	writeFile(path.join(context.repoDir, "src/lib.rs"), "pub fn root_lib() {}\n");
+	writeFile(
+		path.join(context.repoDir, "crates/member/Cargo.toml"),
+		`[package]
+name = "member"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(
+		path.join(context.repoDir, "crates/member/src/lib.rs"),
+		"pub fn member_lib() {}\n",
+	);
+
+	try {
+		const output = execFileSync(
+			"bash",
+			[scriptPath, "run", "src/lib.rs", "crates/member/src/lib.rs"],
+			{
+				cwd: context.repoDir,
+				encoding: "utf8",
+				env: {
+					...process.env,
+					CARGO_MANIFEST_LOG: cargoManifestLog,
+					PATH: `${context.binDir}:${process.env.PATH}`,
+					RUNNER_TEMP: context.runnerTemp,
+				},
+			},
+		);
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 0);
+		assert.deepEqual(
+			fs.readFileSync(cargoManifestLog, "utf8").trim().split("\n"),
+			["Cargo.toml"],
+		);
+		assert.match(
+			result.details,
+			/cargo fmt --check --manifest-path Cargo\.toml/,
+		);
+		assert.doesNotMatch(result.details, /crates\/member\/Cargo\.toml/);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
 });


### PR DESCRIPTION
## Summary
- add a shared cargo metadata helper to resolve workspace-root manifests
- normalize cargo-fmt and cargo-clippy runs to workspace roots before executing
- switch cargo-deny to the shared helper and add workspace regressions for fmt/clippy

## Testing
- node --test .github/scripts/*.test.js .github/scripts/linters/*.test.js
- git diff --check