### PR TITLE
feat(workflows): add serial linter scheduling

### DIFF
--- a/.github/scripts/linter-targeting.js
+++ b/.github/scripts/linter-targeting.js
@@ -45,6 +45,47 @@ function selectLinters({ candidatePaths, definitions, serviceConfig }) {
 	return selectedLinters;
 }
 
+function buildLinterJobAssignments({ definitions, selectedLinters }) {
+	const selectedSet = new Set(selectedLinters);
+	const groupedAssignments = new Map();
+	const assignments = [];
+
+	for (const definition of definitions) {
+		validateDefinition(definition);
+
+		if (!selectedSet.has(definition.name)) {
+			continue;
+		}
+
+		if (typeof definition.execution_group === "string") {
+			const artifactName = `group-${definition.execution_group}`;
+			let assignment = groupedAssignments.get(definition.execution_group);
+
+			if (!assignment) {
+				assignment = {
+					artifact_name: artifactName,
+					linter_names: [],
+					name: "",
+				};
+				groupedAssignments.set(definition.execution_group, assignment);
+				assignments.push(assignment);
+			}
+
+			assignment.linter_names.push(definition.name);
+			assignment.name = assignment.linter_names.join(" + ");
+			continue;
+		}
+
+		assignments.push({
+			artifact_name: definition.name,
+			linter_names: [definition.name],
+			name: definition.name,
+		});
+	}
+
+	return assignments;
+}
+
 function readPatterns(patternPath) {
 	return fs
 		.readFileSync(patternPath, "utf8")
@@ -76,9 +117,20 @@ function validateDefinition(definition) {
 	) {
 		throw new Error("Each linter definition must include name and patterns");
 	}
+
+	if (
+		typeof definition.execution_group !== "undefined" &&
+		(typeof definition.execution_group !== "string" ||
+			!/^[A-Za-z0-9][A-Za-z0-9._-]*$/u.test(definition.execution_group))
+	) {
+		throw new Error(
+			"execution_group must contain only letters, digits, dot, underscore, or hyphen",
+		);
+	}
 }
 
 module.exports = {
+	buildLinterJobAssignments,
 	compilePatterns,
 	readPatterns,
 	selectFiles,

--- a/.github/scripts/linter-targeting.test.js
+++ b/.github/scripts/linter-targeting.test.js
@@ -5,6 +5,7 @@ const path = require("node:path");
 const test = require("node:test");
 
 const {
+	buildLinterJobAssignments,
 	readPatterns,
 	selectFiles,
 	selectLinters,
@@ -74,4 +75,71 @@ test("readPatterns trims blank lines", () => {
 	} finally {
 		fs.rmSync(tempDir, { force: true, recursive: true });
 	}
+});
+
+test("buildLinterJobAssignments groups selected linters in definition order", () => {
+	const assignments = buildLinterJobAssignments({
+		definitions: [
+			{
+				execution_group: "github-actions",
+				name: "actionlint",
+				patterns: ["workflow"],
+			},
+			{
+				execution_group: "github-actions",
+				name: "ghalint",
+				patterns: ["workflow"],
+			},
+			{
+				name: "biome",
+				patterns: ["js"],
+			},
+			{
+				execution_group: "yaml",
+				name: "yamllint",
+				patterns: ["yaml"],
+			},
+			{
+				execution_group: "yaml",
+				name: "yamlfmt",
+				patterns: ["yaml"],
+			},
+		],
+		selectedLinters: ["biome", "yamlfmt", "ghalint", "yamllint", "actionlint"],
+	});
+
+	assert.deepEqual(assignments, [
+		{
+			artifact_name: "group-github-actions",
+			linter_names: ["actionlint", "ghalint"],
+			name: "actionlint + ghalint",
+		},
+		{
+			artifact_name: "biome",
+			linter_names: ["biome"],
+			name: "biome",
+		},
+		{
+			artifact_name: "group-yaml",
+			linter_names: ["yamllint", "yamlfmt"],
+			name: "yamllint + yamlfmt",
+		},
+	]);
+});
+
+test("buildLinterJobAssignments rejects invalid execution group names", () => {
+	assert.throws(
+		() =>
+			buildLinterJobAssignments({
+				definitions: [
+					{
+						execution_group: "yaml fast",
+						name: "yamllint",
+						patterns: ["yaml"],
+					},
+				],
+				selectedLinters: ["yamllint"],
+			}),
+		/execution_group must contain only/u,
+	);
 });

--- a/.github/scripts/run-fixture-tests.js
+++ b/.github/scripts/run-fixture-tests.js
@@ -11,6 +11,7 @@ const {
 const { renderReport } = require("./render-linter-report.js");
 const { renderSarif } = require("./render-linter-sarif.js");
 const { selectFiles } = require("./linter-targeting.js");
+const { applyWorkflowEnvironment } = require("./workflow-command-env.js");
 
 function runCli(argv = process.argv.slice(2), env = process.env) {
 	const options = parseArgs(argv);
@@ -126,42 +127,6 @@ function installLinterTools({ linterName, repositoryPath }) {
 			githubPathPath,
 		}),
 	};
-}
-
-function applyWorkflowEnvironment(baseEnv, { githubEnvPath, githubPathPath }) {
-	const nextEnv = { ...baseEnv };
-
-	if (fs.existsSync(githubPathPath)) {
-		const pathEntries = fs
-			.readFileSync(githubPathPath, "utf8")
-			.split(/\r?\n/u)
-			.map((line) => line.trim())
-			.filter(Boolean);
-
-		if (pathEntries.length > 0) {
-			nextEnv.PATH = `${pathEntries.join(path.delimiter)}${path.delimiter}${baseEnv.PATH}`;
-		}
-	}
-
-	if (fs.existsSync(githubEnvPath)) {
-		for (const line of fs
-			.readFileSync(githubEnvPath, "utf8")
-			.split(/\r?\n/u)
-			.filter(Boolean)) {
-			const separator = line.indexOf("=");
-
-			if (separator <= 0) {
-				continue;
-			}
-
-			nextEnv[line.slice(0, separator)] = line.slice(separator + 1);
-		}
-	}
-
-	delete nextEnv.GITHUB_ENV;
-	delete nextEnv.GITHUB_PATH;
-
-	return nextEnv;
 }
 
 function runFixtureCase({

--- a/.github/scripts/run-fixture-tests.test.js
+++ b/.github/scripts/run-fixture-tests.test.js
@@ -178,6 +178,32 @@ test("applyWorkflowEnvironment persists GITHUB_PATH and GITHUB_ENV entries", () 
 	}
 });
 
+test("applyWorkflowEnvironment builds PATH when the base env has no PATH", () => {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fixture-env-"));
+	const githubPathPath = path.join(tempDir, "github-path.txt");
+	const githubEnvPath = path.join(tempDir, "github-env.txt");
+
+	fs.writeFileSync(githubPathPath, "/tmp/tool/bin\n", "utf8");
+	fs.writeFileSync(githubEnvPath, "", "utf8");
+
+	try {
+		const nextEnv = applyWorkflowEnvironment(
+			{
+				GITHUB_ENV: githubEnvPath,
+				GITHUB_PATH: githubPathPath,
+			},
+			{
+				githubEnvPath,
+				githubPathPath,
+			},
+		);
+
+		assert.equal(nextEnv.PATH, "/tmp/tool/bin");
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
 test("normalizeFixtureResult removes temp paths and volatile durations", () => {
 	const repositoryPath = "/tmp/fixture-run/repo";
 	const actual = normalizeFixtureResult({

--- a/.github/scripts/run-linter-batch.js
+++ b/.github/scripts/run-linter-batch.js
@@ -1,0 +1,340 @@
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { renderReport } = require("./render-linter-report.js");
+const { renderSarif } = require("./render-linter-sarif.js");
+const { runFromEnv: selectLintTargets } = require("./select-lint-targets.js");
+const { applyWorkflowEnvironment } = require("./workflow-command-env.js");
+
+function runFromEnv(env = process.env) {
+	const result = runLinterBatch({
+		baseEnv: env,
+		contextPath: requireEnv(env, "CONTEXT_PATH"),
+		linterConfigPath: requireEnv(env, "LINTER_CONFIG_PATH"),
+		linterNames: parseLinterNames(requireEnv(env, "LINTER_NAMES_JSON")),
+		linterServicePath: requireEnv(env, "LINTER_SERVICE_PATH"),
+		runnerTemp: requireEnv(env, "RUNNER_TEMP"),
+		sourceRepositoryPath: requireEnv(env, "SOURCE_REPOSITORY_PATH"),
+	});
+
+	if (result.infrastructureFailures > 0) {
+		process.exitCode = 1;
+	}
+
+	return result;
+}
+
+function runLinterBatch({
+	applyWorkflowEnvironmentImpl = applyWorkflowEnvironment,
+	baseEnv,
+	contextPath,
+	execFileSyncImpl = execFileSync,
+	linterConfigPath,
+	linterNames,
+	linterServicePath,
+	renderReportImpl = renderReport,
+	renderSarifImpl = renderSarif,
+	runnerTemp,
+	selectLintTargetsImpl = selectLintTargets,
+	sourceRepositoryPath,
+}) {
+	const executionBaseEnv = {
+		...baseEnv,
+		LINTER_CONFIG_PATH: linterConfigPath,
+		LINTER_SERVICE_PATH: linterServicePath,
+		RUNNER_TEMP: runnerTemp,
+		SOURCE_REPOSITORY_PATH: sourceRepositoryPath,
+	};
+	let executionEnv = executionBaseEnv;
+	let infrastructureFailures = 0;
+	const linters = [];
+
+	for (const linterName of linterNames) {
+		console.log(`::group::${linterName}`);
+		const workDir = path.join(runnerTemp, "linter-batch", linterName);
+		const patternPath = path.join(workDir, "patterns.txt");
+		const selectedFilesPath = path.join(workDir, "selected-files.txt");
+		const resultPath = path.join(workDir, "linter-result.json");
+		const summaryPath = path.join(
+			runnerTemp,
+			`linter-summary-${linterName}.json`,
+		);
+		const sarifPath = path.join(runnerTemp, `linter-sarif-${linterName}.sarif`);
+		let selectOutcome = "success";
+		let installOutcome = "skipped";
+		let runOutcome = "skipped";
+		let exitCodeRaw = "";
+
+		fs.rmSync(workDir, { force: true, recursive: true });
+		fs.mkdirSync(workDir, { recursive: true });
+		fs.rmSync(summaryPath, { force: true });
+		fs.rmSync(sarifPath, { force: true });
+
+		try {
+			const patterns = execFileSyncImpl(
+				"bash",
+				[path.join(linterServicePath, linterName, "patterns.sh")],
+				{
+					cwd: linterServicePath,
+					encoding: "utf8",
+					env: executionEnv,
+				},
+			);
+			fs.writeFileSync(patternPath, patterns, "utf8");
+			selectLintTargetsImpl({
+				...executionEnv,
+				CONTEXT_PATH: contextPath,
+				LINTER_NAME: linterName,
+				OUTPUT_PATH: selectedFilesPath,
+				PATTERN_PATH: patternPath,
+				SOURCE_REPOSITORY_PATH: sourceRepositoryPath,
+			});
+		} catch (error) {
+			selectOutcome = "failure";
+			infrastructureFailures += 1;
+			logStepFailure("select", linterName, error);
+		}
+
+		const selectedFiles = readLines(selectedFilesPath);
+		if (selectOutcome === "success" && selectedFiles.length > 0) {
+			try {
+				executionEnv = installLinterTools({
+					applyWorkflowEnvironmentImpl,
+					execFileSyncImpl,
+					executionEnv,
+					linterName,
+					linterServicePath,
+					runnerTemp,
+				});
+				installOutcome = "success";
+			} catch (error) {
+				installOutcome = "failure";
+				infrastructureFailures += 1;
+				logStepFailure("install", linterName, error);
+			}
+		}
+
+		if (installOutcome === "success" && selectedFiles.length > 0) {
+			try {
+				const output = execFileSyncImpl(
+					"bash",
+					[
+						path.join(linterServicePath, linterName, "run.sh"),
+						...selectedFiles,
+					],
+					{
+						cwd: sourceRepositoryPath,
+						encoding: "utf8",
+						env: executionEnv,
+					},
+				);
+				fs.writeFileSync(resultPath, output, "utf8");
+				const parsed = JSON.parse(output);
+
+				if (!Number.isInteger(parsed.exit_code)) {
+					throw new Error(
+						`${linterName} run.sh output must include integer exit_code`,
+					);
+				}
+
+				exitCodeRaw = String(parsed.exit_code);
+				runOutcome = "success";
+			} catch (error) {
+				runOutcome = "failure";
+				infrastructureFailures += 1;
+				logStepFailure("run", linterName, error);
+			}
+		}
+
+		try {
+			const report = renderReportImpl({
+				configPath: linterConfigPath,
+				exitCodeRaw,
+				installOutcome,
+				linterName,
+				resultPath,
+				runOutcome,
+				selectedFilesPath,
+				selectOutcome,
+				sourceRepositoryPath,
+			});
+
+			fs.writeFileSync(
+				summaryPath,
+				JSON.stringify(
+					{
+						comment_body: report.body,
+						conclusion: report.conclusion,
+						linter_name: linterName,
+					},
+					null,
+					2,
+				),
+				"utf8",
+			);
+
+			const sarifReport = renderSarifImpl({
+				configPath: linterConfigPath,
+				installOutcome,
+				linterName,
+				outputPath: sarifPath,
+				resultPath,
+				runnerTemp,
+				runOutcome,
+				selectedFilesPath,
+				selectOutcome,
+				sourceRepositoryPath,
+			});
+
+			if (sarifReport.produced) {
+				fs.writeFileSync(
+					sarifReport.outputPath,
+					JSON.stringify(sarifReport.sarif, null, 2),
+					"utf8",
+				);
+			}
+
+			linters.push({
+				conclusion: report.conclusion,
+				exitCodeRaw,
+				installOutcome,
+				linterName,
+				resultPath,
+				runOutcome,
+				sarifProduced: sarifReport.produced,
+				selectOutcome,
+				selectedFiles,
+			});
+		} catch (error) {
+			infrastructureFailures += 1;
+			logStepFailure("render", linterName, error);
+			linters.push({
+				conclusion: "failure",
+				exitCodeRaw,
+				installOutcome,
+				linterName,
+				resultPath,
+				runOutcome,
+				sarifProduced: false,
+				selectOutcome,
+				selectedFiles,
+			});
+		}
+
+		console.log(
+			`${linterName}: selected ${selectedFiles.length} file(s), ` +
+				`select=${selectOutcome}, install=${installOutcome}, run=${runOutcome}`,
+		);
+		console.log("::endgroup::");
+	}
+
+	return {
+		infrastructureFailures,
+		linters,
+	};
+}
+
+function installLinterTools({
+	applyWorkflowEnvironmentImpl,
+	execFileSyncImpl,
+	executionEnv,
+	linterName,
+	linterServicePath,
+	runnerTemp,
+}) {
+	const envDir = path.join(
+		runnerTemp,
+		"linter-batch",
+		linterName,
+		"workflow-env",
+	);
+	const githubEnvPath = path.join(envDir, "github-env.txt");
+	const githubPathPath = path.join(envDir, "github-path.txt");
+	const installPath = path.join(linterServicePath, linterName, "install.sh");
+
+	fs.rmSync(envDir, { force: true, recursive: true });
+	fs.mkdirSync(envDir, { recursive: true });
+
+	const installEnv = {
+		...executionEnv,
+		GITHUB_ENV: githubEnvPath,
+		GITHUB_PATH: githubPathPath,
+	};
+
+	execFileSyncImpl("bash", [installPath], {
+		cwd: linterServicePath,
+		encoding: "utf8",
+		env: installEnv,
+	});
+
+	return applyWorkflowEnvironmentImpl(installEnv, {
+		githubEnvPath,
+		githubPathPath,
+	});
+}
+
+function parseLinterNames(input) {
+	const parsed = JSON.parse(input);
+
+	if (
+		!Array.isArray(parsed) ||
+		parsed.some((name) => typeof name !== "string")
+	) {
+		throw new Error("LINTER_NAMES_JSON must be a JSON array of strings");
+	}
+
+	return parsed;
+}
+
+function readLines(filePath) {
+	if (!fs.existsSync(filePath)) {
+		return [];
+	}
+
+	return fs
+		.readFileSync(filePath, "utf8")
+		.split(/\r?\n/u)
+		.map((line) => line.trim())
+		.filter(Boolean);
+}
+
+function logStepFailure(stepName, linterName, error) {
+	const details = formatExecError(error);
+	console.error(`::warning::${linterName} ${stepName} step failed${details}`);
+}
+
+function formatExecError(error) {
+	if (!error || typeof error !== "object") {
+		return "";
+	}
+
+	const stdout = typeof error.stdout === "string" ? error.stdout.trim() : "";
+	const stderr = typeof error.stderr === "string" ? error.stderr.trim() : "";
+	const message = typeof error.message === "string" ? error.message.trim() : "";
+	const details = [message, stdout, stderr].filter(Boolean).join("\n");
+
+	return details.length > 0 ? `\n${details}` : "";
+}
+
+function requireEnv(env, key) {
+	const value = env[key];
+
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(`${key} is required`);
+	}
+
+	return value;
+}
+
+if (require.main === module) {
+	runFromEnv(process.env);
+}
+
+module.exports = {
+	formatExecError,
+	installLinterTools,
+	parseLinterNames,
+	runFromEnv,
+	runLinterBatch,
+};

--- a/.github/scripts/run-linter-batch.test.js
+++ b/.github/scripts/run-linter-batch.test.js
@@ -1,0 +1,289 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { runLinterBatch } = require("./run-linter-batch.js");
+
+function createTempWorkspace() {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "run-linter-batch-"));
+	const linterServicePath = path.join(tempDir, "linter-service");
+	const sourceRepositoryPath = path.join(tempDir, "source-repo");
+	const runnerTemp = path.join(tempDir, "runner-temp");
+	const contextPath = path.join(runnerTemp, "context.json");
+	const linterConfigPath = path.join(linterServicePath, "linters.json");
+
+	fs.mkdirSync(path.join(linterServicePath, ".github", "scripts"), {
+		recursive: true,
+	});
+	fs.mkdirSync(sourceRepositoryPath, { recursive: true });
+	fs.mkdirSync(runnerTemp, { recursive: true });
+	fs.writeFileSync(
+		contextPath,
+		JSON.stringify({ changed_files: ["alpha.txt", "beta.md"] }),
+		"utf8",
+	);
+
+	return {
+		contextPath,
+		linterConfigPath,
+		linterServicePath,
+		runnerTemp,
+		sourceRepositoryPath,
+		tempDir,
+	};
+}
+
+function cleanupTempWorkspace(tempDir) {
+	fs.rmSync(tempDir, { force: true, recursive: true });
+}
+
+function writeFile(filePath, content) {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, content, "utf8");
+}
+
+function writeExecutable(filePath, content) {
+	writeFile(filePath, content);
+	fs.chmodSync(filePath, 0o755);
+}
+
+function writeLinterConfig(linterConfigPath, linters) {
+	writeFile(linterConfigPath, JSON.stringify({ linters }, null, 2));
+}
+
+function writeFakeLinter(
+	linterServicePath,
+	{ name, installScript, pattern, runScript },
+) {
+	const linterDir = path.join(linterServicePath, name);
+	writeExecutable(
+		path.join(linterDir, "patterns.sh"),
+		`#!/usr/bin/env bash\nprintf '%s\\n' '${pattern}'\n`,
+	);
+	writeExecutable(path.join(linterDir, "install.sh"), installScript);
+	writeExecutable(path.join(linterDir, "run.sh"), runScript);
+}
+
+test("runLinterBatch executes multiple linters and preserves workflow env updates", () => {
+	const workspace = createTempWorkspace();
+	writeFile(path.join(workspace.sourceRepositoryPath, "alpha.txt"), "alpha\n");
+	writeFile(path.join(workspace.sourceRepositoryPath, "beta.md"), "# beta\n");
+	writeLinterConfig(workspace.linterConfigPath, [
+		{
+			name: "alpha",
+			heading: "### alpha",
+			no_files: "no files",
+			success: "alpha ok",
+			failure: "alpha failed",
+			infra_failure: "alpha infra failed",
+			details_fallback: "alpha fallback",
+			sarif: {
+				enabled: false,
+			},
+		},
+		{
+			name: "beta",
+			heading: "### beta",
+			no_files: "no files",
+			success: "beta ok",
+			failure: "beta failed",
+			infra_failure: "beta infra failed",
+			details_fallback: "beta fallback",
+			sarif: {
+				enabled: false,
+			},
+		},
+	]);
+	writeFakeLinter(workspace.linterServicePath, {
+		name: "alpha",
+		installScript: `#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p "$RUNNER_TEMP/alpha-bin"
+cat > "$RUNNER_TEMP/alpha-bin/alpha-helper" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\\n' helper-ready
+EOF
+chmod +x "$RUNNER_TEMP/alpha-bin/alpha-helper"
+printf '%s\\n' "$RUNNER_TEMP/alpha-bin" >> "$GITHUB_PATH"
+printf '%s\\n' "ALPHA_READY=yes" >> "$GITHUB_ENV"
+`,
+		pattern: "^alpha\\.txt$",
+		runScript: `#!/usr/bin/env bash
+set -euo pipefail
+printf '{"details":"alpha:%s:%s:%s","exit_code":0}\\n' "$ALPHA_READY" "$(alpha-helper)" "$1"
+`,
+	});
+	writeFakeLinter(workspace.linterServicePath, {
+		name: "beta",
+		installScript: `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "BETA_READY=yes" >> "$GITHUB_ENV"
+`,
+		pattern: "^beta\\.md$",
+		runScript: `#!/usr/bin/env bash
+set -euo pipefail
+printf '{"details":"beta:%s:%s","exit_code":0}\\n' "$BETA_READY" "$1"
+`,
+	});
+
+	try {
+		const result = runLinterBatch({
+			baseEnv: {
+				...process.env,
+				PATH: process.env.PATH || "",
+			},
+			contextPath: workspace.contextPath,
+			linterConfigPath: workspace.linterConfigPath,
+			linterNames: ["alpha", "beta"],
+			linterServicePath: workspace.linterServicePath,
+			runnerTemp: workspace.runnerTemp,
+			sourceRepositoryPath: workspace.sourceRepositoryPath,
+		});
+
+		assert.equal(result.infrastructureFailures, 0);
+		assert.equal(result.linters.length, 2);
+		assert.equal(result.linters[0].conclusion, "success");
+		assert.equal(result.linters[1].conclusion, "success");
+
+		const alphaResult = JSON.parse(
+			fs.readFileSync(
+				path.join(
+					workspace.runnerTemp,
+					"linter-batch",
+					"alpha",
+					"linter-result.json",
+				),
+				"utf8",
+			),
+		);
+		const betaResult = JSON.parse(
+			fs.readFileSync(
+				path.join(
+					workspace.runnerTemp,
+					"linter-batch",
+					"beta",
+					"linter-result.json",
+				),
+				"utf8",
+			),
+		);
+		assert.equal(alphaResult.details, "alpha:yes:helper-ready:alpha.txt");
+		assert.equal(betaResult.details, "beta:yes:beta.md");
+
+		const alphaSummary = JSON.parse(
+			fs.readFileSync(
+				path.join(workspace.runnerTemp, "linter-summary-alpha.json"),
+				"utf8",
+			),
+		);
+		const betaSummary = JSON.parse(
+			fs.readFileSync(
+				path.join(workspace.runnerTemp, "linter-summary-beta.json"),
+				"utf8",
+			),
+		);
+		assert.equal(alphaSummary.conclusion, "success");
+		assert.equal(betaSummary.conclusion, "success");
+		assert.match(alphaSummary.comment_body, /alpha ok/u);
+		assert.match(betaSummary.comment_body, /beta ok/u);
+	} finally {
+		cleanupTempWorkspace(workspace.tempDir);
+	}
+});
+
+test("runLinterBatch continues after an install failure and reports infrastructure failure", () => {
+	const workspace = createTempWorkspace();
+	writeFile(path.join(workspace.sourceRepositoryPath, "alpha.txt"), "alpha\n");
+	writeFile(path.join(workspace.sourceRepositoryPath, "beta.md"), "# beta\n");
+	writeLinterConfig(workspace.linterConfigPath, [
+		{
+			name: "alpha",
+			heading: "### alpha",
+			no_files: "no files",
+			success: "alpha ok",
+			failure: "alpha failed",
+			infra_failure: "alpha infra failed",
+			details_fallback: "alpha fallback",
+			sarif: {
+				enabled: false,
+			},
+		},
+		{
+			name: "beta",
+			heading: "### beta",
+			no_files: "no files",
+			success: "beta ok",
+			failure: "beta failed",
+			infra_failure: "beta infra failed",
+			details_fallback: "beta fallback",
+			sarif: {
+				enabled: false,
+			},
+		},
+	]);
+	writeFakeLinter(workspace.linterServicePath, {
+		name: "alpha",
+		installScript: `#!/usr/bin/env bash
+set -euo pipefail
+echo "install boom" >&2
+exit 1
+`,
+		pattern: "^alpha\\.txt$",
+		runScript: `#!/usr/bin/env bash
+set -euo pipefail
+printf '{"details":"should-not-run","exit_code":0}\\n'
+`,
+	});
+	writeFakeLinter(workspace.linterServicePath, {
+		name: "beta",
+		installScript: `#!/usr/bin/env bash
+set -euo pipefail
+:
+`,
+		pattern: "^beta\\.md$",
+		runScript: `#!/usr/bin/env bash
+set -euo pipefail
+printf '{"details":"beta ok","exit_code":0}\\n'
+`,
+	});
+
+	try {
+		const result = runLinterBatch({
+			baseEnv: {
+				...process.env,
+				PATH: process.env.PATH || "",
+			},
+			contextPath: workspace.contextPath,
+			linterConfigPath: workspace.linterConfigPath,
+			linterNames: ["alpha", "beta"],
+			linterServicePath: workspace.linterServicePath,
+			runnerTemp: workspace.runnerTemp,
+			sourceRepositoryPath: workspace.sourceRepositoryPath,
+		});
+
+		assert.equal(result.infrastructureFailures, 1);
+		assert.equal(result.linters[0].installOutcome, "failure");
+		assert.equal(result.linters[0].runOutcome, "skipped");
+		assert.equal(result.linters[1].conclusion, "success");
+
+		const alphaSummary = JSON.parse(
+			fs.readFileSync(
+				path.join(workspace.runnerTemp, "linter-summary-alpha.json"),
+				"utf8",
+			),
+		);
+		const betaSummary = JSON.parse(
+			fs.readFileSync(
+				path.join(workspace.runnerTemp, "linter-summary-beta.json"),
+				"utf8",
+			),
+		);
+		assert.equal(alphaSummary.conclusion, "failure");
+		assert.match(alphaSummary.comment_body, /alpha infra failed/u);
+		assert.equal(betaSummary.conclusion, "success");
+	} finally {
+		cleanupTempWorkspace(workspace.tempDir);
+	}
+});

--- a/.github/scripts/workflow-command-env.js
+++ b/.github/scripts/workflow-command-env.js
@@ -1,0 +1,48 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+function applyWorkflowEnvironment(baseEnv, { githubEnvPath, githubPathPath }) {
+	const nextEnv = { ...baseEnv };
+
+	if (fs.existsSync(githubPathPath)) {
+		const pathEntries = fs
+			.readFileSync(githubPathPath, "utf8")
+			.split(/\r?\n/u)
+			.map((line) => line.trim())
+			.filter(Boolean);
+
+		if (pathEntries.length > 0) {
+			const basePath =
+				typeof baseEnv.PATH === "string" && baseEnv.PATH.length > 0
+					? baseEnv.PATH
+					: "";
+			nextEnv.PATH = [pathEntries.join(path.delimiter), basePath]
+				.filter(Boolean)
+				.join(path.delimiter);
+		}
+	}
+
+	if (fs.existsSync(githubEnvPath)) {
+		for (const line of fs
+			.readFileSync(githubEnvPath, "utf8")
+			.split(/\r?\n/u)
+			.filter(Boolean)) {
+			const separator = line.indexOf("=");
+
+			if (separator <= 0) {
+				continue;
+			}
+
+			nextEnv[line.slice(0, separator)] = line.slice(separator + 1);
+		}
+	}
+
+	delete nextEnv.GITHUB_ENV;
+	delete nextEnv.GITHUB_PATH;
+
+	return nextEnv;
+}
+
+module.exports = {
+	applyWorkflowEnvironment,
+};

--- a/.github/workflows/lint-common.yml
+++ b/.github/workflows/lint-common.yml
@@ -2,7 +2,10 @@ name: Lint Common
 on:
   workflow_call:
     inputs:
-      linter-name:
+      artifact-name:
+        required: true
+        type: string
+      linter-names-json:
         required: true
         type: string
     secrets:
@@ -18,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      LINTER_NAME: ${{ inputs.linter-name }}
       LINTER_CONFIG_PATH: ${{ github.workspace }}/linter-service/linters.json
+      LINTER_NAMES_JSON: ${{ inputs.linter-names-json }}
       LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
       SOURCE_REPOSITORY_PATH: ${{ github.workspace }}/source-repo
     steps:
@@ -88,117 +91,78 @@ jobs:
           ref: ${{ steps.decode_context.outputs.source-head-sha }}
           repository: ${{ steps.decode_context.outputs.source-owner }}/${{ steps.decode_context.outputs.source-repo }}
           token: ${{ steps.get_source_token.outputs.token }}
-      - name: Select lint target files
-        id: select_files
+      - name: Run linter batch
+        id: run_linter_batch
+        if: ${{ always() }}
         env:
           CONTEXT_PATH: ${{ runner.temp }}/detect-targets-context/detect-targets-context.json
-          OUTPUT_PATH: ${{ runner.temp }}/selected-files.txt
-          PATTERN_PATH: ${{ runner.temp }}/linter-patterns.txt
         run: |
-          script_path="$LINTER_SERVICE_PATH/$LINTER_NAME/patterns.sh"
-          bash "$script_path" > "$PATTERN_PATH"
-          node "$LINTER_SERVICE_PATH/.github/scripts/select-lint-targets.js"
-      - name: Install linter tool
-        id: install_tool
-        if: ${{ steps.select_files.outputs.count != '0' }}
-        run: |
-          script_path="$LINTER_SERVICE_PATH/$LINTER_NAME/install.sh"
-          (
-            cd "$LINTER_SERVICE_PATH" || exit 1
-            bash "$script_path"
-          )
-      - name: Run linter
-        id: run_linter
-        if: ${{ steps.select_files.outputs.count != '0' }}
-        env:
-          RESULT_PATH: ${{ runner.temp }}/linter-result.json
-        run: |
-          script_path="$LINTER_SERVICE_PATH/$LINTER_NAME/run.sh"
-          mapfile -t files < "$RUNNER_TEMP/selected-files.txt"
-          (
-            cd "$SOURCE_REPOSITORY_PATH" || exit 1
-            bash "$script_path" "${files[@]}" > "$RESULT_PATH"
-          )
-
-          python3 - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          result = json.loads(Path(os.environ["RESULT_PATH"]).read_text(encoding="utf-8"))
-          exit_code = result.get("exit_code")
-
-          if not isinstance(exit_code, int):
-              raise SystemExit("linter result JSON must include integer exit_code")
-
-          output_path = Path(os.environ["GITHUB_OUTPUT"])
-          with output_path.open("a", encoding="utf-8") as fh:
-              fh.write(f"exit_code={exit_code}\n")
-          PY
-      - name: Prepare linter report
-        id: prepare_report
-        if: ${{ always() }}
-        env:
-          EXIT_CODE: ${{ steps.run_linter.outputs.exit_code }}
-          INSTALL_TOOL_OUTCOME: ${{ steps.install_tool.outcome }}
-          LINTER_NAME: ${{ inputs.linter-name }}
-          RESULT_PATH: ${{ runner.temp }}/linter-result.json
-          RUN_LINTER_OUTCOME: ${{ steps.run_linter.outcome }}
-          SELECTED_FILES_PATH: ${{ runner.temp }}/selected-files.txt
-          SELECT_FILES_OUTCOME: ${{ steps.select_files.outcome }}
-        run: |
-          node "$LINTER_SERVICE_PATH/.github/scripts/render-linter-report.js"
-      - name: Prepare linter SARIF
-        id: prepare_sarif
-        if: ${{ always() }}
-        env:
-          INSTALL_TOOL_OUTCOME: ${{ steps.install_tool.outcome }}
-          LINTER_NAME: ${{ inputs.linter-name }}
-          OUTPUT_PATH: ${{ runner.temp }}/linter-sarif-${{ inputs.linter-name }}.sarif
-          RESULT_PATH: ${{ runner.temp }}/linter-result.json
-          RUN_LINTER_OUTCOME: ${{ steps.run_linter.outcome }}
-          SELECTED_FILES_PATH: ${{ runner.temp }}/selected-files.txt
-          SELECT_FILES_OUTCOME: ${{ steps.select_files.outcome }}
-        run: |
-          node "$LINTER_SERVICE_PATH/.github/scripts/render-linter-sarif.js"
-      - name: Encrypt linter summary artifact
+          node "$LINTER_SERVICE_PATH/.github/scripts/run-linter-batch.js"
+      - name: Encrypt linter summary artifacts
         id: encrypt_summary
         if: ${{ always() }}
         run: |
-          input_path="$RUNNER_TEMP/linter-summary-$LINTER_NAME.json"
-          output_path="$RUNNER_TEMP/linter-summary-$LINTER_NAME.json.enc"
-          bash "$LINTER_SERVICE_PATH/.github/scripts/secure-artifact.sh" \
-            encrypt \
-            "$input_path" \
-            "$output_path"
-          rm -f "$input_path"
-      - name: Upload linter summary artifact
+          shopt -s nullglob
+          failures=0
+          summary_files=("$RUNNER_TEMP"/linter-summary-*.json)
+          if [ "${#summary_files[@]}" -eq 0 ]; then
+            exit 0
+          fi
+
+          for input_path in "${summary_files[@]}"; do
+            output_path="$input_path.enc"
+            if ! bash "$LINTER_SERVICE_PATH/.github/scripts/secure-artifact.sh" \
+              encrypt \
+              "$input_path" \
+              "$output_path"; then
+              echo "::warning::Failed to encrypt $(basename "$input_path")"
+              failures=1
+              continue
+            fi
+
+            rm -f "$input_path"
+          done
+
+          exit "$failures"
+      - name: Upload linter summary artifacts
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: linter-summary-${{ inputs.linter-name }}
-          path: ${{ runner.temp }}/linter-summary-${{ inputs.linter-name }}.json.enc
+          name: linter-summary-${{ inputs.artifact-name }}
+          path: ${{ runner.temp }}/linter-summary-*.json.enc
           if-no-files-found: warn
           retention-days: 1
-      - name: Encrypt linter SARIF artifact
+      - name: Encrypt linter SARIF artifacts
         id: encrypt_sarif
         if: ${{ always() }}
         run: |
-          input_path="$RUNNER_TEMP/linter-sarif-$LINTER_NAME.sarif"
-          if [ ! -f "$input_path" ]; then
+          shopt -s nullglob
+          failures=0
+          sarif_files=("$RUNNER_TEMP"/linter-sarif-*.sarif)
+          if [ "${#sarif_files[@]}" -eq 0 ]; then
             exit 0
           fi
-          output_path="$RUNNER_TEMP/linter-sarif-$LINTER_NAME.sarif.enc"
-          bash "$LINTER_SERVICE_PATH/.github/scripts/secure-artifact.sh" \
-            encrypt \
-            "$input_path" \
-            "$output_path"
-          rm -f "$input_path"
-      - name: Upload linter SARIF artifact
+
+          for input_path in "${sarif_files[@]}"; do
+            output_path="$input_path.enc"
+            if ! bash "$LINTER_SERVICE_PATH/.github/scripts/secure-artifact.sh" \
+              encrypt \
+              "$input_path" \
+              "$output_path"; then
+              echo "::warning::Failed to encrypt $(basename "$input_path")"
+              failures=1
+              continue
+            fi
+
+            rm -f "$input_path"
+          done
+
+          exit "$failures"
+      - name: Upload linter SARIF artifacts
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: linter-sarif-${{ inputs.linter-name }}
-          path: ${{ runner.temp }}/linter-sarif-${{ inputs.linter-name }}.sarif.enc
+          name: linter-sarif-${{ inputs.artifact-name }}
+          path: ${{ runner.temp }}/linter-sarif-*.sarif.enc
           if-no-files-found: warn
           retention-days: 1

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -25,6 +25,7 @@ jobs:
     timeout-minutes: 30
     outputs:
       pull-request-number: ${{ steps.collect.outputs.pull-request-number }}
+      selected-linter-jobs-json: ${{ steps.collect.outputs.selected-linter-jobs-json }}
       selected-linters-json: ${{ steps.collect.outputs.selected-linters-json }}
       skip-reason: ${{ steps.collect.outputs.skip-reason }}
     env:
@@ -125,7 +126,11 @@ jobs:
                   text=True,
               )
               patterns = [line.strip() for line in result.stdout.splitlines() if line.strip()]
-              definitions.append({"name": linter_name, "patterns": patterns})
+              definition = {"name": linter_name, "patterns": patterns}
+              execution_group = item.get("execution_group")
+              if isinstance(execution_group, str) and execution_group:
+                  definition["execution_group"] = execution_group
+              definitions.append(definition)
 
           output_path = Path(os.environ["RUNNER_TEMP"]) / "linter-definitions.json"
           output_path.write_text(json.dumps(definitions), encoding="utf-8")
@@ -190,6 +195,7 @@ jobs:
               ".github/scripts/linter-service-config.js",
             ));
             const {
+              buildLinterJobAssignments,
               selectLinters,
               validateDefinition,
             } = require(path.join(
@@ -220,8 +226,17 @@ jobs:
               );
               core.setOutput("context-path", contextPath);
             };
-            const finalizeOutputs = ({ pullRequestNumber = pullNumberText, selectedLinters, skipReason }) => {
+            const finalizeOutputs = ({
+              pullRequestNumber = pullNumberText,
+              selectedLinterJobs,
+              selectedLinters,
+              skipReason,
+            }) => {
               core.setOutput("pull-request-number", pullRequestNumber);
+              core.setOutput(
+                "selected-linter-jobs-json",
+                JSON.stringify(selectedLinterJobs),
+              );
               core.setOutput("selected-linters-json", JSON.stringify(selectedLinters));
               core.setOutput("skip-reason", skipReason);
             };
@@ -270,6 +285,7 @@ jobs:
               });
               finalizeOutputs({
                 pullRequestNumber,
+                selectedLinterJobs: [],
                 selectedLinters: [],
                 skipReason,
               });
@@ -353,6 +369,10 @@ jobs:
                 definitions,
                 serviceConfig,
               });
+              const selectedLinterJobs = buildLinterJobAssignments({
+                definitions,
+                selectedLinters,
+              });
 
               writeContext({
                 changed_files: currentFiles,
@@ -371,6 +391,7 @@ jobs:
               });
               finalizeOutputs({
                 pullRequestNumber: String(pullNumber),
+                selectedLinterJobs,
                 selectedLinters,
                 skipReason: "",
               });
@@ -412,6 +433,10 @@ jobs:
                 definitions,
                 serviceConfig,
               });
+              const selectedLinterJobs = buildLinterJobAssignments({
+                definitions,
+                selectedLinters,
+              });
 
               writeContext({
                 changed_files: currentFiles,
@@ -430,6 +455,7 @@ jobs:
               });
               finalizeOutputs({
                 pullRequestNumber: "",
+                selectedLinterJobs,
                 selectedLinters,
                 skipReason: "",
               });
@@ -439,12 +465,14 @@ jobs:
             throw new Error(`Unsupported routed event: ${routedEventName}`);
       - name: Report routing status
         env:
+          SELECTED_LINTER_JOBS_JSON: ${{ steps.collect.outputs.selected-linter-jobs-json }}
           ROUTED_EVENT_NAME: ${{ env.ROUTED_EVENT_NAME }}
           SELECTED_LINTERS_JSON: ${{ steps.collect.outputs.selected-linters-json }}
         run: |
           echo "Routing targets resolved."
           echo "Routed event: ${ROUTED_EVENT_NAME}"
           echo "Selected linters: ${SELECTED_LINTERS_JSON}"
+          echo "Selected linter jobs: ${SELECTED_LINTER_JOBS_JSON}"
       - name: Derive artifact passphrase
         env:
           CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}
@@ -577,20 +605,21 @@ jobs:
             );
             await upsertCheckRun({ github, env: process.env });
   run-linters:
-    name: ${{ matrix.linter }}
+    name: ${{ matrix.assignment.name }}
     needs:
       - detect-targets
       - notify-processing-started
-    if: ${{ needs.detect-targets.outputs.selected-linters-json != '[]' }}
+    if: ${{ needs.detect-targets.outputs.selected-linter-jobs-json != '[]' }}
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        linter: ${{ fromJSON(needs.detect-targets.outputs.selected-linters-json) }}
+        assignment: ${{ fromJSON(needs.detect-targets.outputs.selected-linter-jobs-json) }}
     uses: ./.github/workflows/lint-common.yml
     with:
-      linter-name: ${{ matrix.linter }}
+      artifact-name: ${{ matrix.assignment.artifact_name }}
+      linter-names-json: ${{ toJSON(matrix.assignment.linter_names) }}
     secrets:
       CHECKER_APP_ID: ${{ secrets.CHECKER_APP_ID }}
       CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -8,21 +8,19 @@ rules:
         - CHECKER_APP_ID
         - CHECKER_PRIVATE_KEY
     ignore:
-      - lint-common.yml:39
-      - lint-common.yml:78
+      - lint-common.yml:42
       - lint-common.yml:81
-      - repository-dispatch.yml:141
-      - repository-dispatch.yml:145
-      - repository-dispatch.yml:152
-      - repository-dispatch.yml:155
-      - repository-dispatch.yml:450
-      - repository-dispatch.yml:495
-      - repository-dispatch.yml:542
-      - repository-dispatch.yml:545
-      - repository-dispatch.yml:595
-      - repository-dispatch.yml:596
-      - repository-dispatch.yml:621
-      - repository-dispatch.yml:690
-      - repository-dispatch.yml:694
-      - repository-dispatch.yml:701
-      - repository-dispatch.yml:704
+      - lint-common.yml:84
+      - repository-dispatch.yml:146
+      - repository-dispatch.yml:150
+      - repository-dispatch.yml:157
+      - repository-dispatch.yml:160
+      - repository-dispatch.yml:478
+      - repository-dispatch.yml:523
+      - repository-dispatch.yml:570
+      - repository-dispatch.yml:573
+      - repository-dispatch.yml:650
+      - repository-dispatch.yml:719
+      - repository-dispatch.yml:723
+      - repository-dispatch.yml:730
+      - repository-dispatch.yml:733

--- a/linters.json
+++ b/linters.json
@@ -2,6 +2,7 @@
   "linters": [
     {
       "name": "actionlint",
+      "execution_group": "github-actions",
       "heading": "### actionlint",
       "no_files": "No matching workflow files were selected for `actionlint`.",
       "success": "✅ No issues were reported for the selected GitHub Actions workflow target(s).",
@@ -14,6 +15,7 @@
     },
     {
       "name": "ghalint",
+      "execution_group": "github-actions",
       "heading": "### ghalint",
       "no_files": "No matching GitHub Actions workflow files were selected for `ghalint`.",
       "success": "✅ No issues were reported for the selected GitHub Actions workflow target(s).",
@@ -62,6 +64,7 @@
     },
     {
       "name": "yamllint",
+      "execution_group": "yaml",
       "heading": "### yamllint",
       "no_files": "No matching YAML files were selected for `yamllint`.",
       "success": "✅ No issues were reported for the selected YAML target(s).",
@@ -74,6 +77,7 @@
     },
     {
       "name": "yamlfmt",
+      "execution_group": "yaml",
       "heading": "### yamlfmt",
       "no_files": "No matching YAML files were selected for `yamlfmt`.",
       "success": "✅ No issues were reported for the selected YAML target(s).",
@@ -195,6 +199,7 @@
     },
     {
       "name": "zizmor",
+      "execution_group": "github-actions",
       "heading": "### zizmor",
       "no_files": "No matching workflow files were selected for `zizmor`.",
       "success": "✅ No issues were reported for the selected GitHub Actions workflow target(s).",


### PR DESCRIPTION
## Summary
- add optional `execution_group` routing in `linters.json` for lightweight GitHub Actions and YAML linters
- group selected linters into shared reusable-workflow jobs while keeping per-linter summary and SARIF filenames stable
- add batch execution and regression coverage for multi-linter runs, workflow command env propagation, and infra-failure handling

## Validation
- node --test .github/scripts/*.test.js
- RUNNER_TEMP=<tmp> bash actionlint/install.sh && actionlint .github/workflows/lint-common.yml .github/workflows/repository-dispatch.yml
- git diff --check