### PR TITLE
fix(worker): use web crypto for dispatch signing

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,4 +1,3 @@
-import { createHmac } from "node:crypto";
 import { SignJWT } from "jose";
 
 export interface Env {
@@ -535,7 +534,7 @@ async function sendRepositoryDispatch(
 	token: string,
 	clientPayload: JsonRecord,
 ): Promise<void> {
-	const signedPayload = signDispatchPayload(
+	const signedPayload = await signDispatchPayload(
 		requireEnv(
 			env.GITHUB_CHECKER_APP_PRIVATE_KEY,
 			"GITHUB_CHECKER_APP_PRIVATE_KEY",
@@ -562,12 +561,16 @@ async function sendRepositoryDispatch(
 	);
 }
 
-function signDispatchPayload(secret: string, payload: JsonRecord): JsonRecord {
+async function signDispatchPayload(
+	secret: string,
+	payload: JsonRecord,
+): Promise<JsonRecord> {
 	return {
 		...payload,
-		signature: `${DISPATCH_SIGNATURE_PREFIX}${createHmac("sha256", secret)
-			.update(stableStringify(payload))
-			.digest("hex")}`,
+		signature: `${DISPATCH_SIGNATURE_PREFIX}${await signHmacSha256Hex(
+			secret,
+			stableStringify(payload),
+		)}`,
 	};
 }
 
@@ -844,10 +847,24 @@ async function verifySignature(
 	receivedSignature: string,
 	webhookSecret: string,
 ): Promise<void> {
+	const expectedSignature = `${DISPATCH_SIGNATURE_PREFIX}${await signHmacSha256Hex(
+		webhookSecret,
+		rawBody,
+	)}`;
+
+	if (!timingSafeEqual(expectedSignature, receivedSignature)) {
+		throw new HttpError(401, "invalid webhook signature");
+	}
+}
+
+async function signHmacSha256Hex(
+	secret: string,
+	message: string,
+): Promise<string> {
 	const encoder = new TextEncoder();
 	const key = await crypto.subtle.importKey(
 		"raw",
-		encoder.encode(webhookSecret),
+		encoder.encode(secret),
 		{ hash: "SHA-256", name: "HMAC" },
 		false,
 		["sign"],
@@ -855,13 +872,10 @@ async function verifySignature(
 	const signature = await crypto.subtle.sign(
 		"HMAC",
 		key,
-		encoder.encode(rawBody),
+		encoder.encode(message),
 	);
-	const expectedSignature = `sha256=${toHex(new Uint8Array(signature))}`;
 
-	if (!timingSafeEqual(expectedSignature, receivedSignature)) {
-		throw new HttpError(401, "invalid webhook signature");
-	}
+	return toHex(new Uint8Array(signature));
 }
 
 function getSourceInstallationId(

--- a/worker/test/index.test.ts
+++ b/worker/test/index.test.ts
@@ -1,8 +1,20 @@
 import { createHmac, generateKeyPairSync } from "node:crypto";
+import { createRequire } from "node:module";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import worker, { type Env } from "../src/index";
 
+const require = createRequire(import.meta.url);
+const { verifyDispatchSignature } =
+	require("../../.github/scripts/verify-dispatch-signature.js") as {
+		verifyDispatchSignature: ({
+			payloadJson,
+			secret,
+		}: {
+			payloadJson: string;
+			secret: string;
+		}) => void;
+	};
 const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
 const TEST_PRIVATE_KEY = privateKey
 	.export({ format: "pem", type: "pkcs1" })
@@ -152,9 +164,7 @@ describe("github webhook proxy worker", () => {
 			"feature/example",
 		);
 		expect(dispatchBody.client_payload.repository.owner.login).toBe("acme");
-		expect(dispatchBody.client_payload.signature).toMatch(
-			/^sha256=[a-f0-9]{64}$/u,
-		);
+		expectValidDispatchSignature(dispatchBody.client_payload);
 
 		const queuedCheckBody = JSON.parse(
 			(fetchMock.mock.calls[5]?.[1] as RequestInit).body as string,
@@ -775,9 +785,7 @@ describe("github webhook proxy worker", () => {
 		expect(dispatchBody.client_payload.push.ref).toBe("refs/heads/main");
 		expect(dispatchBody.client_payload.push.ref_name).toBe("main");
 		expect(dispatchBody.client_payload.repository.default_branch).toBe("main");
-		expect(dispatchBody.client_payload.signature).toMatch(
-			/^sha256=[a-f0-9]{64}$/u,
-		);
+		expectValidDispatchSignature(dispatchBody.client_payload);
 	});
 
 	it("skips push events outside the default branch", async () => {
@@ -1135,6 +1143,18 @@ function createWebhookRequest(
 		},
 		method: "POST",
 	});
+}
+
+function expectValidDispatchSignature(
+	payload: { signature: string } & Record<string, unknown>,
+): void {
+	expect(payload.signature).toMatch(/^sha256=[a-f0-9]{64}$/u);
+	expect(() => {
+		verifyDispatchSignature({
+			payloadJson: JSON.stringify(payload),
+			secret: TEST_PRIVATE_KEY,
+		});
+	}).not.toThrow();
 }
 
 function mockPullRequestDispatchAndQueuedCheck(


### PR DESCRIPTION
## Summary
- replace the worker's dispatch-signing HMAC implementation with Web Crypto so Cloudflare Workers deploy validation accepts the bundle
- reuse the same Web Crypto helper for inbound webhook verification to keep HMAC handling consistent
- strengthen worker tests by verifying generated dispatch payloads with the production repository_dispatch verifier

## Testing
- cd worker && npm run check
- node --test .github/scripts/verify-dispatch-signature.test.js
- cd worker && npx wrangler deploy --dry-run
