### PR TITLE
fix(reporting): include detailed check-run output

### DIFF
--- a/.github/scripts/render-combined-report.js
+++ b/.github/scripts/render-combined-report.js
@@ -1,0 +1,216 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const COMMENT_MARKER = "<!-- linter-service:results -->";
+
+function runFromEnv(env = process.env) {
+	const report = renderCombinedReport({
+		decryptOutcome: env.DECRYPT_SUMMARIES_OUTCOME ?? "",
+		selectedLinters: parseSelectedLinters(
+			requireEnv(env, "SELECTED_LINTERS_JSON"),
+		),
+		summaryRoot: requireEnv(env, "LINTER_SUMMARY_PATH"),
+	});
+	const runnerTemp = requireEnv(env, "RUNNER_TEMP");
+
+	writeCombinedReportFiles({
+		checkRunText: report.checkRunText,
+		commentBody: report.commentBody,
+		runnerTemp,
+	});
+
+	if (typeof env.GITHUB_OUTPUT === "string" && env.GITHUB_OUTPUT.length > 0) {
+		fs.appendFileSync(
+			env.GITHUB_OUTPUT,
+			[
+				`overall_conclusion=${report.overallConclusion}`,
+				`overall_summary=${report.overallSummary}`,
+				"",
+			].join("\n"),
+			"utf8",
+		);
+	}
+
+	return report;
+}
+
+function renderCombinedReport({
+	decryptOutcome,
+	selectedLinters,
+	summaryRoot,
+}) {
+	const summaries = readLinterSummaries(summaryRoot);
+	const sections = [];
+	let failed = 0;
+
+	for (const linterName of selectedLinters) {
+		const summary = summaries.get(linterName) ?? {};
+		const conclusion = String(summary.conclusion || "");
+		let section = String(summary.comment_body || "").trim();
+
+		if (!section) {
+			section = buildFallbackSection({
+				decryptOutcome,
+				linterName,
+			});
+		}
+
+		if (conclusion !== "success") {
+			failed += 1;
+		}
+
+		if (section) {
+			sections.push(section);
+		}
+	}
+
+	const total = selectedLinters.length;
+	const overallConclusion =
+		failed === 0 && decryptOutcome !== "failure" ? "success" : "failure";
+	let overallSummary;
+
+	if (decryptOutcome === "failure") {
+		overallSummary =
+			"One or more encrypted linter summaries could not be read. See the workflow logs.";
+	} else if (overallConclusion === "success") {
+		overallSummary = `All ${total} selected linter(s) completed successfully.`;
+	} else {
+		overallSummary = `${failed} of ${total} selected linter(s) reported issues or failed.`;
+	}
+
+	const commentLines = [
+		COMMENT_MARKER,
+		"## linter-service",
+		"",
+		overallSummary,
+		"",
+	];
+	const checkRunLines = ["## linter-service", "", overallSummary, ""];
+
+	appendSections(commentLines, sections);
+	appendSections(checkRunLines, sections);
+
+	return {
+		checkRunText: `${checkRunLines.join("\n")}\n`,
+		commentBody: `${commentLines.join("\n")}\n`,
+		overallConclusion,
+		overallSummary,
+	};
+}
+
+function writeCombinedReportFiles({ checkRunText, commentBody, runnerTemp }) {
+	fs.writeFileSync(
+		path.join(runnerTemp, "combined-linter-comment.md"),
+		commentBody,
+		"utf8",
+	);
+	fs.writeFileSync(
+		path.join(runnerTemp, "combined-linter-check-run.md"),
+		checkRunText,
+		"utf8",
+	);
+}
+
+function appendSections(lines, sections) {
+	for (const [index, section] of sections.entries()) {
+		lines.push(section);
+		if (index !== sections.length - 1) {
+			lines.push("");
+		}
+	}
+}
+
+function buildFallbackSection({ decryptOutcome, linterName }) {
+	if (decryptOutcome === "failure") {
+		return [
+			`### ${linterName}`,
+			"",
+			`❌ The encrypted \`${linterName}\` summary could not be decrypted. See the workflow logs.`,
+		].join("\n");
+	}
+
+	return [
+		`### ${linterName}`,
+		"",
+		`❌ The \`${linterName}\` workflow failed before producing a detailed report. See the workflow logs.`,
+	].join("\n");
+}
+
+function readLinterSummaries(summaryRoot) {
+	const summaries = new Map();
+
+	if (!fs.existsSync(summaryRoot)) {
+		return summaries;
+	}
+
+	const summaryFileNames = fs
+		.readdirSync(summaryRoot)
+		.filter(
+			(fileName) =>
+				fileName.startsWith("linter-summary-") && fileName.endsWith(".json"),
+		)
+		.sort();
+
+	for (const fileName of summaryFileNames) {
+		let summary;
+
+		try {
+			summary = JSON.parse(
+				fs.readFileSync(path.join(summaryRoot, fileName), "utf8"),
+			);
+		} catch {
+			continue;
+		}
+
+		if (
+			summary &&
+			typeof summary === "object" &&
+			typeof summary.linter_name === "string"
+		) {
+			summaries.set(summary.linter_name, summary);
+		}
+	}
+
+	return summaries;
+}
+
+function parseSelectedLinters(rawValue) {
+	let selectedLinters;
+
+	try {
+		selectedLinters = JSON.parse(rawValue);
+	} catch {
+		throw new Error("SELECTED_LINTERS_JSON must be valid JSON");
+	}
+
+	if (
+		!Array.isArray(selectedLinters) ||
+		selectedLinters.some((linterName) => typeof linterName !== "string")
+	) {
+		throw new Error("SELECTED_LINTERS_JSON must be a JSON array of strings");
+	}
+
+	return selectedLinters;
+}
+
+function requireEnv(env, key) {
+	const value = env[key];
+
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(`${key} is required`);
+	}
+
+	return value;
+}
+
+if (require.main === module) {
+	runFromEnv(process.env);
+}
+
+module.exports = {
+	buildFallbackSection,
+	parseSelectedLinters,
+	readLinterSummaries,
+	renderCombinedReport,
+	runFromEnv,
+};

--- a/.github/scripts/render-combined-report.test.js
+++ b/.github/scripts/render-combined-report.test.js
@@ -1,0 +1,159 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { runFromEnv } = require("./render-combined-report.js");
+
+test("writes comment and check-run reports from detailed linter summaries", () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "render-combined-report-"),
+	);
+	const runnerTemp = path.join(tempDir, "runner-temp");
+	const summaryRoot = path.join(tempDir, "summaries");
+	const githubOutputPath = path.join(tempDir, "github-output.txt");
+
+	fs.mkdirSync(runnerTemp, { recursive: true });
+	fs.mkdirSync(summaryRoot, { recursive: true });
+	fs.writeFileSync(
+		path.join(summaryRoot, "linter-summary-actionlint.json"),
+		JSON.stringify(
+			{
+				comment_body:
+					"### actionlint\n\n✅ No issues were reported for the selected GitHub Actions workflow target(s).\n",
+				conclusion: "success",
+				linter_name: "actionlint",
+			},
+			null,
+			2,
+		),
+		"utf8",
+	);
+	fs.writeFileSync(
+		path.join(summaryRoot, "linter-summary-rustfmt.json"),
+		JSON.stringify(
+			{
+				comment_body:
+					"### rustfmt\n\n❌ Rust formatting issues were detected.\n",
+				conclusion: "failure",
+				linter_name: "rustfmt",
+			},
+			null,
+			2,
+		),
+		"utf8",
+	);
+
+	try {
+		const report = runFromEnv({
+			DECRYPT_SUMMARIES_OUTCOME: "success",
+			GITHUB_OUTPUT: githubOutputPath,
+			LINTER_SUMMARY_PATH: summaryRoot,
+			RUNNER_TEMP: runnerTemp,
+			SELECTED_LINTERS_JSON: JSON.stringify(["actionlint", "rustfmt"]),
+		});
+		const commentBody = fs.readFileSync(
+			path.join(runnerTemp, "combined-linter-comment.md"),
+			"utf8",
+		);
+		const checkRunText = fs.readFileSync(
+			path.join(runnerTemp, "combined-linter-check-run.md"),
+			"utf8",
+		);
+		const githubOutput = fs.readFileSync(githubOutputPath, "utf8");
+
+		assert.equal(report.overallConclusion, "failure");
+		assert.equal(
+			report.overallSummary,
+			"1 of 2 selected linter(s) reported issues or failed.",
+		);
+		assert.equal(
+			commentBody,
+			[
+				"<!-- linter-service:results -->",
+				"## linter-service",
+				"",
+				"1 of 2 selected linter(s) reported issues or failed.",
+				"",
+				"### actionlint",
+				"",
+				"✅ No issues were reported for the selected GitHub Actions workflow target(s).",
+				"",
+				"### rustfmt",
+				"",
+				"❌ Rust formatting issues were detected.",
+				"",
+			].join("\n"),
+		);
+		assert.equal(
+			checkRunText,
+			[
+				"## linter-service",
+				"",
+				"1 of 2 selected linter(s) reported issues or failed.",
+				"",
+				"### actionlint",
+				"",
+				"✅ No issues were reported for the selected GitHub Actions workflow target(s).",
+				"",
+				"### rustfmt",
+				"",
+				"❌ Rust formatting issues were detected.",
+				"",
+			].join("\n"),
+		);
+		assert.match(githubOutput, /^overall_conclusion=failure$/m);
+		assert.match(
+			githubOutput,
+			/^overall_summary=1 of 2 selected linter\(s\) reported issues or failed\.$/m,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("falls back to decrypt failure messaging when detailed summaries are unavailable", () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "render-combined-report-missing-"),
+	);
+	const runnerTemp = path.join(tempDir, "runner-temp");
+	const summaryRoot = path.join(tempDir, "summaries");
+
+	fs.mkdirSync(runnerTemp, { recursive: true });
+	fs.mkdirSync(summaryRoot, { recursive: true });
+
+	try {
+		const report = runFromEnv({
+			DECRYPT_SUMMARIES_OUTCOME: "failure",
+			LINTER_SUMMARY_PATH: summaryRoot,
+			RUNNER_TEMP: runnerTemp,
+			SELECTED_LINTERS_JSON: JSON.stringify(["cargo-deny"]),
+		});
+		const commentBody = fs.readFileSync(
+			path.join(runnerTemp, "combined-linter-comment.md"),
+			"utf8",
+		);
+		const checkRunText = fs.readFileSync(
+			path.join(runnerTemp, "combined-linter-check-run.md"),
+			"utf8",
+		);
+
+		assert.equal(report.overallConclusion, "failure");
+		assert.equal(
+			report.overallSummary,
+			"One or more encrypted linter summaries could not be read. See the workflow logs.",
+		);
+		assert.match(
+			commentBody,
+			/❌ The encrypted `cargo-deny` summary could not be decrypted\. See the workflow logs\./,
+		);
+		assert.doesNotMatch(checkRunText, /<!-- linter-service:results -->/);
+		assert.match(
+			checkRunText,
+			/❌ The encrypted `cargo-deny` summary could not be decrypted\. See the workflow logs\./,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});

--- a/.github/scripts/upsert-check-run.js
+++ b/.github/scripts/upsert-check-run.js
@@ -1,3 +1,8 @@
+const fs = require("node:fs");
+
+const CHECK_RUN_OUTPUT_TEXT_LIMIT = 60000;
+const TRUNCATED_OUTPUT_SUFFIX = "\n... truncated ...";
+
 module.exports = async function upsertCheckRun({ github, env }) {
 	const owner = env.CHECK_RUN_OWNER;
 	const repo = env.CHECK_RUN_REPO;
@@ -13,6 +18,11 @@ module.exports = async function upsertCheckRun({ github, env }) {
 		title: env.CHECK_RUN_OUTPUT_TITLE,
 		summary: env.CHECK_RUN_OUTPUT_SUMMARY,
 	};
+	const outputText = resolveOutputText(env);
+
+	if (outputText) {
+		output.text = outputText;
+	}
 	const now = new Date().toISOString();
 	const checkRuns = await github.paginate(
 		github.rest.checks.listForRef,
@@ -67,3 +77,32 @@ module.exports = async function upsertCheckRun({ github, env }) {
 
 	await github.rest.checks.create(createRequest);
 };
+
+function resolveOutputText(env) {
+	if (
+		typeof env.CHECK_RUN_OUTPUT_TEXT === "string" &&
+		env.CHECK_RUN_OUTPUT_TEXT.length > 0
+	) {
+		return truncateOutputText(env.CHECK_RUN_OUTPUT_TEXT);
+	}
+
+	if (
+		typeof env.CHECK_RUN_OUTPUT_TEXT_FILE === "string" &&
+		env.CHECK_RUN_OUTPUT_TEXT_FILE.length > 0 &&
+		fs.existsSync(env.CHECK_RUN_OUTPUT_TEXT_FILE)
+	) {
+		return truncateOutputText(
+			fs.readFileSync(env.CHECK_RUN_OUTPUT_TEXT_FILE, "utf8"),
+		);
+	}
+
+	return undefined;
+}
+
+function truncateOutputText(text) {
+	if (text.length <= CHECK_RUN_OUTPUT_TEXT_LIMIT) {
+		return text;
+	}
+
+	return `${text.slice(0, CHECK_RUN_OUTPUT_TEXT_LIMIT - TRUNCATED_OUTPUT_SUFFIX.length)}${TRUNCATED_OUTPUT_SUFFIX}`;
+}

--- a/.github/scripts/upsert-check-run.test.js
+++ b/.github/scripts/upsert-check-run.test.js
@@ -1,0 +1,193 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const upsertCheckRun = require("./upsert-check-run.js");
+
+test("creates a new check run with detailed output text loaded from a file", async () => {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "upsert-check-run-"));
+	const outputTextPath = path.join(tempDir, "check-run.md");
+	const createCalls = [];
+
+	fs.writeFileSync(
+		outputTextPath,
+		"## linter-service\n\nDetailed check-run output.\n",
+		"utf8",
+	);
+
+	try {
+		await upsertCheckRun({
+			env: {
+				CHECK_RUN_DETAILS_URL: "https://example.com/checks/42",
+				CHECK_RUN_EXTERNAL_ID: "linter-service:42:abc123",
+				CHECK_RUN_HEAD_SHA: "abc123",
+				CHECK_RUN_NAME: "linter-service",
+				CHECK_RUN_OUTPUT_SUMMARY:
+					"1 of 2 selected linter(s) reported issues or failed.",
+				CHECK_RUN_OUTPUT_TEXT_FILE: outputTextPath,
+				CHECK_RUN_OUTPUT_TITLE: "linter-service found issues",
+				CHECK_RUN_OWNER: "chalharu",
+				CHECK_RUN_REPO: "linter-service",
+				CHECK_RUN_STATUS: "completed",
+				CHECK_RUN_CONCLUSION: "failure",
+			},
+			github: createGitHubClient({
+				checkRuns: [],
+				createCalls,
+				updateCalls: [],
+			}),
+		});
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+
+	assert.equal(createCalls.length, 1);
+	assert.deepEqual(createCalls[0], {
+		completed_at: "2026-04-03T04:00:00.000Z",
+		conclusion: "failure",
+		details_url: "https://example.com/checks/42",
+		external_id: "linter-service:42:abc123",
+		head_sha: "abc123",
+		name: "linter-service",
+		owner: "chalharu",
+		output: {
+			summary: "1 of 2 selected linter(s) reported issues or failed.",
+			text: "## linter-service\n\nDetailed check-run output.\n",
+			title: "linter-service found issues",
+		},
+		repo: "linter-service",
+		started_at: "2026-04-03T04:00:00.000Z",
+		status: "completed",
+	});
+});
+
+test("updates an existing check run and truncates oversized output text", async () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "upsert-check-run-update-"),
+	);
+	const outputTextPath = path.join(tempDir, "check-run.md");
+	const updateCalls = [];
+
+	fs.writeFileSync(outputTextPath, "x".repeat(61000), "utf8");
+
+	try {
+		await upsertCheckRun({
+			env: {
+				CHECK_RUN_DETAILS_URL: "https://example.com/checks/42",
+				CHECK_RUN_EXTERNAL_ID: "linter-service:42:def456",
+				CHECK_RUN_HEAD_SHA: "def456",
+				CHECK_RUN_NAME: "linter-service",
+				CHECK_RUN_OUTPUT_SUMMARY:
+					"All 2 selected linter(s) completed successfully.",
+				CHECK_RUN_OUTPUT_TEXT_FILE: outputTextPath,
+				CHECK_RUN_OUTPUT_TITLE: "linter-service completed",
+				CHECK_RUN_OWNER: "chalharu",
+				CHECK_RUN_REPO: "linter-service",
+				CHECK_RUN_STATUS: "completed",
+				CHECK_RUN_CONCLUSION: "success",
+			},
+			github: createGitHubClient({
+				checkRuns: [{ external_id: "linter-service:42:def456", id: 73 }],
+				createCalls: [],
+				updateCalls,
+			}),
+		});
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+
+	assert.equal(updateCalls.length, 1);
+	assert.equal(updateCalls[0].check_run_id, 73);
+	assert.equal(
+		updateCalls[0].output.summary,
+		"All 2 selected linter(s) completed successfully.",
+	);
+	assert.ok(updateCalls[0].output.text.endsWith("\n... truncated ..."));
+	assert.equal(updateCalls[0].output.text.length, 60000);
+});
+
+test("omits output.text when no detailed output is configured", async () => {
+	const createCalls = [];
+
+	await upsertCheckRun({
+		env: {
+			CHECK_RUN_DETAILS_URL: "https://example.com/checks/42",
+			CHECK_RUN_EXTERNAL_ID: "linter-service:42:ghi789",
+			CHECK_RUN_HEAD_SHA: "ghi789",
+			CHECK_RUN_NAME: "linter-service",
+			CHECK_RUN_OUTPUT_SUMMARY:
+				"The linter-service workflow request is being queued and should start shortly.",
+			CHECK_RUN_OUTPUT_TITLE: "linter-service is queued",
+			CHECK_RUN_OWNER: "chalharu",
+			CHECK_RUN_REPO: "linter-service",
+			CHECK_RUN_STATUS: "queued",
+		},
+		github: createGitHubClient({
+			checkRuns: [],
+			createCalls,
+			updateCalls: [],
+		}),
+	});
+
+	assert.equal(createCalls.length, 1);
+	assert.deepEqual(createCalls[0].output, {
+		summary:
+			"The linter-service workflow request is being queued and should start shortly.",
+		title: "linter-service is queued",
+	});
+});
+
+function createGitHubClient({ checkRuns, createCalls, updateCalls }) {
+	return {
+		paginate: async (handler, params, mapper) => {
+			assert.equal(handler, checks.listForRef);
+			assert.deepEqual(params, {
+				owner: "chalharu",
+				per_page: 100,
+				ref: params.ref,
+				repo: "linter-service",
+			});
+			return mapper({ data: { check_runs: checkRuns } });
+		},
+		rest: {
+			checks: {
+				create: async (params) => {
+					createCalls.push(params);
+				},
+				listForRef: checks.listForRef,
+				update: async (params) => {
+					updateCalls.push(params);
+				},
+			},
+		},
+	};
+}
+
+const checks = {
+	listForRef() {},
+};
+
+const RealDate = Date;
+
+test.after(() => {
+	global.Date = RealDate;
+});
+
+test.beforeEach(() => {
+	global.Date = class extends RealDate {
+		constructor(...args) {
+			if (args.length === 0) {
+				super("2026-04-03T04:00:00.000Z");
+				return;
+			}
+
+			super(...args);
+		}
+
+		static now() {
+			return new RealDate("2026-04-03T04:00:00.000Z").valueOf();
+		}
+	};
+});

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -770,85 +770,11 @@ jobs:
         env:
           DECRYPT_SUMMARIES_OUTCOME: ${{ steps.decrypt_summaries.outcome }}
           LINTER_SUMMARY_PATH: ${{ runner.temp }}/linter-summaries-decrypted
+          LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
+          RUNNER_TEMP: ${{ runner.temp }}
           SELECTED_LINTERS_JSON: ${{ needs.detect-targets.outputs.selected-linters-json }}
         run: |
-          python3 - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          selected_linters = json.loads(os.environ["SELECTED_LINTERS_JSON"])
-          decrypt_outcome = os.environ.get("DECRYPT_SUMMARIES_OUTCOME", "")
-          runner_temp = Path(os.environ["RUNNER_TEMP"])
-          comment_path = runner_temp / "combined-linter-comment.md"
-          summary_root = Path(os.environ["LINTER_SUMMARY_PATH"])
-          summaries = {}
-          for summary_path in sorted(summary_root.glob("linter-summary-*.json")):
-              try:
-                  summary = json.loads(summary_path.read_text(encoding="utf-8"))
-              except json.JSONDecodeError:
-                  continue
-
-              linter_name = summary.get("linter_name")
-              if isinstance(linter_name, str):
-                  summaries[linter_name] = summary
-
-          sections = []
-          failed = 0
-
-          for linter_name in selected_linters:
-              summary = summaries.get(linter_name, {})
-              section = str(summary.get("comment_body") or "").strip()
-              conclusion = str(summary.get("conclusion") or "")
-
-              if not section:
-                  if decrypt_outcome == "failure":
-                      section = (
-                          f"### {linter_name}\n\n"
-                          f"❌ The encrypted `{linter_name}` summary could not be decrypted. See the workflow logs."
-                      )
-                  else:
-                      section = (
-                          f"### {linter_name}\n\n"
-                          f"❌ The `{linter_name}` workflow failed before producing a detailed report. See the workflow logs."
-                      )
-
-              if conclusion != "success":
-                  failed += 1
-
-              if section:
-                  sections.append(section)
-
-          total = len(selected_linters)
-          overall_conclusion = "success" if failed == 0 and decrypt_outcome != "failure" else "failure"
-
-          if decrypt_outcome == "failure":
-              overall_summary = "One or more encrypted linter summaries could not be read. See the workflow logs."
-          elif overall_conclusion == "success":
-              overall_summary = f"All {total} selected linter(s) completed successfully."
-          else:
-              overall_summary = f"{failed} of {total} selected linter(s) reported issues or failed."
-
-          lines = [
-              "<!-- linter-service:results -->",
-              "## linter-service",
-              "",
-              overall_summary,
-              "",
-          ]
-
-          for index, section in enumerate(sections):
-              lines.append(section)
-              if index != len(sections) - 1:
-                  lines.append("")
-
-          comment_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-          output_path = Path(os.environ["GITHUB_OUTPUT"])
-          with output_path.open("a", encoding="utf-8") as fh:
-              fh.write(f"overall_conclusion={overall_conclusion}\n")
-              fh.write(f"overall_summary={overall_summary}\n")
-          PY
+          node "$LINTER_SERVICE_PATH/.github/scripts/render-combined-report.js"
       - name: Upsert combined PR comment
         if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' && steps.decode_repository_context.outputs.comment-enabled == 'true' }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -930,6 +856,7 @@ jobs:
           CHECK_RUN_HEAD_SHA: ${{ steps.decode_repository_context.outputs.source-head-sha }}
           CHECK_RUN_NAME: ${{ steps.decode_repository_context.outputs.processing-check-name }}
           CHECK_RUN_OUTPUT_SUMMARY: ${{ steps.prepare_final_summary.outputs.summary || 'The linter-service workflow failed to generate a combined report.' }}
+          CHECK_RUN_OUTPUT_TEXT_FILE: ${{ runner.temp }}/combined-linter-check-run.md
           CHECK_RUN_OUTPUT_TITLE: ${{ steps.prepare_final_summary.outputs.title || 'linter-service found issues' }}
           CHECK_RUN_OWNER: ${{ steps.decode_repository_context.outputs.source-owner }}
           CHECK_RUN_REPO: ${{ steps.decode_repository_context.outputs.source-repo }}


### PR DESCRIPTION
## Summary
- move combined linter report rendering into a reusable script shared by PR comments and processing checks
- attach the detailed combined report body to the final processing check run so push-triggered failures stay readable without code scanning
- add regression tests for combined report rendering and check-run output text handling

## Validation
- node --test .github/scripts/*.test.js
- actionlint .github/workflows/repository-dispatch.yml