### PR TITLE
fix(renovate): repair textlint preset regex

### DIFF
--- a/.github/scripts/installer-version-pins.test.js
+++ b/.github/scripts/installer-version-pins.test.js
@@ -5,6 +5,18 @@ const test = require("node:test");
 
 const repoRoot = path.join(__dirname, "..", "..");
 
+function createJavaScriptRegExpFromRenovatePattern(pattern) {
+	let flags = "g";
+	let source = pattern;
+
+	if (source.startsWith("(?m)")) {
+		flags += "m";
+		source = source.slice(4);
+	}
+
+	return new RegExp(source, flags);
+}
+
 const installerExpectations = [
 	{
 		path: "actionlint/install.sh",
@@ -219,6 +231,62 @@ test("renovate manages textlint preset package pins from YAML config", () => {
 		yamlConfig,
 		/^\s+- "@textlint-ja\/textlint-rule-preset-ai-writing@1\.6\.1"$/mu,
 	);
+});
+
+test("renovate custom regex managers avoid RE2 lookaround syntax", () => {
+	const config = JSON.parse(
+		fs.readFileSync(path.join(repoRoot, "renovate.json"), "utf8"),
+	);
+
+	for (const manager of config.customManagers ?? []) {
+		if (
+			manager.customType !== "regex" ||
+			!Array.isArray(manager.matchStrings)
+		) {
+			continue;
+		}
+
+		for (const pattern of manager.matchStrings) {
+			assert.equal(typeof pattern, "string");
+			assert.doesNotMatch(
+				pattern,
+				/\(\?(?:!?=|<[=!])/u,
+				`custom regex manager must avoid RE2-unsupported lookaround: ${pattern}`,
+			);
+		}
+	}
+});
+
+test("renovate textlint preset regex matches all YAML preset packages", () => {
+	const config = JSON.parse(
+		fs.readFileSync(path.join(repoRoot, "renovate.json"), "utf8"),
+	);
+	const manager = config.customManagers.find(
+		(candidate) =>
+			candidate.customType === "regex" &&
+			Array.isArray(candidate.managerFilePatterns) &&
+			candidate.managerFilePatterns.includes(
+				"/(^|/)\\.github/linter-service\\.ya?ml$/",
+			),
+	);
+
+	assert.ok(manager, "expected YAML regex custom manager");
+	assert.ok(Array.isArray(manager.matchStrings), "expected regex matchStrings");
+
+	const yamlConfig = fs.readFileSync(
+		path.join(repoRoot, ".github", "linter-service.yaml"),
+		"utf8",
+	);
+	const matches = [
+		...yamlConfig.matchAll(
+			createJavaScriptRegExpFromRenovatePattern(manager.matchStrings[0]),
+		),
+	].map(({ groups }) => `${groups.depName}@${groups.currentValue}`);
+
+	assert.deepEqual(matches, [
+		"textlint-rule-preset-ja-technical-writing@12.0.2",
+		"@textlint-ja/textlint-rule-preset-ai-writing@1.6.1",
+	]);
 });
 
 test("root shared Node dependencies use exact version pins", () => {

--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,7 @@
       "managerFilePatterns": ["/(^|/)\\.github/linter-service\\.ya?ml$/"],
       "datasourceTemplate": "npm",
       "matchStrings": [
-        "(^|\\n)\\s*-\\s*\"?(?<depName>(?:@[^/\\s\"#]+/)?textlint-rule-preset-[^@\\s\"#]+)@(?<currentValue>[^\"\\s#]+)\"?\\s*(?=\\n|$)"
+        "(?m)^\\s*-\\s*\"?(?<depName>(?:@[^/\\s\"#]+/)?textlint-rule-preset-[^@\\s\"#]+)@(?<currentValue>[^\"\\s#]+)\"?\\s*$"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- replace the textlint preset custom regex with an RE2-safe multiline pattern
- add regression coverage to keep custom regex managers free of RE2-unsupported lookaround
- assert the YAML preset regex still matches both pinned preset packages

## Validation
- npx --yes --package renovate renovate-config-validator --strict renovate.json
- node --test .github/scripts/installer-version-pins.test.js
- git diff --check
