### PR TITLE
feat(trivy): add shared Dockerfile scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ default branch push では repository 全体の tracked file path から対象 l
 | `actionlint` | `.github/workflows/*.yml`, `.github/workflows/*.yaml` | `.github/actionlint.yaml` / `.github/actionlint.yml` | - |
 | `ghalint` | `.github/workflows/*.yml`, `.github/workflows/*.yaml` | `.ghalint.yaml` → `.ghalint.yml` → `ghalint.yaml` → `ghalint.yml` → `.github/ghalint.yaml` → `.github/ghalint.yml` | - |
 | `hadolint` | `Dockerfile`, `Dockerfile.*`, `Containerfile`, `Containerfile.*`, `*.dockerfile`, `*.containerfile` | 対象ファイルの directory から親へ向けて `.hadolint.yaml` / `.hadolint.yml` を探し、見つかれば `--config` で明示します。 | 未配置時は既定値を使います。 |
+| `trivy` | `Dockerfile`, `Dockerfile.*`, `Containerfile`, `Containerfile.*`, `*.dockerfile`, `*.containerfile` | repo root の `trivy.yaml` / `trivy.yml` と `.trivyignore` | shared workflow は Dockerfile/Containerfile の misconfiguration scan だけを、SHA pin した official image 内で実行します。container は `--cap-drop ALL --security-opt no-new-privileges --read-only --tmpfs /tmp --network=none --user <uid>:<gid>` で動かし、`--skip-check-update` により実行時の rule update は行いません。 |
 | `dotenv-linter` | `.env`, `.env.*` | なし | shared workflow は upstream default checks を changed `.env` file に直接適用します。`--schema` や ignore-checks の注入は現状未対応です。 |
 | `spectral` | `*.json`, `*.yaml`, `*.yml` | `.spectral.yml` / `.spectral.yaml` / `.spectral.json` | 未配置時は `spectral:oas` を使い、unknown format は無視します。`.spectral.js` は任意コード実行を避けるため対象外です。 |
 | `yamllint` | `*.yaml`, `*.yml` | `.yamllint` → `.yamllint.yaml` → `.yamllint.yml` | - |

--- a/linters.json
+++ b/linters.json
@@ -39,6 +39,19 @@
       }
     },
     {
+      "name": "trivy",
+      "heading": "### trivy",
+      "no_files": "No matching Dockerfile or Containerfile files were selected for `trivy`.",
+      "success": "✅ No misconfigurations were reported for the selected Dockerfile or Containerfile target(s).",
+      "failure": "❌ Misconfigurations were reported for the selected Dockerfile or Containerfile target(s).",
+      "infra_failure": "❌ The `trivy` workflow failed before producing a detailed report. See the workflow logs.",
+      "details_fallback": "trivy did not produce diagnostic output before the job failed.",
+      "sarif": {
+        "enabled": true,
+        "default_level": "warning"
+      }
+    },
+    {
       "name": "dotenv-linter",
       "heading": "### dotenv-linter",
       "no_files": "No matching .env files were selected for `dotenv-linter`.",

--- a/trivy/common.sh
+++ b/trivy/common.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../.github/scripts/linter-library.sh
+source "$script_dir/../.github/scripts/linter-library.sh"
+
+trivy_image_ref() {
+  printf '%s\n' "${TRIVY_IMAGE_REF:-ghcr.io/aquasecurity/trivy:0.69.3@sha256:7228e304ae0f610a1fad937baa463598cadac0c2ac4027cc68f3a8b997115689}"
+}
+
+trivy_platform() {
+  printf '%s\n' "${TRIVY_PLATFORM:-linux/amd64}"
+}
+
+trivy_container_bin() {
+  local docker_bin resolved_bin podman_bin
+
+  podman_bin="${CONTROL_PLANE_PODMAN_BIN:-/usr/bin/podman}"
+  docker_bin=""
+  resolved_bin=""
+
+  if command -v docker >/dev/null 2>&1; then
+    docker_bin=$(command -v docker)
+    resolved_bin="$docker_bin"
+  elif command -v podman >/dev/null 2>&1; then
+    printf '%s\n' "$(command -v podman)"
+    return 0
+  else
+    echo "docker or podman is required to run trivy in an isolated container" >&2
+    return 1
+  fi
+
+  if command -v readlink >/dev/null 2>&1; then
+    resolved_bin=$(readlink -f "$docker_bin" 2>/dev/null || printf '%s\n' "$docker_bin")
+  fi
+
+  if [ "$(basename "$resolved_bin")" = "control-plane-podman" ] && [ -x "$podman_bin" ]; then
+    printf '%s\n' "$podman_bin"
+    return 0
+  fi
+
+  printf '%s\n' "$docker_bin"
+}
+
+trivy_require_container_runtime() {
+  if ! command -v docker >/dev/null 2>&1 && ! command -v podman >/dev/null 2>&1; then
+    echo "docker or podman is required to run trivy in an isolated container" >&2
+    return 1
+  fi
+}
+
+trivy_find_root_config() {
+  local candidate
+
+  for candidate in trivy.yaml trivy.yml; do
+    if [ -f "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+trivy_copy_root_support_files() {
+  local target_root=$1
+
+  linter_lib::copy_first_existing_path "$target_root" trivy.yaml trivy.yml || true
+
+  if [ -f .trivyignore ]; then
+    local destination="$target_root/.trivyignore"
+    mkdir -p "$(dirname "$destination")"
+    cp .trivyignore "$destination"
+  fi
+}

--- a/trivy/install.sh
+++ b/trivy/install.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=./common.sh
+source "$script_dir/common.sh"
+
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+trivy_require_container_runtime
+
+container_bin=$(trivy_container_bin)
+image_ref=$(trivy_image_ref)
+platform=$(trivy_platform)
+
+if "$container_bin" image inspect "$image_ref" >/dev/null 2>&1; then
+  exit 0
+fi
+
+"$container_bin" pull --platform "$platform" "$image_ref" >/dev/null

--- a/trivy/patterns.sh
+++ b/trivy/patterns.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=./common.sh
+source "$script_dir/common.sh"
+
+cat <<'EOF'
+(?:^|/)(?:Dockerfile(?:\.[^/]+)?|Containerfile(?:\.[^/]+)?|[^/]+\.(?:dockerfile|containerfile))$
+EOF

--- a/trivy/render-linter-sarif.test.js
+++ b/trivy/render-linter-sarif.test.js
@@ -1,0 +1,74 @@
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	assert,
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("../.github/scripts/cargo-linter-test-lib.js");
+const { runFromEnv } = require("../.github/scripts/render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "..", "linters.json");
+const details = [
+	"Dockerfile:1:1: warning DS-0001 (MEDIUM): Specify a tag in the 'FROM' statement for image 'ubuntu'",
+	"Dockerfile:2:1: error DS-0002 (HIGH): Last USER command in Dockerfile should not be 'root'",
+].join("\n");
+
+test("emits SARIF for Trivy diagnostics rendered as path diagnostics", () => {
+	const context = makeTempRepo("render-linter-sarif-trivy-");
+
+	writeFile(
+		path.join(context.repoDir, "Dockerfile"),
+		"FROM ubuntu:latest\nUSER root\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"Dockerfile\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "trivy",
+			OUTPUT_PATH: path.join(context.runnerTemp, "trivy.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.deepEqual(
+			report.sarif.runs[0].results.map((result) => ({
+				level: result.level,
+				line: result.locations[0].physicalLocation.region.startLine,
+				ruleId: result.ruleId,
+			})),
+			[
+				{
+					level: "warning",
+					line: 1,
+					ruleId: "DS-0001",
+				},
+				{
+					level: "error",
+					line: 2,
+					ruleId: "DS-0002",
+				},
+			],
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/trivy/run.sh
+++ b/trivy/run.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=./common.sh
+source "$script_dir/common.sh"
+
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+trivy_require_container_runtime
+output_file="$RUNNER_TEMP/linter-output.txt"
+workspace_root="$RUNNER_TEMP/trivy-workspace"
+source_root="$workspace_root/source"
+report_path="$workspace_root/trivy-report.json"
+stderr_path="$workspace_root/trivy-stderr.txt"
+container_bin=$(trivy_container_bin)
+image_ref=$(trivy_image_ref)
+platform=$(trivy_platform)
+user_id=$(id -u)
+group_id=$(id -g)
+
+docker_run_common=(
+  --rm
+  --platform "$platform"
+  --cap-drop ALL
+  --security-opt no-new-privileges
+  --read-only
+  --tmpfs /tmp
+  --network=none
+  --user "$user_id:$group_id"
+  --workdir /work
+  --mount "type=bind,src=$source_root,dst=/work,readonly"
+  --env HOME=/tmp
+)
+
+run_trivy() {
+  local exit_code=0
+  local config_path path
+  local -a trivy_args=()
+
+  rm -rf "$workspace_root"
+  mkdir -p "$source_root"
+
+  linter_lib::copy_paths_to_root "$source_root" "$@"
+  trivy_copy_root_support_files "$source_root"
+
+  for path in "$@"; do
+    if [ ! -f "$source_root/$path" ]; then
+      echo "failed to prepare trivy target: $path" >&2
+      return 1
+    fi
+  done
+
+  if config_path=$(trivy_find_root_config 2>/dev/null); then
+    trivy_args+=(--config "$config_path")
+  fi
+
+  if "$container_bin" run \
+    "${docker_run_common[@]}" \
+    "$image_ref" \
+    config \
+      --skip-check-update \
+      --skip-version-check \
+      --disable-telemetry \
+      --quiet \
+      --format json \
+      --exit-code 1 \
+      "${trivy_args[@]}" \
+      /work >"$report_path" 2>"$stderr_path"; then
+    exit_code=0
+  else
+    exit_code=$?
+  fi
+
+  node "$script_dir/trivy-result.js" "$report_path" "$stderr_path" "$exit_code"
+  return "$exit_code"
+}
+
+linter_lib::run_and_emit_json "$output_file" run_trivy "$@"

--- a/trivy/tests/fail/result.json
+++ b/trivy/tests/fail/result.json
@@ -1,0 +1,10 @@
+{
+  "checked_projects": [],
+  "result": {
+    "details": "Dockerfile:1:1: warning DS-0001 (MEDIUM): Specify a tag in the 'FROM' statement for image 'ubuntu'\nDockerfile:1:1: warning DS-0026 (LOW): Add HEALTHCHECK instruction in your Dockerfile\nDockerfile:2:1: error DS-0002 (HIGH): Last USER command in Dockerfile should not be 'root'",
+    "exit_code": 1
+  },
+  "selected_files": [
+    "Dockerfile"
+  ]
+}

--- a/trivy/tests/fail/sarif.json
+++ b/trivy/tests/fail/sarif.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "runs": [
+    {
+      "automationDetails": {
+        "id": "linter-service/trivy"
+      },
+      "results": [
+        {
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "Dockerfile"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "warning DS-0001 (MEDIUM): Specify a tag in the 'FROM' statement for image 'ubuntu'"
+          },
+          "properties": {
+            "linter_name": "trivy"
+          },
+          "ruleId": "DS-0001"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "Dockerfile"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "error DS-0002 (HIGH): Last USER command in Dockerfile should not be 'root'"
+          },
+          "properties": {
+            "linter_name": "trivy"
+          },
+          "ruleId": "DS-0002"
+        },
+        {
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "Dockerfile"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "warning DS-0026 (LOW): Add HEALTHCHECK instruction in your Dockerfile"
+          },
+          "properties": {
+            "linter_name": "trivy"
+          },
+          "ruleId": "DS-0026"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/chalharu/linter-service",
+          "name": "linter-service/trivy",
+          "rules": [
+            {
+              "id": "DS-0001",
+              "name": "DS-0001",
+              "shortDescription": {
+                "text": "DS-0001"
+              }
+            },
+            {
+              "id": "DS-0002",
+              "name": "DS-0002",
+              "shortDescription": {
+                "text": "DS-0002"
+              }
+            },
+            {
+              "id": "DS-0026",
+              "name": "DS-0026",
+              "shortDescription": {
+                "text": "DS-0026"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/trivy/tests/fail/target/Dockerfile
+++ b/trivy/tests/fail/target/Dockerfile
@@ -1,0 +1,2 @@
+FROM ubuntu:latest
+USER root

--- a/trivy/tests/pass/result.json
+++ b/trivy/tests/pass/result.json
@@ -1,0 +1,10 @@
+{
+  "checked_projects": [],
+  "result": {
+    "details": "",
+    "exit_code": 0
+  },
+  "selected_files": [
+    "Dockerfile"
+  ]
+}

--- a/trivy/tests/pass/sarif.json
+++ b/trivy/tests/pass/sarif.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "runs": [
+    {
+      "automationDetails": {
+        "id": "linter-service/trivy"
+      },
+      "results": [],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/chalharu/linter-service",
+          "name": "linter-service/trivy",
+          "rules": []
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/trivy/tests/pass/target/Dockerfile
+++ b/trivy/tests/pass/target/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:24.04
+RUN useradd --system --uid 10001 app
+USER app
+HEALTHCHECK CMD ["true"]

--- a/trivy/trivy-result.js
+++ b/trivy/trivy-result.js
@@ -1,0 +1,180 @@
+const fs = require("node:fs");
+
+function renderTrivyDetails({ exitCode, report, stderr }) {
+	const diagnostics = collectTrivyDiagnostics(report);
+	if (diagnostics.length > 0) {
+		return diagnostics.map(formatTrivyDiagnostic).join("\n");
+	}
+
+	const stderrText = typeof stderr === "string" ? stderr.trim() : "";
+	if (stderrText.length > 0) {
+		return stderrText;
+	}
+
+	return exitCode === 0
+		? ""
+		: "trivy failed before producing diagnostic output.";
+}
+
+function collectTrivyDiagnostics(report) {
+	const diagnostics = [];
+
+	for (const result of Array.isArray(report?.Results) ? report.Results : []) {
+		for (const misconfiguration of Array.isArray(result?.Misconfigurations)
+			? result.Misconfigurations
+			: []) {
+			diagnostics.push(
+				buildTrivyDiagnostic({
+					misconfiguration,
+					target: result?.Target,
+				}),
+			);
+		}
+	}
+
+	return diagnostics.sort(compareTrivyDiagnostics);
+}
+
+function buildTrivyDiagnostic({ misconfiguration, target }) {
+	const severity = normalizeSeverity(misconfiguration?.Severity);
+	return {
+		column: 1,
+		level: severityToLinterLevel(severity),
+		line: parsePositiveInteger(misconfiguration?.CauseMetadata?.StartLine) ?? 1,
+		message: resolveTrivyMessage(misconfiguration),
+		ruleId:
+			typeof misconfiguration?.ID === "string" && misconfiguration.ID.length > 0
+				? misconfiguration.ID
+				: "trivy/diagnostic",
+		severity,
+		target: normalizePath(target || "Dockerfile"),
+	};
+}
+
+function resolveTrivyMessage(misconfiguration) {
+	if (
+		typeof misconfiguration?.Message === "string" &&
+		misconfiguration.Message.length > 0
+	) {
+		return misconfiguration.Message;
+	}
+
+	if (
+		typeof misconfiguration?.Title === "string" &&
+		misconfiguration.Title.length > 0
+	) {
+		return misconfiguration.Title;
+	}
+
+	if (
+		typeof misconfiguration?.Description === "string" &&
+		misconfiguration.Description.length > 0
+	) {
+		return misconfiguration.Description;
+	}
+
+	return "Trivy reported a misconfiguration.";
+}
+
+function formatTrivyDiagnostic(diagnostic) {
+	return `${diagnostic.target}:${diagnostic.line}:${diagnostic.column}: ${diagnostic.level} ${diagnostic.ruleId} (${diagnostic.severity}): ${diagnostic.message}`;
+}
+
+function compareTrivyDiagnostics(left, right) {
+	return [
+		left.target,
+		String(left.line),
+		String(left.column),
+		left.ruleId,
+		left.message,
+	]
+		.join("\u0000")
+		.localeCompare(
+			[
+				right.target,
+				String(right.line),
+				String(right.column),
+				right.ruleId,
+				right.message,
+			].join("\u0000"),
+		);
+}
+
+function normalizeSeverity(value) {
+	const severity = String(value || "")
+		.trim()
+		.toUpperCase();
+	return ["UNKNOWN", "LOW", "MEDIUM", "HIGH", "CRITICAL"].includes(severity)
+		? severity
+		: "UNKNOWN";
+}
+
+function severityToLinterLevel(severity) {
+	return severity === "HIGH" || severity === "CRITICAL" ? "error" : "warning";
+}
+
+function normalizePath(filePath) {
+	return String(filePath || "")
+		.replace(/\\/gu, "/")
+		.replace(/^\.\//u, "");
+}
+
+function parsePositiveInteger(value) {
+	if (typeof value === "number") {
+		return Number.isInteger(value) && value > 0 ? value : null;
+	}
+
+	if (typeof value !== "string" || value.trim().length === 0) {
+		return null;
+	}
+
+	const parsed = Number(value);
+	return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function readTextFile(filePath) {
+	if (typeof filePath !== "string" || filePath.length === 0) {
+		return "";
+	}
+
+	return fs.existsSync(filePath) ? fs.readFileSync(filePath, "utf8") : "";
+}
+
+function readTrivyReport(filePath) {
+	const source = readTextFile(filePath);
+	if (source.trim().length === 0) {
+		return null;
+	}
+
+	try {
+		return JSON.parse(source);
+	} catch {
+		return null;
+	}
+}
+
+function runCli(argv = process.argv.slice(2)) {
+	const [reportPath, stderrPath, exitCodeRaw] = argv;
+	const details = renderTrivyDetails({
+		exitCode: Number.parseInt(exitCodeRaw || "0", 10) || 0,
+		report: readTrivyReport(reportPath),
+		stderr: readTextFile(stderrPath),
+	});
+
+	if (details.length > 0) {
+		process.stdout.write(`${details}\n`);
+	}
+}
+
+if (require.main === module) {
+	runCli();
+}
+
+module.exports = {
+	buildTrivyDiagnostic,
+	collectTrivyDiagnostics,
+	formatTrivyDiagnostic,
+	readTrivyReport,
+	renderTrivyDetails,
+	severityToLinterLevel,
+};

--- a/trivy/trivy-result.test.js
+++ b/trivy/trivy-result.test.js
@@ -1,0 +1,137 @@
+const test = require("node:test");
+
+const { assert } = require("../.github/scripts/cargo-linter-test-lib.js");
+const {
+	collectTrivyDiagnostics,
+	renderTrivyDetails,
+	severityToLinterLevel,
+} = require("./trivy-result.js");
+
+test("severityToLinterLevel maps high severities to errors", () => {
+	assert.equal(severityToLinterLevel("CRITICAL"), "error");
+	assert.equal(severityToLinterLevel("HIGH"), "error");
+	assert.equal(severityToLinterLevel("MEDIUM"), "warning");
+	assert.equal(severityToLinterLevel("LOW"), "warning");
+});
+
+test("collectTrivyDiagnostics normalizes and sorts misconfigurations", () => {
+	const diagnostics = collectTrivyDiagnostics({
+		Results: [
+			{
+				Target: "services/api/Containerfile",
+				Misconfigurations: [
+					{
+						ID: "DS-0002",
+						Message: "Last USER command in Dockerfile should not be 'root'",
+						Severity: "HIGH",
+						CauseMetadata: {
+							StartLine: 4,
+						},
+					},
+				],
+			},
+			{
+				Target: "Dockerfile",
+				Misconfigurations: [
+					{
+						ID: "DS-0026",
+						Message: "Add HEALTHCHECK instruction in your Dockerfile",
+						Severity: "LOW",
+					},
+				],
+			},
+		],
+	});
+
+	assert.deepEqual(diagnostics, [
+		{
+			column: 1,
+			level: "warning",
+			line: 1,
+			message: "Add HEALTHCHECK instruction in your Dockerfile",
+			ruleId: "DS-0026",
+			severity: "LOW",
+			target: "Dockerfile",
+		},
+		{
+			column: 1,
+			level: "error",
+			line: 4,
+			message: "Last USER command in Dockerfile should not be 'root'",
+			ruleId: "DS-0002",
+			severity: "HIGH",
+			target: "services/api/Containerfile",
+		},
+	]);
+});
+
+test("renderTrivyDetails renders path diagnostics from a Trivy report", () => {
+	const details = renderTrivyDetails({
+		exitCode: 1,
+		report: {
+			Results: [
+				{
+					Target: "Dockerfile",
+					Misconfigurations: [
+						{
+							ID: "DS-0001",
+							Message:
+								"Specify a tag in the 'FROM' statement for image 'ubuntu'",
+							Severity: "MEDIUM",
+							CauseMetadata: {
+								StartLine: 1,
+							},
+						},
+						{
+							ID: "DS-0002",
+							Message: "Last USER command in Dockerfile should not be 'root'",
+							Severity: "HIGH",
+							CauseMetadata: {
+								StartLine: 2,
+							},
+						},
+					],
+				},
+			],
+		},
+		stderr: "",
+	});
+
+	assert.equal(
+		details,
+		[
+			"Dockerfile:1:1: warning DS-0001 (MEDIUM): Specify a tag in the 'FROM' statement for image 'ubuntu'",
+			"Dockerfile:2:1: error DS-0002 (HIGH): Last USER command in Dockerfile should not be 'root'",
+		].join("\n"),
+	);
+});
+
+test("renderTrivyDetails falls back to stderr when Trivy fails before reporting", () => {
+	const details = renderTrivyDetails({
+		exitCode: 1,
+		report: null,
+		stderr: "FATAL init error",
+	});
+
+	assert.equal(details, "FATAL init error");
+});
+
+test("renderTrivyDetails is empty for a clean report", () => {
+	const details = renderTrivyDetails({
+		exitCode: 0,
+		report: {
+			Results: [
+				{
+					Target: "Dockerfile",
+					MisconfSummary: {
+						Failures: 0,
+						Successes: 27,
+					},
+				},
+			],
+		},
+		stderr: "",
+	});
+
+	assert.equal(details, "");
+});

--- a/trivy/trivy.test.js
+++ b/trivy/trivy.test.js
@@ -1,0 +1,234 @@
+const test = require("node:test");
+const { execFileSync } = require("node:child_process");
+
+const {
+	assert,
+	cleanupTempRepo,
+	fs,
+	makeTempRepo,
+	path,
+	writeExecutable,
+	writeFile,
+} = require("../.github/scripts/cargo-linter-test-lib.js");
+
+const installPath = path.join(__dirname, "install.sh");
+const patternsPath = path.join(__dirname, "patterns.sh");
+const runPath = path.join(__dirname, "run.sh");
+
+function createEnv(context, extraEnv = {}) {
+	return {
+		...process.env,
+		...extraEnv,
+		PATH: `${context.binDir}:${process.env.PATH}`,
+		RUNNER_TEMP: context.runnerTemp,
+	};
+}
+
+function createDockerStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "docker"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+command="$1"
+shift
+
+case "$command" in
+  image)
+    subcommand="$1"
+    shift
+    if [ "$subcommand" != "inspect" ]; then
+      echo "unsupported docker image subcommand: $subcommand" >&2
+      exit 1
+    fi
+    printf '%s\\n' "$*" >> "$DOCKER_IMAGE_INSPECT_LOG"
+    if [ -n "\${MISSING_IMAGE:-}" ]; then
+      exit 1
+    fi
+    ;;
+  pull)
+    printf '%s\\n' "$*" >> "$DOCKER_PULL_ARGS_LOG"
+    ;;
+  run)
+    printf '%s\\n' "$*" >> "$DOCKER_RUN_ARGS_LOG"
+    image_ref=""
+    option_with_value=""
+    command_args=()
+    for arg in "$@"; do
+      if [ -n "$option_with_value" ]; then
+        option_with_value=""
+        continue
+      fi
+      case "$arg" in
+        --mount|--workdir|--user|--tmpfs|--security-opt|--cap-drop|--env|-e|--platform)
+          option_with_value="$arg"
+          continue
+          ;;
+        --rm|--read-only|--network=*)
+          continue
+          ;;
+      esac
+      if [ -z "$image_ref" ]; then
+        image_ref="$arg"
+        continue
+      fi
+      command_args+=("$arg")
+    done
+    if [ "\${#command_args[@]}" -eq 0 ]; then
+      exit 0
+    fi
+    if [ "\${command_args[0]}" = "config" ]; then
+      if [ -n "\${TRIVY_STDOUT:-}" ]; then
+        printf '%s' "$TRIVY_STDOUT"
+      fi
+      if [ -n "\${TRIVY_STDERR:-}" ]; then
+        printf '%s' "$TRIVY_STDERR" >&2
+      fi
+      exit "\${TRIVY_EXIT_CODE:-0}"
+    fi
+    echo "unsupported docker run command: \${command_args[*]}" >&2
+    exit 1
+    ;;
+  *)
+    echo "unsupported docker command: $command" >&2
+    exit 1
+    ;;
+esac
+`,
+	);
+}
+
+test("trivy patterns match Dockerfile and Containerfile naming conventions", () => {
+	const output = execFileSync("bash", [patternsPath], {
+		encoding: "utf8",
+	});
+	const patterns = output
+		.trim()
+		.split("\n")
+		.filter(Boolean)
+		.map((pattern) => new RegExp(pattern, "i"));
+
+	const matches = (filePath) =>
+		patterns.some((pattern) => pattern.test(filePath));
+
+	assert.equal(matches("Dockerfile"), true);
+	assert.equal(matches("Dockerfile.dev"), true);
+	assert.equal(matches("containers/Containerfile"), true);
+	assert.equal(matches("containers/base.containerfile"), true);
+	assert.equal(matches("docker/api.dockerfile"), true);
+	assert.equal(matches("docs/docker-guide.md"), false);
+	assert.equal(matches(".dockerignore"), false);
+});
+
+test("trivy install pulls the pinned Trivy image when it is missing", () => {
+	const context = makeTempRepo("trivy-install-");
+	const imageInspectLog = path.join(
+		context.tempDir,
+		"docker-image-inspect.log",
+	);
+	const pullArgsLog = path.join(context.tempDir, "docker-pull-args.log");
+
+	createDockerStub(context.binDir);
+
+	try {
+		execFileSync("bash", [installPath], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createEnv(context, {
+				DOCKER_IMAGE_INSPECT_LOG: imageInspectLog,
+				DOCKER_PULL_ARGS_LOG: pullArgsLog,
+				MISSING_IMAGE: "1",
+			}),
+		});
+
+		assert.match(
+			fs.readFileSync(imageInspectLog, "utf8"),
+			/ghcr\.io\/aquasecurity\/trivy:0\.69\.3@sha256:7228e304ae0f610a1fad937baa463598cadac0c2ac4027cc68f3a8b997115689/u,
+		);
+		assert.match(
+			fs.readFileSync(pullArgsLog, "utf8"),
+			/--platform linux\/amd64 ghcr\.io\/aquasecurity\/trivy:0\.69\.3@sha256:7228e304ae0f610a1fad937baa463598cadac0c2ac4027cc68f3a8b997115689/u,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("trivy run scans a temp workspace with least-privilege container flags", () => {
+	const context = makeTempRepo("trivy-run-");
+	const runArgsLog = path.join(context.tempDir, "docker-run-args.log");
+	const imageInspectLog = path.join(
+		context.tempDir,
+		"docker-image-inspect.log",
+	);
+	const pullArgsLog = path.join(context.tempDir, "docker-pull-args.log");
+
+	createDockerStub(context.binDir);
+	writeFile(
+		path.join(context.repoDir, "trivy.yml"),
+		"scan:\\n  skip-dirs: []\\n",
+	);
+	writeFile(path.join(context.repoDir, ".trivyignore"), "DS-9999\n");
+	writeFile(path.join(context.repoDir, "Dockerfile"), "FROM ubuntu:latest\n");
+
+	try {
+		const output = execFileSync("bash", [runPath, "Dockerfile"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createEnv(context, {
+				DOCKER_IMAGE_INSPECT_LOG: imageInspectLog,
+				DOCKER_PULL_ARGS_LOG: pullArgsLog,
+				DOCKER_RUN_ARGS_LOG: runArgsLog,
+				TRIVY_EXIT_CODE: "1",
+				TRIVY_STDOUT: JSON.stringify({
+					Results: [
+						{
+							Target: "Dockerfile",
+							Misconfigurations: [
+								{
+									ID: "DS-0001",
+									Message:
+										"Specify a tag in the 'FROM' statement for image 'ubuntu'",
+									Severity: "MEDIUM",
+									CauseMetadata: {
+										StartLine: 1,
+									},
+								},
+							],
+						},
+					],
+				}),
+			}),
+		});
+		const result = JSON.parse(output);
+		const runArgs = fs.readFileSync(runArgsLog, "utf8");
+
+		assert.equal(result.exit_code, 1);
+		assert.match(
+			result.details,
+			/Dockerfile:1:1: warning DS-0001 \(MEDIUM\): Specify a tag/u,
+		);
+		assert.match(runArgs, /--platform linux\/amd64/u);
+		assert.match(runArgs, /--cap-drop ALL/u);
+		assert.match(runArgs, /--security-opt no-new-privileges/u);
+		assert.match(runArgs, /--read-only/u);
+		assert.match(runArgs, /--tmpfs \/tmp/u);
+		assert.match(runArgs, /--network=none/u);
+		assert.match(runArgs, /--config trivy\.yml/u);
+		assert.match(runArgs, /--skip-check-update/u);
+		assert.match(runArgs, /--format json/u);
+		assert.match(runArgs, /\/work/u);
+		assert.equal(
+			fs.existsSync(
+				path.join(
+					context.runnerTemp,
+					"trivy-workspace",
+					"source",
+					".trivyignore",
+				),
+			),
+			true,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});


### PR DESCRIPTION
## Summary
- add a shared `trivy` linter for Dockerfile and Containerfile misconfiguration scanning
- run Trivy from a SHA-pinned official container image with least-privilege flags and network disabled during scan execution
- add focused tests and pass/fail fixtures for the new shared linter

## Validation
- `node --test trivy/*.test.js`
- `node .github/scripts/run-fixture-tests.js trivy`
- `source shellcheck/install.sh && shellcheck -x -P SCRIPTDIR trivy/*.sh`
- `source markdownlint-cli2/install.sh && markdownlint-cli2 --no-globs README.md`
- `RUNNER_TEMP=<temp> bash trivy/install.sh && (cd trivy/tests/fail/target && RUNNER_TEMP=<temp> bash /workspace/trivy/run.sh Dockerfile)`
- `git diff --check`
