### PR TITLE
fix(worker): normalize dispatch signing secrets

### DIFF
--- a/.github/scripts/verify-dispatch-signature.js
+++ b/.github/scripts/verify-dispatch-signature.js
@@ -81,7 +81,16 @@ function normalizeSecret(secret) {
 		throw new Error("CHECKER_PRIVATE_KEY is required");
 	}
 
-	const normalizedSecret = secret.trim();
+	const trimmedSecret = secret.trim();
+	const unwrappedSecret =
+		trimmedSecret.startsWith('"') && trimmedSecret.endsWith('"')
+			? trimmedSecret.slice(1, -1)
+			: trimmedSecret;
+	const normalizedSecret = unwrappedSecret
+		.replace(/\\r/g, "\r")
+		.replace(/\\n/g, "\n")
+		.replace(/\r\n?/g, "\n")
+		.trim();
 
 	if (normalizedSecret.length === 0) {
 		throw new Error("CHECKER_PRIVATE_KEY is required");

--- a/.github/scripts/verify-dispatch-signature.test.js
+++ b/.github/scripts/verify-dispatch-signature.test.js
@@ -81,3 +81,26 @@ test("verifyDispatchSignature trims the shared secret like the worker", () => {
 		});
 	});
 });
+
+test("verifyDispatchSignature accepts multiline secrets in quoted env format", () => {
+	const payload = {
+		delivery_id: "delivery-123",
+		event_name: "push",
+		repository: {
+			full_name: "acme/service-repo",
+		},
+	};
+	const secret =
+		"-----BEGIN RSA PRIVATE KEY-----\r\nline-one\r\nline-two\r\n-----END RSA PRIVATE KEY-----";
+	const signedPayload = {
+		...payload,
+		signature: signDispatchPayload({ payload, secret }),
+	};
+
+	assert.doesNotThrow(() => {
+		verifyDispatchSignature({
+			payloadJson: JSON.stringify(signedPayload),
+			secret: JSON.stringify(secret),
+		});
+	});
+});

--- a/worker/README.md
+++ b/worker/README.md
@@ -103,6 +103,8 @@ npm run deploy
 Cloudflare では同じ値を Secret として入れる。
 dispatcher App の installation は owner/repo から引く。
 追加の installation ID 設定は不要です。
+PEM 系 secret は複数行の実改行でも、`.dev.vars.example` のような quoted `\n`
+形式でも扱えるように正規化する。
 
 ## Worker の環境変数
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -568,7 +568,7 @@ async function signDispatchPayload(
 	return {
 		...payload,
 		signature: `${DISPATCH_SIGNATURE_PREFIX}${await signHmacSha256Hex(
-			secret,
+			normalizeMultilineSecret(secret),
 			stableStringify(payload),
 		)}`,
 	};
@@ -1055,7 +1055,11 @@ function normalizeMultilineSecret(secret: string): string {
 			? trimmedSecret.slice(1, -1)
 			: trimmedSecret;
 
-	return unwrappedSecret.replace(/\\n/g, "\n");
+	return unwrappedSecret
+		.replace(/\\r/g, "\r")
+		.replace(/\\n/g, "\n")
+		.replace(/\r\n?/g, "\n")
+		.trim();
 }
 
 async function importAppPrivateKey(privateKeyPem: string): Promise<CryptoKey> {

--- a/worker/test/index.test.ts
+++ b/worker/test/index.test.ts
@@ -19,6 +19,9 @@ const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
 const TEST_PRIVATE_KEY = privateKey
 	.export({ format: "pem", type: "pkcs1" })
 	.toString();
+const TEST_PRIVATE_KEY_ESCAPED = JSON.stringify(
+	TEST_PRIVATE_KEY.replace(/\n/g, "\r\n"),
+);
 
 const baseEnv: Env = {
 	GITHUB_CHECKER_APP_ID: "987654",
@@ -788,6 +791,46 @@ describe("github webhook proxy worker", () => {
 		expectValidDispatchSignature(dispatchBody.client_payload);
 	});
 
+	it("normalizes escaped checker app private keys before signing dispatch payloads", async () => {
+		const fetchMock = vi.mocked(fetch);
+
+		mockPushDispatch(fetchMock);
+
+		const request = createWebhookRequest(
+			"push",
+			{
+				after: "abc123",
+				installation: { id: 987 },
+				ref: "refs/heads/main",
+				repository: {
+					default_branch: "main",
+					full_name: "acme/source-repo",
+					id: 10,
+					name: "source-repo",
+					owner: { id: 1, login: "acme", type: "Organization" },
+					private: false,
+				},
+				sender: { id: 2, login: "octocat", type: "User" },
+			},
+			baseEnv.GITHUB_CHECKER_WEBHOOK_SECRET,
+		);
+
+		const response = await worker.fetch(request, {
+			...baseEnv,
+			GITHUB_CHECKER_APP_PRIVATE_KEY: TEST_PRIVATE_KEY_ESCAPED,
+		});
+		const dispatchBody = JSON.parse(
+			(fetchMock.mock.calls[2]?.[1] as RequestInit).body as string,
+		) as {
+			client_payload: {
+				signature: string;
+			} & Record<string, unknown>;
+		};
+
+		expect(response.status).toBe(200);
+		expectValidDispatchSignature(dispatchBody.client_payload);
+	});
+
 	it("skips push events outside the default branch", async () => {
 		const fetchMock = vi.mocked(fetch);
 
@@ -1155,6 +1198,20 @@ function expectValidDispatchSignature(
 			secret: TEST_PRIVATE_KEY,
 		});
 	}).not.toThrow();
+}
+
+function mockPushDispatch(
+	fetchMock: ReturnType<typeof vi.mocked<typeof fetch>>,
+): void {
+	fetchMock.mockResolvedValueOnce(
+		new Response(JSON.stringify({ id: 456 }), { status: 200 }),
+	);
+	fetchMock.mockResolvedValueOnce(
+		new Response(JSON.stringify({ token: "dispatcher-token" }), {
+			status: 201,
+		}),
+	);
+	fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
 }
 
 function mockPullRequestDispatchAndQueuedCheck(


### PR DESCRIPTION
## Summary
- canonicalize checker private-key secrets before repository_dispatch signing and verification so quoted `\n` and CRLF PEM formats hash identically
- add regression coverage for quoted env-formatted secrets in both the workflow verifier and worker dispatch path
- document that PEM secrets can be stored either as real multiline values or quoted `\n` form

## Testing
- node --test .github/scripts/verify-dispatch-signature.test.js
- cd worker && npm run check
- cd worker && npx wrangler deploy --dry-run
