### PR TITLE
feat(config): add linter config schemas

### DIFF
--- a/.github/linter-service.schema.json
+++ b/.github/linter-service.schema.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "linter-service .github/linter-service.yaml",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "exclude_paths": {
+          "$ref": "#/$defs/nonEmptyStringArray"
+        }
+      }
+    },
+    "linters": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/knownLinterName"
+      },
+      "properties": {
+        "textlint": {
+          "$ref": "#/$defs/textlintLinterConfig"
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/linterConfig"
+      }
+    }
+  },
+  "$defs": {
+    "knownLinterName": {
+      "type": "string",
+      "enum": [
+        "actionlint",
+        "ghalint",
+        "hadolint",
+        "trivy",
+        "dotenv-linter",
+        "spectral",
+        "yamllint",
+        "yamlfmt",
+        "markdownlint-cli2",
+        "textlint",
+        "ruff",
+        "rustfmt",
+        "cargo-clippy",
+        "cargo-deny",
+        "taplo",
+        "biome",
+        "editorconfig-checker",
+        "shellcheck",
+        "zizmor"
+      ]
+    },
+    "nonEmptyString": {
+      "type": "string",
+      "pattern": "\\S"
+    },
+    "nonEmptyStringArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/nonEmptyString"
+      }
+    },
+    "linterConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "disabled": {
+          "type": "boolean"
+        },
+        "exclude_paths": {
+          "$ref": "#/$defs/nonEmptyStringArray"
+        }
+      }
+    },
+    "textlintPresetPackage": {
+      "type": "string",
+      "pattern": "^(?:@[a-z0-9][a-z0-9._-]*\\/)?textlint-rule-preset-[a-z0-9][a-z0-9._-]*@\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$"
+    },
+    "textlintLinterConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "disabled": {
+          "type": "boolean"
+        },
+        "exclude_paths": {
+          "$ref": "#/$defs/nonEmptyStringArray"
+        },
+        "preset_packages": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/textlintPresetPackage"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "disabled": {
+                "const": false
+              }
+            },
+            "required": [
+              "disabled"
+            ]
+          },
+          "then": {
+            "required": [
+              "preset_packages"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.github/linter-service.yaml
+++ b/.github/linter-service.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./linter-service.schema.json
 global:
   exclude_paths:
     - "**/tests/*/target/**"

--- a/.github/scripts/lib/linter-shared.js
+++ b/.github/scripts/lib/linter-shared.js
@@ -1,10 +1,37 @@
 const fs = require("node:fs");
 
+const { validateLintersConfig } = require("../validate-linters-config.js");
+
+function listLinterConfigs(configData) {
+	if (
+		!configData ||
+		!configData.linters ||
+		typeof configData.linters !== "object" ||
+		Array.isArray(configData.linters)
+	) {
+		throw new Error("linters config must include a linters object");
+	}
+
+	return Object.entries(configData.linters).map(([name, value]) => {
+		if (!value || typeof value !== "object" || Array.isArray(value)) {
+			throw new Error(`${name} must be configured as an object`);
+		}
+
+		return {
+			...value,
+			name,
+		};
+	});
+}
+
+function readLintersConfig(configPath) {
+	return validateLintersConfig({ configPath }).config;
+}
+
 function readLinterConfig(configPath, linterName) {
-	const configData = JSON.parse(fs.readFileSync(configPath, "utf8"));
-	const linters = Array.isArray(configData.linters) ? configData.linters : [];
-	const config = linters.find(
-		(item) => item && typeof item.name === "string" && item.name === linterName,
+	const configData = readLintersConfig(configPath);
+	const config = listLinterConfigs(configData).find(
+		(item) => item.name === linterName,
 	);
 
 	if (!config) {
@@ -87,6 +114,8 @@ module.exports = {
 	deriveTargetCount,
 	escapeHtml,
 	formatTargetLabel,
+	listLinterConfigs,
+	readLintersConfig,
 	normalizeOptionalCount,
 	normalizeStringArray,
 	readLinterConfig,

--- a/.github/scripts/lib/linter-shared.js
+++ b/.github/scripts/lib/linter-shared.js
@@ -3,16 +3,13 @@ const fs = require("node:fs");
 const { validateLintersConfig } = require("../validate-linters-config.js");
 
 function listLinterConfigs(configData) {
-	if (
-		!configData ||
-		!configData.linters ||
-		typeof configData.linters !== "object" ||
-		Array.isArray(configData.linters)
-	) {
+	const linters = configData?.linters;
+
+	if (!linters || typeof linters !== "object" || Array.isArray(linters)) {
 		throw new Error("linters config must include a linters object");
 	}
 
-	return Object.entries(configData.linters).map(([name, value]) => {
+	return Object.entries(linters).map(([name, value]) => {
 		if (!value || typeof value !== "object" || Array.isArray(value)) {
 			throw new Error(`${name} must be configured as an object`);
 		}

--- a/.github/scripts/lib/schema-validator.js
+++ b/.github/scripts/lib/schema-validator.js
@@ -1,0 +1,50 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const Ajv2020 = require("ajv/dist/2020").default;
+
+function readJson(filePath) {
+	return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function formatValidationError(error) {
+	const instancePath =
+		typeof error.instancePath === "string" && error.instancePath.length > 0
+			? error.instancePath
+			: "<root>";
+	if (
+		error.keyword === "additionalProperties" &&
+		error.params &&
+		typeof error.params.additionalProperty === "string"
+	) {
+		return `${instancePath}: unexpected property ${JSON.stringify(error.params.additionalProperty)}`;
+	}
+
+	return `${instancePath}: ${error.message}`;
+}
+
+function validateDataAgainstSchema({ data, label, schemaPath }) {
+	const ajv = new Ajv2020({ allErrors: true });
+	const schema = readJson(schemaPath);
+	const validate = ajv.compile(schema);
+
+	if (validate(data)) {
+		return { schema, schemaPath };
+	}
+
+	const message =
+		Array.isArray(validate.errors) && validate.errors.length > 0
+			? validate.errors.map(formatValidationError).join("\n")
+			: "schema validation failed";
+	const error = new Error(
+		`${label} does not match ${path.basename(schemaPath)}:\n${message}`,
+	);
+	error.errors = validate.errors;
+	throw error;
+}
+
+module.exports = {
+	formatValidationError,
+	readJson,
+	validateDataAgainstSchema,
+};

--- a/.github/scripts/linter-service-config.js
+++ b/.github/scripts/linter-service-config.js
@@ -3,6 +3,7 @@ const path = require("node:path");
 const yaml = require("js-yaml");
 
 const { parseExactPackageSpec } = require("./npm-package-spec.js");
+const { getTextlintPresetRuleKey } = require("./textlint-preset-package.js");
 const requireEnv = require("./lib/require-env.js");
 const LINTER_SERVICE_CONFIG_CANDIDATES = [
 	".github/linter-service.yaml",
@@ -210,6 +211,7 @@ function normalizeTextlintPresetPackages({ label, presetPackages }) {
 
 	for (const spec of normalized) {
 		const { name } = parseExactPackageSpec(spec, `${label}.preset_packages`);
+		getTextlintPresetRuleKey(name);
 		if (seenNames.has(name)) {
 			throw new Error(
 				`${label}.preset_packages must not contain duplicate package names`,
@@ -379,5 +381,6 @@ module.exports = {
 	normalizeGlobPattern,
 	normalizeLinterServiceConfig,
 	normalizeRelativePath,
+	parseLinterServiceConfigSource,
 	runFromEnv,
 };

--- a/.github/scripts/linter-service-config.test.js
+++ b/.github/scripts/linter-service-config.test.js
@@ -428,6 +428,56 @@ test("rejects duplicate textlint preset package names", () => {
 	}
 });
 
+test("rejects non-preset textlint package names", () => {
+	const context = makeTempRepo();
+
+	writeLinterServiceConfig(context.repoDir, {
+		linters: {
+			textlint: {
+				disabled: false,
+				preset_packages: ["left-pad@1.3.0"],
+			},
+		},
+	});
+
+	try {
+		assert.throws(
+			() =>
+				loadLinterServiceConfig({
+					repositoryPath: context.repoDir,
+				}),
+			/must use textlint preset packages/u,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("rejects malformed textlint preset package names", () => {
+	const context = makeTempRepo();
+
+	writeLinterServiceConfig(context.repoDir, {
+		linters: {
+			textlint: {
+				disabled: false,
+				preset_packages: ["textlint-rule-preset-_experimental@1.0.0"],
+			},
+		},
+	});
+
+	try {
+		assert.throws(
+			() =>
+				loadLinterServiceConfig({
+					repositoryPath: context.repoDir,
+				}),
+			/must use textlint preset packages/u,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
 test("rejects legacy textlint preset_package", () => {
 	const context = makeTempRepo();
 

--- a/.github/scripts/prepare-deselected-sarif.js
+++ b/.github/scripts/prepare-deselected-sarif.js
@@ -1,6 +1,10 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const requireEnv = require("./lib/require-env.js");
+const {
+	listLinterConfigs,
+	readLintersConfig,
+} = require("./lib/linter-shared.js");
 const { buildSarifEnvelope } = require("./lib/sarif.js");
 
 function runFromEnv(env = process.env) {
@@ -26,8 +30,8 @@ function prepareDeselectedSarif({
 	outputRoot,
 	selectedLintersJson,
 }) {
-	const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-	const linters = Array.isArray(config.linters) ? config.linters : [];
+	const config = readLintersConfig(configPath);
+	const linters = listLinterConfigs(config);
 	const selectedLinters = new Set(parseSelectedLinters(selectedLintersJson));
 
 	fs.mkdirSync(outputRoot, { recursive: true });

--- a/.github/scripts/prepare-deselected-sarif.test.js
+++ b/.github/scripts/prepare-deselected-sarif.test.js
@@ -19,25 +19,21 @@ test("writes empty SARIF files for enabled deselected linters", () => {
 		configPath,
 		JSON.stringify(
 			{
-				linters: [
-					{
-						name: "actionlint",
+				linters: {
+					actionlint: {
 						sarif: {
 							enabled: true,
 						},
 					},
-					{
-						name: "hadolint",
+					hadolint: {
 						sarif: {
 							category: "custom/hadolint",
 							enabled: true,
 							tool_name: "custom-hadolint",
 						},
 					},
-					{
-						name: "ruff",
-					},
-				],
+					ruff: {},
+				},
 			},
 			null,
 			2,
@@ -79,14 +75,13 @@ test("returns without writing files when every enabled linter is selected", () =
 		configPath,
 		JSON.stringify(
 			{
-				linters: [
-					{
-						name: "actionlint",
+				linters: {
+					actionlint: {
 						sarif: {
 							enabled: true,
 						},
 					},
-				],
+				},
 			},
 			null,
 			2,

--- a/.github/scripts/render-linter-sarif.test.js
+++ b/.github/scripts/render-linter-sarif.test.js
@@ -23,11 +23,9 @@ test("does not emit SARIF when the linter has no SARIF config", () => {
 		configPath,
 		JSON.stringify(
 			{
-				linters: [
-					{
-						name: "example",
-					},
-				],
+				linters: {
+					example: {},
+				},
 			},
 			null,
 			2,
@@ -70,14 +68,13 @@ test("emits empty SARIF when an enabled linter succeeds", () => {
 		configPath,
 		JSON.stringify(
 			{
-				linters: [
-					{
-						name: "example",
+				linters: {
+					example: {
 						sarif: {
 							enabled: true,
 						},
 					},
-				],
+				},
 			},
 			null,
 			2,
@@ -128,14 +125,13 @@ test("does not emit SARIF when the linter run failed before producing a result",
 		configPath,
 		JSON.stringify(
 			{
-				linters: [
-					{
-						name: "example",
+				linters: {
+					example: {
 						sarif: {
 							enabled: true,
 						},
 					},
-				],
+				},
 			},
 			null,
 			2,
@@ -174,14 +170,13 @@ test("parses file line and column diagnostics into SARIF results", () => {
 		configPath,
 		JSON.stringify(
 			{
-				linters: [
-					{
-						name: "example",
+				linters: {
+					example: {
 						sarif: {
 							enabled: true,
 						},
 					},
-				],
+				},
 			},
 			null,
 			2,
@@ -266,14 +261,13 @@ test("keeps substring matches from changing the default SARIF severity", () => {
 		configPath,
 		JSON.stringify(
 			{
-				linters: [
-					{
-						name: "example",
+				linters: {
+					example: {
 						sarif: {
 							enabled: true,
 						},
 					},
-				],
+				},
 			},
 			null,
 			2,

--- a/.github/scripts/run-fixture-tests.js
+++ b/.github/scripts/run-fixture-tests.js
@@ -8,6 +8,10 @@ const {
 	isLinterEnabled,
 	loadLinterServiceConfig,
 } = require("./linter-service-config.js");
+const {
+	listLinterConfigs,
+	readLintersConfig,
+} = require("./lib/linter-shared.js");
 const { renderReport } = require("./render-linter-report.js");
 const { renderSarif } = require("./render-linter-sarif.js");
 const { selectFiles } = require("./linter-targeting.js");
@@ -24,14 +28,10 @@ function runCli(argv = process.argv.slice(2), env = process.env) {
 
 function runFixtureTests({ linterNames, repositoryPath, write = false }) {
 	const resolvedRepositoryPath = path.resolve(repositoryPath);
-	const config = JSON.parse(
-		fs.readFileSync(path.join(resolvedRepositoryPath, "linters.json"), "utf8"),
+	const config = readLintersConfig(
+		path.join(resolvedRepositoryPath, "linters.json"),
 	);
-	const availableLinters = Array.isArray(config.linters)
-		? config.linters
-				.filter((entry) => entry && typeof entry.name === "string")
-				.map((entry) => entry.name)
-		: [];
+	const availableLinters = listLinterConfigs(config).map((entry) => entry.name);
 	const requestedLinters =
 		Array.isArray(linterNames) && linterNames.length > 0
 			? linterNames

--- a/.github/scripts/run-fixture-tests.test.js
+++ b/.github/scripts/run-fixture-tests.test.js
@@ -38,14 +38,13 @@ function scaffoldFakeLinterRepo(repoDir) {
 		path.join(repoDir, "linters.json"),
 		JSON.stringify(
 			{
-				linters: [
-					{
-						name: "fake-linter",
+				linters: {
+					"fake-linter": {
 						sarif: {
 							enabled: true,
 						},
 					},
-				],
+				},
 			},
 			null,
 			2,

--- a/.github/scripts/run-linter-batch.test.js
+++ b/.github/scripts/run-linter-batch.test.js
@@ -70,20 +70,18 @@ test("runLinterBatch executes multiple linters and preserves workflow env update
 	const workspace = createTempWorkspace();
 	writeFile(path.join(workspace.sourceRepositoryPath, "alpha.txt"), "alpha\n");
 	writeFile(path.join(workspace.sourceRepositoryPath, "beta.md"), "# beta\n");
-	writeLinterConfig(workspace.linterConfigPath, [
-		{
-			name: "alpha",
+	writeLinterConfig(workspace.linterConfigPath, {
+		alpha: {
 			sarif: {
 				enabled: false,
 			},
 		},
-		{
-			name: "beta",
+		beta: {
 			sarif: {
 				enabled: false,
 			},
 		},
-	]);
+	});
 	writeFakeLinter(workspace.linterServicePath, {
 		name: "alpha",
 		installScript: `#!/usr/bin/env bash
@@ -199,20 +197,18 @@ test("runLinterBatch continues after an install failure and reports infrastructu
 	const workspace = createTempWorkspace();
 	writeFile(path.join(workspace.sourceRepositoryPath, "alpha.txt"), "alpha\n");
 	writeFile(path.join(workspace.sourceRepositoryPath, "beta.md"), "# beta\n");
-	writeLinterConfig(workspace.linterConfigPath, [
-		{
-			name: "alpha",
+	writeLinterConfig(workspace.linterConfigPath, {
+		alpha: {
 			sarif: {
 				enabled: false,
 			},
 		},
-		{
-			name: "beta",
+		beta: {
 			sarif: {
 				enabled: false,
 			},
 		},
-	]);
+	});
 	writeFakeLinter(workspace.linterServicePath, {
 		name: "alpha",
 		installScript: `#!/usr/bin/env bash

--- a/.github/scripts/textlint-preset-package.js
+++ b/.github/scripts/textlint-preset-package.js
@@ -1,0 +1,27 @@
+const UNSCOPED_PRESET_PACKAGE = /^textlint-rule-preset-[a-z0-9][a-z0-9._-]*$/u;
+const SCOPED_PRESET_PACKAGE =
+	/^@[a-z0-9][a-z0-9._-]*\/textlint-rule-preset-[a-z0-9][a-z0-9._-]*$/u;
+
+function getTextlintPresetRuleKey(packageName) {
+	if (
+		typeof packageName === "string" &&
+		UNSCOPED_PRESET_PACKAGE.test(packageName)
+	) {
+		return packageName.replace(/^textlint-rule-preset-/u, "preset-");
+	}
+
+	if (
+		typeof packageName === "string" &&
+		SCOPED_PRESET_PACKAGE.test(packageName)
+	) {
+		return packageName.replace(/\/textlint-rule-preset-/u, "/preset-");
+	}
+
+	throw new Error(
+		`linters.textlint.preset_packages must use textlint preset packages: ${packageName}`,
+	);
+}
+
+module.exports = {
+	getTextlintPresetRuleKey,
+};

--- a/.github/scripts/validate-linter-service-config.js
+++ b/.github/scripts/validate-linter-service-config.js
@@ -1,0 +1,50 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const {
+	normalizeLinterServiceConfig,
+	parseLinterServiceConfigSource,
+} = require("./linter-service-config.js");
+const { validateDataAgainstSchema } = require("./lib/schema-validator.js");
+
+function validateLinterServiceConfig({
+	configPath = path.join(__dirname, "..", "linter-service.yaml"),
+	schemaPath = path.join(__dirname, "..", "linter-service.schema.json"),
+} = {}) {
+	const source = fs.readFileSync(configPath, "utf8");
+	const config = parseLinterServiceConfigSource({
+		configPath,
+		source,
+	});
+	const { schema } = validateDataAgainstSchema({
+		data: config,
+		label: "linter-service config",
+		schemaPath,
+	});
+	const normalizedConfig = normalizeLinterServiceConfig(config);
+
+	return {
+		config,
+		configPath,
+		normalizedConfig,
+		schema,
+		schemaPath,
+	};
+}
+
+function runFromCli() {
+	const report = validateLinterServiceConfig();
+	process.stdout.write(
+		`${path.basename(report.configPath)} matches ${path.basename(report.schemaPath)}.\n`,
+	);
+	return report;
+}
+
+if (require.main === module) {
+	runFromCli();
+}
+
+module.exports = {
+	runFromCli,
+	validateLinterServiceConfig,
+};

--- a/.github/scripts/validate-linter-service-config.test.js
+++ b/.github/scripts/validate-linter-service-config.test.js
@@ -1,0 +1,251 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const yaml = require("js-yaml");
+
+const {
+	validateLinterServiceConfig,
+} = require("./validate-linter-service-config.js");
+
+const repositoryRoot = path.join(__dirname, "..", "..");
+const rootConfigPath = path.join(
+	repositoryRoot,
+	".github",
+	"linter-service.yaml",
+);
+const rootSchemaPath = path.join(
+	repositoryRoot,
+	".github",
+	"linter-service.schema.json",
+);
+const rootLintersPath = path.join(repositoryRoot, "linters.json");
+const schemaDirective =
+	"# yaml-language-server: $schema=./linter-service.schema.json";
+
+function writeConfig(filePath, value, { withSchemaDirective = false } = {}) {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	const body = filePath.endsWith(".json")
+		? JSON.stringify(value, null, 2)
+		: yaml
+				.dump(value, {
+					lineWidth: -1,
+					noRefs: true,
+				})
+				.trimEnd();
+	const prefix = withSchemaDirective ? `${schemaDirective}\n` : "";
+	fs.writeFileSync(filePath, `${prefix}${body}\n`, "utf8");
+}
+
+test("repository linter-service.yaml references and matches the schema", () => {
+	const source = fs.readFileSync(rootConfigPath, "utf8");
+	assert.match(
+		source,
+		/^# yaml-language-server: \$schema=\.\/linter-service\.schema\.json$/mu,
+	);
+
+	const report = validateLinterServiceConfig({
+		configPath: rootConfigPath,
+		schemaPath: rootSchemaPath,
+	});
+
+	assert.equal(report.configPath, rootConfigPath);
+	assert.equal(report.schemaPath, rootSchemaPath);
+});
+
+test("supported linter names stay in sync with linters.json", () => {
+	const schema = JSON.parse(fs.readFileSync(rootSchemaPath, "utf8"));
+	const lintersConfig = JSON.parse(fs.readFileSync(rootLintersPath, "utf8"));
+	const schemaNames = [...schema.$defs.knownLinterName.enum].sort();
+	const configNames = lintersConfig.linters
+		.map((definition) => definition.name)
+		.sort();
+
+	assert.deepEqual(schemaNames, configNames);
+});
+
+test("accepts supported linter-service config fields", () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "linter-service-schema-"),
+	);
+	const configPath = path.join(tempDir, "linter-service.yaml");
+
+	writeConfig(
+		configPath,
+		{
+			global: {
+				exclude_paths: ["docs/generated/**"],
+			},
+			linters: {
+				textlint: {
+					disabled: false,
+					exclude_paths: ["docs/drafts/**"],
+					preset_packages: ["textlint-rule-preset-ja-technical-writing@12.0.2"],
+				},
+				yamllint: {
+					disabled: true,
+					exclude_paths: ["fixtures/**"],
+				},
+			},
+		},
+		{ withSchemaDirective: true },
+	);
+
+	try {
+		assert.doesNotThrow(() =>
+			validateLinterServiceConfig({
+				configPath,
+				schemaPath: rootSchemaPath,
+			}),
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("rejects unexpected linter properties", () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "linter-service-schema-"),
+	);
+	const configPath = path.join(tempDir, "linter-service.yaml");
+
+	writeConfig(configPath, {
+		linters: {
+			yamllint: {
+				unknown_flag: true,
+			},
+		},
+	});
+
+	try {
+		assert.throws(
+			() =>
+				validateLinterServiceConfig({
+					configPath,
+					schemaPath: rootSchemaPath,
+				}),
+			/unexpected property "unknown_flag"/u,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("rejects unknown linter names", () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "linter-service-schema-"),
+	);
+	const configPath = path.join(tempDir, "linter-service.yaml");
+
+	writeConfig(configPath, {
+		linters: {
+			yamllnit: {
+				disabled: true,
+			},
+		},
+	});
+
+	try {
+		assert.throws(
+			() =>
+				validateLinterServiceConfig({
+					configPath,
+					schemaPath: rootSchemaPath,
+				}),
+			/must be equal to one of the allowed values/u,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("rejects explicitly enabled textlint without preset_packages", () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "linter-service-schema-"),
+	);
+	const configPath = path.join(tempDir, "linter-service.yaml");
+
+	writeConfig(configPath, {
+		linters: {
+			textlint: {
+				disabled: false,
+			},
+		},
+	});
+
+	try {
+		assert.throws(
+			() =>
+				validateLinterServiceConfig({
+					configPath,
+					schemaPath: rootSchemaPath,
+				}),
+			/preset_packages/u,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("rejects non-preset textlint package names", () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "linter-service-schema-"),
+	);
+	const configPath = path.join(tempDir, "linter-service.yaml");
+
+	writeConfig(configPath, {
+		linters: {
+			textlint: {
+				disabled: false,
+				preset_packages: ["left-pad@1.3.0"],
+			},
+		},
+	});
+
+	try {
+		assert.throws(
+			() =>
+				validateLinterServiceConfig({
+					configPath,
+					schemaPath: rootSchemaPath,
+				}),
+			/textlint-rule-preset-|must use textlint preset packages/u,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("rejects duplicate textlint preset package names", () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "linter-service-schema-"),
+	);
+	const configPath = path.join(tempDir, "linter-service.yaml");
+
+	writeConfig(configPath, {
+		linters: {
+			textlint: {
+				disabled: false,
+				preset_packages: [
+					"textlint-rule-preset-ja-technical-writing@12.0.2",
+					"textlint-rule-preset-ja-technical-writing@12.0.3",
+				],
+			},
+		},
+	});
+
+	try {
+		assert.throws(
+			() =>
+				validateLinterServiceConfig({
+					configPath,
+					schemaPath: rootSchemaPath,
+				}),
+			/duplicate package names/u,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});

--- a/.github/scripts/validate-linter-service-config.test.js
+++ b/.github/scripts/validate-linter-service-config.test.js
@@ -59,9 +59,7 @@ test("supported linter names stay in sync with linters.json", () => {
 	const schema = JSON.parse(fs.readFileSync(rootSchemaPath, "utf8"));
 	const lintersConfig = JSON.parse(fs.readFileSync(rootLintersPath, "utf8"));
 	const schemaNames = [...schema.$defs.knownLinterName.enum].sort();
-	const configNames = lintersConfig.linters
-		.map((definition) => definition.name)
-		.sort();
+	const configNames = Object.keys(lintersConfig.linters).sort();
 
 	assert.deepEqual(schemaNames, configNames);
 });

--- a/.github/scripts/validate-linters-config.js
+++ b/.github/scripts/validate-linters-config.js
@@ -1,0 +1,80 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const Ajv2020 = require("ajv/dist/2020").default;
+
+function readJson(filePath) {
+	return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function validateLintersConfig({
+	configPath = path.join(__dirname, "..", "..", "linters.json"),
+	schemaPath = path.join(__dirname, "..", "..", "linters.schema.json"),
+} = {}) {
+	const ajv = new Ajv2020({ allErrors: true });
+	const schema = readJson(schemaPath);
+	const config = readJson(configPath);
+	const validate = ajv.compile(schema);
+
+	if (validate(config)) {
+		validateUniqueLinterNames(config);
+		return { config, configPath, schema, schemaPath };
+	}
+
+	const message = validate.errors.map(formatValidationError).join("\n");
+	const error = new Error(
+		`linters config does not match ${path.basename(schemaPath)}:\n${message}`,
+	);
+	error.errors = validate.errors;
+	throw error;
+}
+
+function validateUniqueLinterNames(config) {
+	const seenNames = new Set();
+
+	for (const [index, linter] of config.linters.entries()) {
+		const name = linter.name;
+
+		if (seenNames.has(name)) {
+			throw new Error(
+				`linters config includes duplicate linter name at /linters/${index}/name: ${JSON.stringify(name)}`,
+			);
+		}
+
+		seenNames.add(name);
+	}
+}
+
+function formatValidationError(error) {
+	const instancePath =
+		typeof error.instancePath === "string" && error.instancePath.length > 0
+			? error.instancePath
+			: "<root>";
+	if (
+		error.keyword === "additionalProperties" &&
+		error.params &&
+		typeof error.params.additionalProperty === "string"
+	) {
+		return `${instancePath}: unexpected property ${JSON.stringify(error.params.additionalProperty)}`;
+	}
+
+	return `${instancePath}: ${error.message}`;
+}
+
+function runFromCli() {
+	const report = validateLintersConfig();
+	process.stdout.write(
+		`${path.basename(report.configPath)} matches ${path.basename(report.schemaPath)}.\n`,
+	);
+	return report;
+}
+
+if (require.main === module) {
+	runFromCli();
+}
+
+module.exports = {
+	formatValidationError,
+	runFromCli,
+	validateLintersConfig,
+};

--- a/.github/scripts/validate-linters-config.js
+++ b/.github/scripts/validate-linters-config.js
@@ -1,32 +1,22 @@
-const fs = require("node:fs");
 const path = require("node:path");
 
-const Ajv2020 = require("ajv/dist/2020").default;
-
-function readJson(filePath) {
-	return JSON.parse(fs.readFileSync(filePath, "utf8"));
-}
+const {
+	readJson,
+	validateDataAgainstSchema,
+} = require("./lib/schema-validator.js");
 
 function validateLintersConfig({
 	configPath = path.join(__dirname, "..", "..", "linters.json"),
 	schemaPath = path.join(__dirname, "..", "..", "linters.schema.json"),
 } = {}) {
-	const ajv = new Ajv2020({ allErrors: true });
-	const schema = readJson(schemaPath);
 	const config = readJson(configPath);
-	const validate = ajv.compile(schema);
-
-	if (validate(config)) {
-		validateUniqueLinterNames(config);
-		return { config, configPath, schema, schemaPath };
-	}
-
-	const message = validate.errors.map(formatValidationError).join("\n");
-	const error = new Error(
-		`linters config does not match ${path.basename(schemaPath)}:\n${message}`,
-	);
-	error.errors = validate.errors;
-	throw error;
+	const { schema } = validateDataAgainstSchema({
+		data: config,
+		label: "linters config",
+		schemaPath,
+	});
+	validateUniqueLinterNames(config);
+	return { config, configPath, schema, schemaPath };
 }
 
 function validateUniqueLinterNames(config) {
@@ -45,22 +35,6 @@ function validateUniqueLinterNames(config) {
 	}
 }
 
-function formatValidationError(error) {
-	const instancePath =
-		typeof error.instancePath === "string" && error.instancePath.length > 0
-			? error.instancePath
-			: "<root>";
-	if (
-		error.keyword === "additionalProperties" &&
-		error.params &&
-		typeof error.params.additionalProperty === "string"
-	) {
-		return `${instancePath}: unexpected property ${JSON.stringify(error.params.additionalProperty)}`;
-	}
-
-	return `${instancePath}: ${error.message}`;
-}
-
 function runFromCli() {
 	const report = validateLintersConfig();
 	process.stdout.write(
@@ -74,7 +48,6 @@ if (require.main === module) {
 }
 
 module.exports = {
-	formatValidationError,
 	runFromCli,
 	validateLintersConfig,
 };

--- a/.github/scripts/validate-linters-config.js
+++ b/.github/scripts/validate-linters-config.js
@@ -1,38 +1,198 @@
+const fs = require("node:fs");
 const path = require("node:path");
 
-const {
-	readJson,
-	validateDataAgainstSchema,
-} = require("./lib/schema-validator.js");
+const { validateDataAgainstSchema } = require("./lib/schema-validator.js");
+
+function skipWhitespace(text, index) {
+	while (index < text.length && /\s/u.test(text[index])) {
+		index += 1;
+	}
+	return index;
+}
+
+function parseStringToken(text, startIndex) {
+	let index = startIndex + 1;
+	while (index < text.length) {
+		if (text[index] === "\\") {
+			index += 2;
+			continue;
+		}
+		if (text[index] === '"') {
+			return {
+				nextIndex: index + 1,
+				value: JSON.parse(text.slice(startIndex, index + 1)),
+			};
+		}
+		index += 1;
+	}
+
+	throw new Error("unterminated JSON string");
+}
+
+function parseNumberToken(text, startIndex) {
+	const match = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/u.exec(
+		text.slice(startIndex),
+	);
+	if (!match) {
+		throw new Error(`invalid JSON number at offset ${startIndex}`);
+	}
+	return startIndex + match[0].length;
+}
+
+function formatJsonPointer(pathSegments) {
+	return pathSegments.length === 0
+		? "/"
+		: `/${pathSegments
+				.map((segment) =>
+					String(segment).replaceAll("~", "~0").replaceAll("/", "~1"),
+				)
+				.join("/")}`;
+}
+
+function parseJsonValue(text, startIndex, pathSegments, duplicatePaths) {
+	const index = skipWhitespace(text, startIndex);
+	const nextPathDepth = pathSegments.length;
+	if (index >= text.length) {
+		throw new Error("unexpected end of JSON input");
+	}
+
+	switch (text[index]) {
+		case "{":
+			return parseJsonObject(text, index, pathSegments, duplicatePaths);
+		case "[":
+			return parseJsonArray(text, index, pathSegments, duplicatePaths);
+		case '"':
+			return parseStringToken(text, index).nextIndex;
+		case "t":
+			if (text.startsWith("true", index)) {
+				return index + 4;
+			}
+			break;
+		case "f":
+			if (text.startsWith("false", index)) {
+				return index + 5;
+			}
+			break;
+		case "n":
+			if (text.startsWith("null", index)) {
+				return index + 4;
+			}
+			break;
+		default:
+			if (text[index] === "-" || /\d/u.test(text[index])) {
+				return parseNumberToken(text, index);
+			}
+	}
+
+	throw new Error(
+		`unsupported JSON token at offset ${index} (path depth ${nextPathDepth})`,
+	);
+}
+
+function parseJsonObject(text, startIndex, pathSegments, duplicatePaths) {
+	let index = skipWhitespace(text, startIndex + 1);
+	const seenKeys = new Set();
+
+	if (text[index] === "}") {
+		return index + 1;
+	}
+
+	while (index < text.length) {
+		if (text[index] !== '"') {
+			throw new Error(`expected object key at offset ${index}`);
+		}
+
+		const { nextIndex, value: key } = parseStringToken(text, index);
+		if (seenKeys.has(key)) {
+			duplicatePaths.add(formatJsonPointer([...pathSegments, key]));
+		}
+		seenKeys.add(key);
+
+		index = skipWhitespace(text, nextIndex);
+		if (text[index] !== ":") {
+			throw new Error(`expected ":" after ${JSON.stringify(key)}`);
+		}
+
+		index = parseJsonValue(
+			text,
+			index + 1,
+			[...pathSegments, key],
+			duplicatePaths,
+		);
+		index = skipWhitespace(text, index);
+
+		if (text[index] === "}") {
+			return index + 1;
+		}
+		if (text[index] !== ",") {
+			throw new Error(`expected "," or "}" at offset ${index}`);
+		}
+		index = skipWhitespace(text, index + 1);
+	}
+
+	throw new Error("unterminated JSON object");
+}
+
+function parseJsonArray(text, startIndex, pathSegments, duplicatePaths) {
+	let index = skipWhitespace(text, startIndex + 1);
+	if (text[index] === "]") {
+		return index + 1;
+	}
+
+	while (index < text.length) {
+		index = parseJsonValue(text, index, pathSegments, duplicatePaths);
+		index = skipWhitespace(text, index);
+		if (text[index] === "]") {
+			return index + 1;
+		}
+		if (text[index] !== ",") {
+			throw new Error(`expected "," or "]" at offset ${index}`);
+		}
+		index = skipWhitespace(text, index + 1);
+	}
+
+	throw new Error("unterminated JSON array");
+}
+
+function assertUniqueLinterObjectKeys(configSource) {
+	const duplicatePaths = new Set();
+	const index = parseJsonValue(
+		configSource,
+		skipWhitespace(configSource, 0),
+		[],
+		duplicatePaths,
+	);
+	if (skipWhitespace(configSource, index) !== configSource.length) {
+		throw new Error("unexpected trailing content in linters.json");
+	}
+	if (duplicatePaths.size === 0) {
+		return;
+	}
+
+	const suffix = duplicatePaths.size === 1 ? "key" : "keys";
+	throw new Error(
+		`linters config contains duplicate object ${suffix}: ${Array.from(
+			duplicatePaths,
+		)
+			.sort()
+			.map((pointer) => JSON.stringify(pointer))
+			.join(", ")}`,
+	);
+}
 
 function validateLintersConfig({
 	configPath = path.join(__dirname, "..", "..", "linters.json"),
 	schemaPath = path.join(__dirname, "..", "..", "linters.schema.json"),
 } = {}) {
-	const config = readJson(configPath);
+	const configSource = fs.readFileSync(configPath, "utf8");
+	const config = JSON.parse(configSource);
+	assertUniqueLinterObjectKeys(configSource);
 	const { schema } = validateDataAgainstSchema({
 		data: config,
 		label: "linters config",
 		schemaPath,
 	});
-	validateUniqueLinterNames(config);
 	return { config, configPath, schema, schemaPath };
-}
-
-function validateUniqueLinterNames(config) {
-	const seenNames = new Set();
-
-	for (const [index, linter] of config.linters.entries()) {
-		const name = linter.name;
-
-		if (seenNames.has(name)) {
-			throw new Error(
-				`linters config includes duplicate linter name at /linters/${index}/name: ${JSON.stringify(name)}`,
-			);
-		}
-
-		seenNames.add(name);
-	}
 }
 
 function runFromCli() {

--- a/.github/scripts/validate-linters-config.test.js
+++ b/.github/scripts/validate-linters-config.test.js
@@ -1,0 +1,180 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { validateLintersConfig } = require("./validate-linters-config.js");
+
+const repositoryRoot = path.join(__dirname, "..", "..");
+const rootConfigPath = path.join(repositoryRoot, "linters.json");
+const rootSchemaPath = path.join(repositoryRoot, "linters.schema.json");
+
+function writeJson(filePath, value) {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(
+		`${filePath}`,
+		`${JSON.stringify(value, null, 2)}\n`,
+		"utf8",
+	);
+}
+
+test("accepts the repository linters.json", () => {
+	const report = validateLintersConfig({
+		configPath: rootConfigPath,
+		schemaPath: rootSchemaPath,
+	});
+
+	assert.equal(report.configPath, rootConfigPath);
+	assert.equal(report.schemaPath, rootSchemaPath);
+});
+
+test("accepts supported optional linter metadata", () => {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "linters-schema-"));
+	const configPath = path.join(tempDir, "linters.json");
+
+	writeJson(configPath, {
+		$schema: "./linters.schema.json",
+		linters: [
+			{
+				default_disabled: true,
+				execution_group: "yaml-fast",
+				isolated: true,
+				name: "example",
+				required_root_files: [".example.yml"],
+				sarif: {
+					category: "custom/example",
+					default_level: "warning",
+					enabled: true,
+					tool_name: "custom-example",
+				},
+			},
+		],
+	});
+
+	try {
+		assert.doesNotThrow(() =>
+			validateLintersConfig({
+				configPath,
+				schemaPath: rootSchemaPath,
+			}),
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("rejects unsupported SARIF default levels", () => {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "linters-schema-"));
+	const configPath = path.join(tempDir, "linters.json");
+
+	writeJson(configPath, {
+		$schema: "./linters.schema.json",
+		linters: [
+			{
+				name: "example",
+				sarif: {
+					default_level: "info",
+					enabled: true,
+				},
+			},
+		],
+	});
+
+	try {
+		assert.throws(
+			() =>
+				validateLintersConfig({
+					configPath,
+					schemaPath: rootSchemaPath,
+				}),
+			/default_level/u,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("rejects unexpected linter properties", () => {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "linters-schema-"));
+	const configPath = path.join(tempDir, "linters.json");
+
+	writeJson(configPath, {
+		$schema: "./linters.schema.json",
+		linters: [
+			{
+				name: "example",
+				unknown_flag: true,
+			},
+		],
+	});
+
+	try {
+		assert.throws(
+			() =>
+				validateLintersConfig({
+					configPath,
+					schemaPath: rootSchemaPath,
+				}),
+			/unexpected property "unknown_flag"/u,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("rejects duplicate linter names", () => {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "linters-schema-"));
+	const configPath = path.join(tempDir, "linters.json");
+
+	writeJson(configPath, {
+		$schema: "./linters.schema.json",
+		linters: [
+			{
+				name: "example",
+			},
+			{
+				name: "example",
+			},
+		],
+	});
+
+	try {
+		assert.throws(
+			() =>
+				validateLintersConfig({
+					configPath,
+					schemaPath: rootSchemaPath,
+				}),
+			/duplicate linter name/u,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("rejects linters.json files that omit the schema association", () => {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "linters-schema-"));
+	const configPath = path.join(tempDir, "linters.json");
+
+	writeJson(configPath, {
+		linters: [
+			{
+				name: "example",
+			},
+		],
+	});
+
+	try {
+		assert.throws(
+			() =>
+				validateLintersConfig({
+					configPath,
+					schemaPath: rootSchemaPath,
+				}),
+			/required property '\$schema'/u,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});

--- a/.github/scripts/validate-linters-config.test.js
+++ b/.github/scripts/validate-linters-config.test.js
@@ -19,6 +19,11 @@ function writeJson(filePath, value) {
 	);
 }
 
+function writeText(filePath, value) {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, value, "utf8");
+}
+
 test("accepts the repository linters.json", () => {
 	const report = validateLintersConfig({
 		configPath: rootConfigPath,
@@ -35,12 +40,11 @@ test("accepts supported optional linter metadata", () => {
 
 	writeJson(configPath, {
 		$schema: "./linters.schema.json",
-		linters: [
-			{
+		linters: {
+			example: {
 				default_disabled: true,
 				execution_group: "yaml-fast",
 				isolated: true,
-				name: "example",
 				required_root_files: [".example.yml"],
 				sarif: {
 					category: "custom/example",
@@ -49,7 +53,7 @@ test("accepts supported optional linter metadata", () => {
 					tool_name: "custom-example",
 				},
 			},
-		],
+		},
 	});
 
 	try {
@@ -69,16 +73,14 @@ test("rejects unsupported SARIF default levels", () => {
 	const configPath = path.join(tempDir, "linters.json");
 
 	writeJson(configPath, {
-		$schema: "./linters.schema.json",
-		linters: [
-			{
-				name: "example",
+		linters: {
+			example: {
 				sarif: {
 					default_level: "info",
 					enabled: true,
 				},
 			},
-		],
+		},
 	});
 
 	try {
@@ -100,13 +102,11 @@ test("rejects unexpected linter properties", () => {
 	const configPath = path.join(tempDir, "linters.json");
 
 	writeJson(configPath, {
-		$schema: "./linters.schema.json",
-		linters: [
-			{
-				name: "example",
+		linters: {
+			example: {
 				unknown_flag: true,
 			},
-		],
+		},
 	});
 
 	try {
@@ -123,21 +123,22 @@ test("rejects unexpected linter properties", () => {
 	}
 });
 
-test("rejects duplicate linter names", () => {
+test("rejects duplicate linter object keys in raw JSON", () => {
 	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "linters-schema-"));
 	const configPath = path.join(tempDir, "linters.json");
 
-	writeJson(configPath, {
-		$schema: "./linters.schema.json",
-		linters: [
-			{
-				name: "example",
-			},
-			{
-				name: "example",
-			},
-		],
-	});
+	writeText(
+		configPath,
+		`{
+  "linters": {
+    "example": {},
+    "example": {
+      "isolated": true
+    }
+  }
+}
+`,
+	);
 
 	try {
 		assert.throws(
@@ -146,14 +147,45 @@ test("rejects duplicate linter names", () => {
 					configPath,
 					schemaPath: rootSchemaPath,
 				}),
-			/duplicate linter name/u,
+			/duplicate object key/u,
 		);
 	} finally {
 		fs.rmSync(tempDir, { force: true, recursive: true });
 	}
 });
 
-test("rejects linters.json files that omit the schema association", () => {
+test("rejects duplicate top-level linters keys in raw JSON", () => {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "linters-schema-"));
+	const configPath = path.join(tempDir, "linters.json");
+
+	writeText(
+		configPath,
+		`{
+  "linters": {
+    "alpha": {}
+  },
+  "linters": {
+    "beta": {}
+  }
+}
+`,
+	);
+
+	try {
+		assert.throws(
+			() =>
+				validateLintersConfig({
+					configPath,
+					schemaPath: rootSchemaPath,
+				}),
+			/\/linters/u,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("rejects legacy array-shaped linters definitions", () => {
 	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "linters-schema-"));
 	const configPath = path.join(tempDir, "linters.json");
 
@@ -172,7 +204,29 @@ test("rejects linters.json files that omit the schema association", () => {
 					configPath,
 					schemaPath: rootSchemaPath,
 				}),
-			/required property '\$schema'/u,
+			/\/linters: must be object/u,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("accepts linters.json files that omit the schema association", () => {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "linters-schema-"));
+	const configPath = path.join(tempDir, "linters.json");
+
+	writeJson(configPath, {
+		linters: {
+			example: {},
+		},
+	});
+
+	try {
+		assert.doesNotThrow(() =>
+			validateLintersConfig({
+				configPath,
+				schemaPath: rootSchemaPath,
+			}),
 		);
 	} finally {
 		fs.rmSync(tempDir, { force: true, recursive: true });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,18 +46,17 @@ jobs:
         id: collect
         run: |
           node - <<'NODE' >> "$GITHUB_OUTPUT"
-          const fs = require("node:fs");
           const { buildLinterJobAssignments } = require("./.github/scripts/linter-targeting.js");
-          const config = JSON.parse(fs.readFileSync("linters.json", "utf8"));
-          const definitions = Array.isArray(config.linters)
-            ? config.linters
-                .filter((definition) => definition && typeof definition.name === "string")
-                .map((definition) => ({
-                  isolated: definition.isolated,
-                  name: definition.name,
-                  patterns: ["."],
-                }))
-            : [];
+          const {
+            listLinterConfigs,
+            readLintersConfig,
+          } = require("./.github/scripts/lib/linter-shared.js");
+          const config = readLintersConfig("linters.json");
+          const definitions = listLinterConfigs(config).map((definition) => ({
+            isolated: definition.isolated,
+            name: definition.name,
+            patterns: ["."],
+          }));
           const selectedLinters = definitions.map((definition) => definition.name);
           const assignments = buildLinterJobAssignments({
             definitions,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
           node-version: 24
       - name: Install shared Node dependencies
         run: npm ci
-      - name: Validate linters config schema
-        run: node --test .github/scripts/validate-linters-config.test.js
+      - name: Validate config schemas
+        run: node --test .github/scripts/validate-linters-config.test.js .github/scripts/validate-linter-service-config.test.js
       - name: Collect fixture test matrix
         id: collect
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
           node-version: 24
       - name: Install shared Node dependencies
         run: npm ci
+      - name: Validate linters config schema
+        run: node --test .github/scripts/validate-linters-config.test.js
       - name: Collect fixture test matrix
         id: collect
         run: |

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -668,6 +668,15 @@ jobs:
           path: linter-service
           persist-credentials: false
           ref: ${{ github.sha }}
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          cache: npm
+          cache-dependency-path: linter-service/package-lock.json
+          node-version: 24
+      - name: Install shared Node dependencies
+        working-directory: linter-service
+        run: npm ci
       - name: Derive artifact passphrase
         env:
           CHECKER_PRIVATE_KEY: ${{ secrets.CHECKER_PRIVATE_KEY }}

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -114,82 +114,75 @@ jobs:
           LINTER_CONFIG_PATH: ${{ github.workspace }}/linter-service/linters.json
           LINTER_SERVICE_PATH: ${{ github.workspace }}/linter-service
         run: |
-          python3 - <<'PY'
-          import json
-          import os
-          import subprocess
-          from pathlib import Path
+          node - <<'NODE'
+          const childProcess = require("node:child_process");
+          const fs = require("node:fs");
+          const path = require("node:path");
+          const { listLinterConfigs, readLintersConfig } = require(path.join(
+            process.env.LINTER_SERVICE_PATH,
+            ".github/scripts/lib/linter-shared.js",
+          ));
+          const { validateDefinition } = require(path.join(
+            process.env.LINTER_SERVICE_PATH,
+            ".github/scripts/linter-targeting.js",
+          ));
 
-          config_path = Path(os.environ["LINTER_CONFIG_PATH"])
-          config_data = json.loads(config_path.read_text(encoding="utf-8"))
-          linters = config_data.get("linters", [])
-          script_root = Path(os.environ["LINTER_SERVICE_PATH"])
-          definitions = []
+          const scriptRoot = process.env.LINTER_SERVICE_PATH;
+          const config = readLintersConfig(process.env.LINTER_CONFIG_PATH);
+          const definitions = listLinterConfigs(config).map((item) => {
+            const definition = {
+              name: item.name,
+              patterns: readPatternScript(path.join(scriptRoot, item.name, "patterns.sh")),
+            };
 
-          if not isinstance(linters, list):
-              raise SystemExit("linter config must include a linters array")
+            if (typeof item.execution_group === "string" && item.execution_group.length > 0) {
+              definition.execution_group = item.execution_group;
+            }
+            if (typeof item.isolated === "boolean") {
+              definition.isolated = item.isolated;
+            }
+            if (typeof item.default_disabled === "boolean") {
+              definition.default_disabled = item.default_disabled;
+            }
+            if (Array.isArray(item.required_root_files)) {
+              definition.required_root_files = item.required_root_files;
+            }
 
-          for item in linters:
-              if not isinstance(item, dict) or not isinstance(item.get("name"), str):
-                  raise SystemExit("each linter config entry must include a name")
+            const configScriptPath = path.join(
+              scriptRoot,
+              item.name,
+              "config_trigger_patterns.sh",
+            );
+            if (fs.existsSync(configScriptPath)) {
+              const configTriggerPatterns = readPatternScript(configScriptPath);
+              if (configTriggerPatterns.length > 0) {
+                definition.config_trigger_patterns = configTriggerPatterns;
+              }
+            }
 
-              linter_name = item["name"]
-              script_path = script_root / linter_name / "patterns.sh"
-              result = subprocess.run(
-                  ["bash", str(script_path)],
-                  capture_output=True,
-                  check=True,
-                  text=True,
-              )
-              patterns = [line.strip() for line in result.stdout.splitlines() if line.strip()]
-              definition = {"name": linter_name, "patterns": patterns}
-              execution_group = item.get("execution_group")
-              if isinstance(execution_group, str) and execution_group:
-                  definition["execution_group"] = execution_group
-              isolated = item.get("isolated")
-              if isolated is not None:
-                  if not isinstance(isolated, bool):
-                      raise SystemExit(f"{linter_name}.isolated must be a boolean")
-                  definition["isolated"] = isolated
-              default_disabled = item.get("default_disabled")
-              if default_disabled is not None:
-                  if not isinstance(default_disabled, bool):
-                      raise SystemExit(f"{linter_name}.default_disabled must be a boolean")
-                  definition["default_disabled"] = default_disabled
-              config_script_path = script_root / linter_name / "config_trigger_patterns.sh"
-              if config_script_path.is_file():
-                  config_result = subprocess.run(
-                      ["bash", str(config_script_path)],
-                      capture_output=True,
-                      check=True,
-                      text=True,
-                  )
-                  config_trigger_patterns = [
-                      line.strip()
-                      for line in config_result.stdout.splitlines()
-                      if line.strip()
-                  ]
-                  if config_trigger_patterns:
-                      definition["config_trigger_patterns"] = config_trigger_patterns
-              required_root_files = item.get("required_root_files")
-              if required_root_files is not None:
-                  if not isinstance(required_root_files, list) or not all(
-                      isinstance(entry, str) and entry.strip()
-                      for entry in required_root_files
-                  ):
-                      raise SystemExit(
-                          f"{linter_name}.required_root_files must be an array of non-empty strings"
-                      )
-                  definition["required_root_files"] = required_root_files
-              definitions.append(definition)
+            validateDefinition(definition);
+            return definition;
+          });
 
-          output_path = Path(os.environ["RUNNER_TEMP"]) / "linter-definitions.json"
-          output_path.write_text(json.dumps(definitions), encoding="utf-8")
+          const outputPath = path.join(process.env.RUNNER_TEMP, "linter-definitions.json");
+          fs.writeFileSync(outputPath, JSON.stringify(definitions), "utf8");
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `path=${outputPath}\n`,
+            "utf8",
+          );
 
-          github_output = Path(os.environ["GITHUB_OUTPUT"])
-          with github_output.open("a", encoding="utf-8") as fh:
-              fh.write(f"path={output_path}\n")
-          PY
+          function readPatternScript(scriptPath) {
+            return childProcess
+              .execFileSync("bash", [scriptPath], {
+                cwd: scriptRoot,
+                encoding: "utf8",
+              })
+              .split(/\r?\n/u)
+              .map((line) => line.trim())
+              .filter(Boolean);
+          }
+          NODE
       - name: Get checker token
         id: get_checker_token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -16,8 +16,8 @@ rules:
       - repository-dispatch.yml:597
       - repository-dispatch.yml:648
       - repository-dispatch.yml:649
-      - repository-dispatch.yml:673
-      - repository-dispatch.yml:742
-      - repository-dispatch.yml:746
-      - repository-dispatch.yml:753
-      - repository-dispatch.yml:756
+      - repository-dispatch.yml:682
+      - repository-dispatch.yml:751
+      - repository-dispatch.yml:755
+      - repository-dispatch.yml:762
+      - repository-dispatch.yml:765

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -7,17 +7,17 @@ rules:
       - lint-common.yml:90
       - lint-common.yml:93
       - repository-dispatch.yml:107
-      - repository-dispatch.yml:197
+      - repository-dispatch.yml:190
+      - repository-dispatch.yml:194
       - repository-dispatch.yml:201
-      - repository-dispatch.yml:208
-      - repository-dispatch.yml:211
-      - repository-dispatch.yml:570
-      - repository-dispatch.yml:601
-      - repository-dispatch.yml:604
-      - repository-dispatch.yml:655
-      - repository-dispatch.yml:656
-      - repository-dispatch.yml:680
-      - repository-dispatch.yml:749
+      - repository-dispatch.yml:204
+      - repository-dispatch.yml:563
+      - repository-dispatch.yml:594
+      - repository-dispatch.yml:597
+      - repository-dispatch.yml:648
+      - repository-dispatch.yml:649
+      - repository-dispatch.yml:673
+      - repository-dispatch.yml:742
+      - repository-dispatch.yml:746
       - repository-dispatch.yml:753
-      - repository-dispatch.yml:760
-      - repository-dispatch.yml:763
+      - repository-dispatch.yml:756

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ GitHub App Webhook を Cloudflare Worker が受け、この repository へ
 | `.github/workflows/repository-dispatch.yml` | router workflow |
 | `<linter>/` | linter ごとの script / fixture test / helper |
 | `linters.json` | linter 定義と SARIF / 実行メタデータ |
+| `linters.schema.json` | `linters.json` の editor validation / 補完用 schema |
 | `worker/` | Webhook を受ける Cloudflare Worker |
 
 ## 共有 linter 一覧
@@ -134,6 +135,7 @@ linters:
 ## 共有 linter の追加方法
 
 - 追加先は root の `linters.json` と root 直下の `<name>/` directory である。`.github/scripts/` は shared script 専用である。
+- `linters.json` は root の `linters.schema.json` を `$schema` で参照する。schema と実データは同時に更新する。
 - 最低限の構成は `patterns.sh`, `install.sh`, `run.sh` である。設定ファイル変更で全 target を再評価する linter だけ `config_trigger_patterns.sh` を追加する。shared helper が必要な場合のみ `common.sh` を追加する。
 - `linters.json` で `isolated: true` を付けた linter は shared batch から分離し、専用 job で実行する。
 - 参考実装は `actionlint/` が最小構成、`cargo-clippy/` と `textlint/` が隔離実行や config 解決を含む例である。

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ GitHub App Webhook を Cloudflare Worker が受け、この repository へ
 |------|------|
 | `.github/codeql/` | CodeQL の分析設定 |
 | `.github/linter-service.yaml` | source repo 側の exclude / disable 設定 |
+| `.github/linter-service.schema.json` | `.github/linter-service.yaml` の editor validation / 補完用 schema |
 | `.github/scripts/` | shared helper / renderer / artifact utility |
 | `.github/workflows/ci.yml` | `worker/` 検証と fixture test CI |
 | `.github/workflows/codeql.yml` | fixture 除外付き CodeQL workflow |
@@ -105,6 +106,10 @@ GitHub App Webhook を Cloudflare Worker が受け、この repository へ
 - 利用 repository 側の target selection 制御用である。
 - `.github/linter-service.yaml` を推奨し、互換のため
   `.github/linter-service.json` も読み込む。
+- この repository 内の sample `.github/linter-service.yaml` は
+  `# yaml-language-server: $schema=./linter-service.schema.json` で
+  local schema を参照する。利用側で同じ comment を使う場合は
+  `.github/linter-service.schema.json` も合わせて配置する。
 - どちらの file もない場合は、`初期選択` 列で有効な linter を、
   この file による除外パス設定なしで処理対象にする。
 - `linters.json` の `required_root_files` に列挙した repo root 必須 file と、

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ GitHub App Webhook を Cloudflare Worker が受け、この repository へ
 | `.github/workflows/lint-common.yml` | 共通 reusable workflow |
 | `.github/workflows/repository-dispatch.yml` | router workflow |
 | `<linter>/` | linter ごとの script / fixture test / helper |
-| `linters.json` | linter 定義と SARIF / 実行メタデータ |
+| `linters.json` | linter 定義 object と SARIF / 実行メタデータ |
 | `linters.schema.json` | `linters.json` の editor validation / 補完用 schema |
 | `worker/` | Webhook を受ける Cloudflare Worker |
 
@@ -140,7 +140,7 @@ linters:
 ## 共有 linter の追加方法
 
 - 追加先は root の `linters.json` と root 直下の `<name>/` directory である。`.github/scripts/` は shared script 専用である。
-- `linters.json` は root の `linters.schema.json` を `$schema` で参照する。schema と実データは同時に更新する。
+- `linters.json` は `linters.<name>` を key に持つ object である。editor validation が必要な場合だけ root の `linters.schema.json` を `$schema` で参照する。schema と実データは同時に更新する。
 - 最低限の構成は `patterns.sh`, `install.sh`, `run.sh` である。設定ファイル変更で全 target を再評価する linter だけ `config_trigger_patterns.sh` を追加する。shared helper が必要な場合のみ `common.sh` を追加する。
 - `linters.json` で `isolated: true` を付けた linter は shared batch から分離し、専用 job で実行する。
 - 参考実装は `actionlint/` が最小構成、`cargo-clippy/` と `textlint/` が隔離実行や config 解決を含む例である。

--- a/linters.json
+++ b/linters.json
@@ -1,63 +1,52 @@
 {
-  "$schema": "./linters.schema.json",
-  "linters": [
-    {
-      "name": "actionlint",
+  "linters": {
+    "actionlint": {
       "sarif": {
         "enabled": true
       }
     },
-    {
-      "name": "ghalint",
+    "ghalint": {
       "sarif": {
         "enabled": true
       }
     },
-    {
-      "name": "hadolint",
+    "hadolint": {
       "sarif": {
         "enabled": true
       }
     },
-    {
-      "name": "trivy",
+    "trivy": {
       "sarif": {
         "enabled": true,
         "default_level": "warning"
       }
     },
-    {
-      "name": "dotenv-linter",
+    "dotenv-linter": {
       "sarif": {
         "enabled": true
       }
     },
-    {
-      "name": "spectral",
+    "spectral": {
       "sarif": {
         "enabled": true
       }
     },
-    {
-      "name": "yamllint",
+    "yamllint": {
       "sarif": {
         "enabled": true
       }
     },
-    {
-      "name": "yamlfmt",
+    "yamlfmt": {
       "sarif": {
         "enabled": true
       }
     },
-    {
-      "name": "markdownlint-cli2",
+    "markdownlint-cli2": {
       "sarif": {
         "enabled": true
       }
     },
-    {
-      "name": "textlint",
+    "textlint": {
       "isolated": true,
       "required_root_files": [
         ".textlintrc"
@@ -66,61 +55,52 @@
         "enabled": true
       }
     },
-    {
-      "name": "ruff",
+    "ruff": {
       "sarif": {
         "enabled": true
       }
     },
-    {
-      "name": "rustfmt",
+    "rustfmt": {
       "sarif": {
         "enabled": true
       }
     },
-    {
-      "name": "cargo-clippy",
+    "cargo-clippy": {
       "isolated": true,
       "sarif": {
         "enabled": true
       }
     },
-    {
-      "name": "cargo-deny",
+    "cargo-deny": {
       "sarif": {
         "enabled": true,
         "target_kind": "cargo-projects"
       }
     },
-    {
-      "name": "taplo",
+    "taplo": {
       "sarif": {
         "enabled": true
       }
     },
-    {
-      "name": "biome",
+    "biome": {
       "sarif": {
         "enabled": true
       }
     },
-    {
-      "name": "editorconfig-checker",
+    "editorconfig-checker": {
       "sarif": {
         "enabled": true
       }
     },
-    {
-      "name": "shellcheck",
+    "shellcheck": {
       "sarif": {
         "enabled": true
       }
     },
-    {
-      "name": "zizmor",
+    "zizmor": {
       "sarif": {
         "enabled": true
       }
     }
-  ]
+  }
 }

--- a/linters.json
+++ b/linters.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./linters.schema.json",
   "linters": [
     {
       "name": "actionlint",

--- a/linters.schema.json
+++ b/linters.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "linter-service linters.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "linters"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "./linters.schema.json",
+      "description": "Local schema reference for editor validation."
+    },
+    "linters": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/linterDefinition"
+      }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "pattern": "\\S"
+    },
+    "linterName": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$"
+    },
+    "nonEmptyStringArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/nonEmptyString"
+      }
+    },
+    "sarifConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enabled"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "default_level": {
+          "type": "string",
+          "enum": [
+            "error",
+            "note",
+            "warning"
+          ]
+        },
+        "target_kind": {
+          "type": "string",
+          "enum": [
+            "cargo-projects"
+          ]
+        },
+        "category": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "tool_name": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "linterDefinition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/linterName"
+        },
+        "execution_group": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+        },
+        "default_disabled": {
+          "type": "boolean"
+        },
+        "isolated": {
+          "type": "boolean"
+        },
+        "required_root_files": {
+          "$ref": "#/$defs/nonEmptyStringArray"
+        },
+        "sarif": {
+          "$ref": "#/$defs/sarifConfig"
+        }
+      }
+    }
+  }
+}

--- a/linters.schema.json
+++ b/linters.schema.json
@@ -4,7 +4,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "$schema",
     "linters"
   ],
   "properties": {
@@ -13,8 +12,11 @@
       "description": "Local schema reference for editor validation."
     },
     "linters": {
-      "type": "array",
-      "items": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/linterName"
+      },
+      "additionalProperties": {
         "$ref": "#/$defs/linterDefinition"
       }
     }
@@ -69,13 +71,7 @@
     "linterDefinition": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name"
-      ],
       "properties": {
-        "name": {
-          "$ref": "#/$defs/linterName"
-        },
         "execution_group": {
           "type": "string",
           "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,26 @@
       "name": "linter-service",
       "dependencies": {
         "js-yaml": "4.1.1"
+      },
+      "devDependencies": {
+        "ajv": "8.18.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/argparse": {
@@ -14,6 +34,30 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -25,6 +69,23 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
   "private": true,
   "dependencies": {
     "js-yaml": "4.1.1"
+  },
+  "devDependencies": {
+    "ajv": "8.18.0"
   }
 }

--- a/textlint/textlint-config.js
+++ b/textlint/textlint-config.js
@@ -7,6 +7,9 @@ const {
 	loadLinterServiceConfig,
 } = require("../.github/scripts/linter-service-config.js");
 const {
+	getTextlintPresetRuleKey,
+} = require("../.github/scripts/textlint-preset-package.js");
+const {
 	parseExactPackageSpec,
 } = require("../.github/scripts/npm-package-spec.js");
 
@@ -111,26 +114,6 @@ function buildSafeTextlintConfig({ config, presetPackages }) {
 	}
 
 	return safeConfig;
-}
-
-function getTextlintPresetRuleKey(packageName) {
-	if (
-		typeof packageName === "string" &&
-		packageName.startsWith("textlint-rule-preset-")
-	) {
-		return packageName.replace(/^textlint-rule-preset-/u, "preset-");
-	}
-
-	if (
-		typeof packageName === "string" &&
-		packageName.includes("/textlint-rule-preset-")
-	) {
-		return packageName.replace(/\/textlint-rule-preset-/u, "/preset-");
-	}
-
-	throw new Error(
-		`linters.textlint.preset_packages must use textlint preset packages: ${packageName}`,
-	);
 }
 
 function requireRepositoryPath(repositoryPath) {


### PR DESCRIPTION
## Summary
- add maintained schemas for `linters.json` and `.github/linter-service.yaml`
- make `linters.json` canonical shape object-based, keep the top-level `$schema` optional, and reject duplicate JSON object keys before runtime reads
- route repository-dispatch, CI helpers, and README guidance through the validated config shape so workflow behavior stays aligned with the schema

## Validation
- node --test .github/scripts/linter-service-config.test.js .github/scripts/prepare-deselected-sarif.test.js .github/scripts/render-linter-report.test.js .github/scripts/render-linter-sarif.test.js .github/scripts/run-fixture-tests.test.js .github/scripts/run-linter-batch.test.js .github/scripts/validate-linters-config.test.js .github/scripts/validate-linter-service-config.test.js .github/scripts/zizmor-config.test.js textlint/textlint.test.js
- node .github/scripts/validate-linters-config.js
- node .github/scripts/validate-linter-service-config.js
- node .github/scripts/run-fixture-tests.js actionlint
- npm --prefix worker run check
- git diff --check