### PR TITLE
fix(biome): use native sarif reporter

### DIFF
--- a/.github/scripts/render-linter-sarif.js
+++ b/.github/scripts/render-linter-sarif.js
@@ -114,6 +114,7 @@ function renderSarif({
 			? []
 			: buildSarifResults({
 					configPath,
+					runnerTemp,
 					result,
 					defaultLevel: sarifConfig?.default_level || "warning",
 					details,
@@ -132,7 +133,16 @@ function renderSarif({
 		return { outputPath, produced: false, sarif: null, targetStats };
 	}
 
-	const rules = buildRuleDescriptors(results);
+	const linterSpecificRules = buildLinterSpecificSarifRules({
+		configPath,
+		linterName,
+		result,
+		runnerTemp,
+	});
+	const rules =
+		linterSpecificRules === null
+			? buildRuleDescriptors(results)
+			: linterSpecificRules;
 	const category = sarifConfig.category || `linter-service/${linterName}`;
 	const toolName = sarifConfig.tool_name || `linter-service/${linterName}`;
 
@@ -269,6 +279,7 @@ function buildSarifResults({
 	linterName,
 	result,
 	reportedPathRoots,
+	runnerTemp,
 	sourceRepositoryPath,
 	targetPaths,
 }) {
@@ -282,6 +293,7 @@ function buildSarifResults({
 		parseInteger,
 		reportedPathRoots,
 		result,
+		runnerTemp,
 		sourceRepositoryPath,
 		targetPaths,
 		toSarifLevel,
@@ -351,6 +363,7 @@ function buildLinterSpecificSarifResults({
 	parseInteger,
 	reportedPathRoots,
 	result,
+	runnerTemp,
 	sourceRepositoryPath,
 	targetPaths,
 	toSarifLevel,
@@ -371,6 +384,7 @@ function buildLinterSpecificSarifResults({
 			parseInteger,
 			reportedPathRoots,
 			result,
+			runnerTemp,
 			sourceRepositoryPath,
 			targetPaths,
 			toSarifLevel,
@@ -386,6 +400,41 @@ function buildLinterSpecificSarifResults({
 	}
 
 	return [];
+}
+
+function buildLinterSpecificSarifRules({
+	configPath,
+	linterName,
+	result,
+	runnerTemp,
+}) {
+	const hook = loadLinterHook({
+		configPath,
+		fileName: "render-linter-sarif.js",
+		linterName,
+	});
+
+	if (typeof hook?.buildSarifRules !== "function") {
+		return null;
+	}
+
+	const rules = hook.buildSarifRules({
+		linterName,
+		result,
+		runnerTemp,
+	});
+
+	if (rules === null || typeof rules === "undefined") {
+		return null;
+	}
+
+	if (!Array.isArray(rules)) {
+		throw new Error(
+			`${linterName} render-linter-sarif.js must return an array of SARIF rules`,
+		);
+	}
+
+	return rules;
 }
 
 function parsePathDiagnostics({

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ GitHub App Webhook を Cloudflare Worker が受け、この repository へ
 | `dotenv-linter` | changed `.env` file への upstream default checks 直接適用、`--schema` と ignore-checks 注入は未対応。 |
 | `editorconfig-checker` | `PassedFiles` 制限、`NoColor` 強制。 |
 | `helmlint` | changed file から親方向の `Chart.yaml` を解決し、chart directory ごとに重複排除して `helm lint` 実行。 |
+| `biome` | native `--reporter=sarif --reporter-file=...` を前提に実行する。 |
 | `lizard` | default disabled。repo 側の `linters.lizard.languages` で選んだ言語だけを対象にし、repo root の `whitelizard.txt` をそのまま利用する。 |
 | `markdownlint-cli2` | 静的 config のみ対応、`.cjs`, `.mjs` 非対応、`globs` 不使用。 |
 | `ruff` | `--force-exclude` 付与。 |

--- a/biome/biome.test.js
+++ b/biome/biome.test.js
@@ -1,0 +1,115 @@
+const test = require("node:test");
+const { execFileSync, spawnSync } = require("node:child_process");
+const {
+	assert,
+	cleanupTempRepo,
+	fs,
+	makeTempRepo,
+	path,
+	writeExecutable,
+	writeFile,
+} = require("../.github/scripts/cargo-linter-test-lib.js");
+
+const runPath = path.join(__dirname, "run.sh");
+
+function createEnv(context, extraEnv = {}) {
+	return {
+		...process.env,
+		...extraEnv,
+		PATH: `${context.binDir}:${process.env.PATH}`,
+		RUNNER_TEMP: context.runnerTemp,
+	};
+}
+
+function createBiomeStub(context) {
+	writeExecutable(
+		path.join(context.binDir, "biome"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+reporter_file=""
+use_sarif=0
+for arg in "$@"; do
+  case "$arg" in
+    --reporter=sarif)
+      use_sarif=1
+      ;;
+    --reporter-file=*)
+      reporter_file="\${arg#--reporter-file=}"
+      ;;
+  esac
+done
+if [ "$use_sarif" -eq 1 ]; then
+  case "\${NATIVE_SARIF_MODE:-success}" in
+    success)
+      cat > "$reporter_file" <<'EOF'
+{"$schema":"https://json.schemastore.org/sarif-2.1.0.json","version":"2.1.0","runs":[{"results":[{"ruleId":"parse","level":"error","message":{"text":"native failure"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"src/app.ts"},"region":{"startLine":4,"startColumn":3}}}]}],"tool":{"driver":{"rules":[{"id":"parse","shortDescription":{"text":"parse"}}]}}}]}
+EOF
+      printf 'SARIF summary\\n' >&2
+      exit 1
+      ;;
+    missing)
+      printf 'SARIF summary\\n' >&2
+      exit 1
+      ;;
+  esac
+fi
+printf 'unexpected invocation\\n' >&2
+exit 99
+`,
+	);
+}
+
+test("biome/run.sh runs Biome in SARIF mode from the start", () => {
+	const context = makeTempRepo("biome-run-native-sarif-");
+
+	createBiomeStub(context);
+	writeFile(path.join(context.repoDir, "src/app.ts"), 'console.log("x")\n');
+
+	try {
+		const output = execFileSync("bash", [runPath, "src/app.ts"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createEnv(context),
+		});
+		const result = JSON.parse(output);
+		const sarifPath = path.join(context.runnerTemp, "biome-native.sarif");
+
+		assert.equal(result.exit_code, 1);
+		assert.equal(result.details, "SARIF summary");
+		assert.equal(fs.existsSync(sarifPath), true);
+		assert.equal(
+			JSON.parse(fs.readFileSync(sarifPath, "utf8")).runs[0].results[0].ruleId,
+			"parse",
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("biome/run.sh fails when native SARIF output is missing", () => {
+	const context = makeTempRepo("biome-run-missing-sarif-");
+
+	createBiomeStub(context);
+	writeFile(path.join(context.repoDir, "src/app.ts"), 'console.log("x")\n');
+
+	try {
+		const sarifPath = path.join(context.runnerTemp, "biome-native.sarif");
+		const result = spawnSync("bash", [runPath, "src/app.ts"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createEnv(context, {
+				NATIVE_SARIF_MODE: "missing",
+			}),
+		});
+
+		assert.equal(result.status, 1);
+		assert.match(
+			result.stderr,
+			/biome native SARIF reporter did not produce output/u,
+		);
+		assert.equal(result.stdout, "");
+		assert.equal(fs.existsSync(sarifPath), false);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/biome/render-linter-sarif.js
+++ b/biome/render-linter-sarif.js
@@ -1,0 +1,167 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const NATIVE_SARIF_FILE = "biome-native.sarif";
+
+function buildSarifResults({
+	dedupeResults,
+	linterName,
+	normalizeReportedPath,
+	reportedPathRoots,
+	runnerTemp,
+	sourceRepositoryPath,
+	targetPaths,
+}) {
+	if (linterName !== "biome") {
+		return [];
+	}
+
+	const run = readNativeSarifRun(runnerTemp);
+	if (!run || !Array.isArray(run.results)) {
+		return [];
+	}
+
+	return dedupeResults(
+		run.results.map((result) =>
+			normalizeBiomeSarifResult({
+				linterName,
+				normalizeReportedPath,
+				reportedPathRoots,
+				result,
+				sourceRepositoryPath,
+				targetPaths,
+			}),
+		),
+	);
+}
+
+function buildSarifRules({ linterName, runnerTemp }) {
+	if (linterName !== "biome") {
+		return null;
+	}
+
+	const rules = readNativeSarifRun(runnerTemp)?.tool?.driver?.rules;
+	if (!Array.isArray(rules)) {
+		return null;
+	}
+
+	return dedupeRules(rules.map((rule) => structuredClone(rule)));
+}
+
+function readNativeSarifRun(runnerTemp) {
+	if (typeof runnerTemp !== "string" || runnerTemp.length === 0) {
+		return null;
+	}
+
+	const nativeSarifPath = path.join(runnerTemp, NATIVE_SARIF_FILE);
+	if (!fs.existsSync(nativeSarifPath)) {
+		return null;
+	}
+
+	const parsed = JSON.parse(fs.readFileSync(nativeSarifPath, "utf8"));
+	return Array.isArray(parsed?.runs) ? parsed.runs[0] || null : null;
+}
+
+function normalizeBiomeSarifResult({
+	linterName,
+	normalizeReportedPath,
+	reportedPathRoots,
+	result,
+	sourceRepositoryPath,
+	targetPaths,
+}) {
+	const normalizedResult = structuredClone(result);
+	const normalizedLocations = normalizeLocations({
+		locations: normalizedResult.locations,
+		normalizeReportedPath,
+		reportedPathRoots,
+		sourceRepositoryPath,
+		targetPaths,
+	});
+
+	if (normalizedLocations.length > 0) {
+		normalizedResult.locations = normalizedLocations;
+	} else {
+		delete normalizedResult.locations;
+	}
+
+	normalizedResult.properties = {
+		...(normalizedResult.properties &&
+		typeof normalizedResult.properties === "object"
+			? normalizedResult.properties
+			: {}),
+		linter_name: linterName,
+	};
+
+	return normalizedResult;
+}
+
+function normalizeLocations({
+	locations,
+	normalizeReportedPath,
+	reportedPathRoots,
+	sourceRepositoryPath,
+	targetPaths,
+}) {
+	if (!Array.isArray(locations)) {
+		return [];
+	}
+
+	return locations.flatMap((location) => {
+		const uri = location?.physicalLocation?.artifactLocation?.uri;
+		const normalizedUri = normalizeReportedPath(
+			sourceRepositoryPath,
+			uri,
+			targetPaths,
+			reportedPathRoots,
+		);
+
+		if (!normalizedUri) {
+			return [];
+		}
+
+		return [
+			{
+				...location,
+				physicalLocation: {
+					...(location.physicalLocation &&
+					typeof location.physicalLocation === "object"
+						? location.physicalLocation
+						: {}),
+					artifactLocation: {
+						...(location?.physicalLocation?.artifactLocation &&
+						typeof location.physicalLocation.artifactLocation === "object"
+							? location.physicalLocation.artifactLocation
+							: {}),
+						uri: normalizedUri,
+					},
+				},
+			},
+		];
+	});
+}
+
+function dedupeRules(rules) {
+	const seen = new Set();
+	const deduped = [];
+
+	for (const rule of rules) {
+		const key =
+			typeof rule?.id === "string" && rule.id.length > 0
+				? rule.id
+				: JSON.stringify(rule);
+		if (seen.has(key)) {
+			continue;
+		}
+
+		seen.add(key);
+		deduped.push(rule);
+	}
+
+	return deduped;
+}
+
+module.exports = {
+	buildSarifResults,
+	buildSarifRules,
+};

--- a/biome/render-linter-sarif.test.js
+++ b/biome/render-linter-sarif.test.js
@@ -10,25 +10,79 @@ const {
 const { runFromEnv } = require("../.github/scripts/render-linter-sarif.js");
 
 const configPath = path.join(__dirname, "..", "linters.json");
-const details = "src/app.ts:4:3: BIOME001 debug statements are not allowed";
+const details =
+	"lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n  × Some errors were emitted while running checks.";
+const nativeSarif = {
+	$schema: "https://json.schemastore.org/sarif-2.1.0.json",
+	runs: [
+		{
+			results: [
+				{
+					level: "error",
+					locations: [
+						{
+							physicalLocation: {
+								artifactLocation: {
+									uri: "/tmp/placeholder/repo/src/app.ts",
+								},
+								region: {
+									endColumn: 10,
+									endLine: 4,
+									startColumn: 3,
+									startLine: 4,
+								},
+							},
+						},
+					],
+					message: {
+						text: "debug statements are not allowed",
+					},
+					ruleId: "lint/suspicious/noDebugger",
+				},
+			],
+			tool: {
+				driver: {
+					rules: [
+						{
+							helpUri: "https://biomejs.dev/linter/rules/no-debugger/",
+							id: "lint/suspicious/noDebugger",
+							shortDescription: {
+								text: "Disallow debugger statements.",
+							},
+						},
+					],
+				},
+			},
+		},
+	],
+	version: "2.1.0",
+};
 
-test("emits SARIF for biome diagnostics", () => {
+test("prefers native Biome SARIF when available", () => {
 	const context = makeTempRepo("render-linter-sarif-biome-");
 
-	writeFile(path.join(context.repoDir, "src/app.ts"), 'console.log("x")\n');
-	writeFile(
-		path.join(context.runnerTemp, "selected-files.txt"),
-		"src/app.ts\n",
-	);
-	writeFile(
-		path.join(context.runnerTemp, "linter-result.json"),
-		JSON.stringify({
-			details,
-			exit_code: 1,
-		}),
-	);
-
 	try {
+		const nativeSarifReport = structuredClone(nativeSarif);
+		nativeSarifReport.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri =
+			path.join(context.repoDir, "src/app.ts");
+
+		writeFile(path.join(context.repoDir, "src/app.ts"), 'console.log("x")\n');
+		writeFile(
+			path.join(context.runnerTemp, "selected-files.txt"),
+			"src/app.ts\n",
+		);
+		writeFile(
+			path.join(context.runnerTemp, "linter-result.json"),
+			JSON.stringify({
+				details,
+				exit_code: 1,
+			}),
+		);
+		writeFile(
+			path.join(context.runnerTemp, "biome-native.sarif"),
+			JSON.stringify(nativeSarifReport),
+		);
+
 		const report = runFromEnv({
 			INSTALL_TOOL_OUTCOME: "success",
 			LINTER_CONFIG_PATH: configPath,
@@ -43,7 +97,11 @@ test("emits SARIF for biome diagnostics", () => {
 		});
 
 		assert.equal(report.produced, true);
-		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(report.sarif.runs[0].results.length, 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].ruleId,
+			"lint/suspicious/noDebugger",
+		);
 		assert.equal(
 			report.sarif.runs[0].results[0].locations[0].physicalLocation
 				.artifactLocation.uri,
@@ -58,6 +116,15 @@ test("emits SARIF for biome diagnostics", () => {
 			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
 				.startColumn,
 			3,
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
+				.endColumn,
+			10,
+		);
+		assert.equal(
+			report.sarif.runs[0].tool.driver.rules[0].helpUri,
+			"https://biomejs.dev/linter/rules/no-debugger/",
 		);
 	} finally {
 		cleanupTempRepo(context.tempDir);

--- a/biome/run.sh
+++ b/biome/run.sh
@@ -8,10 +8,23 @@ source "$script_dir/common.sh"
 
 : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
 output_file="$RUNNER_TEMP/linter-output.txt"
-linter_lib::run_and_emit_json \
-  "$output_file" \
-  biome lint \
+native_sarif_file="$RUNNER_TEMP/biome-native.sarif"
+rm -f "$native_sarif_file"
+
+set +e
+biome lint \
   --colors=off \
   --error-on-warnings \
   --no-errors-on-unmatched \
-  "$@"
+  --reporter=sarif \
+  --reporter-file="$native_sarif_file" \
+  "$@" >"$output_file" 2>&1
+exit_code=$?
+set -e
+
+if [ ! -s "$native_sarif_file" ]; then
+  echo "biome native SARIF reporter did not produce output" >&2
+  exit 1
+fi
+
+linter_lib::emit_json_result "$exit_code" "$output_file"

--- a/biome/tests/fail/result.json
+++ b/biome/tests/fail/result.json
@@ -1,7 +1,7 @@
 {
   "checked_projects": [],
   "result": {
-    "details": "src/index.js:1:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n  × Expected an identifier, an array pattern, or an object pattern but instead found '= 1'.\n  \n  > 1 │ const = 1;\n      │       ^^^\n    2 │ \n  \n  i Expected an identifier, an array pattern, or an object pattern here.\n  \n  > 1 │ const = 1;\n      │       ^^^\n    2 │ \n  \n\nsrc/index.js:1:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n  × expected `,` but instead found `;`\n  \n  > 1 │ const = 1;\n      │          ^\n    2 │ \n  \n  i Remove ;\n  \n\nsrc/index.js:1:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n  × Expected an identifier, an array pattern, or an object pattern but instead found '= 1'.\n  \n  > 1 │ const = 1;\n      │       ^^^\n    2 │ \n  \n  i Expected an identifier, an array pattern, or an object pattern here.\n  \n  > 1 │ const = 1;\n      │       ^^^\n    2 │ \n  \n\nChecked 1 file in <duration>. No fixes applied.\nFound 3 errors.\nlint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n  × Some errors were emitted while running checks.",
+    "details": "lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n  × Some errors were emitted while running checks.",
     "exit_code": 1
   },
   "selected_files": [

--- a/biome/tests/fail/sarif.json
+++ b/biome/tests/fail/sarif.json
@@ -7,7 +7,7 @@
       },
       "results": [
         {
-          "level": "warning",
+          "level": "error",
           "locations": [
             {
               "physicalLocation": {
@@ -15,22 +15,24 @@
                   "uri": "src/index.js"
                 },
                 "region": {
-                  "startColumn": 1,
+                  "endColumn": 11,
+                  "endLine": 1,
+                  "startColumn": 10,
                   "startLine": 1
                 }
               }
             }
           ],
           "message": {
-            "text": "10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            "text": "expected `,` but instead found `;`"
           },
           "properties": {
             "linter_name": "biome"
           },
-          "ruleId": "biome/diagnostic"
+          "ruleId": "parse"
         },
         {
-          "level": "warning",
+          "level": "error",
           "locations": [
             {
               "physicalLocation": {
@@ -38,19 +40,21 @@
                   "uri": "src/index.js"
                 },
                 "region": {
-                  "startColumn": 1,
+                  "endColumn": 10,
+                  "endLine": 1,
+                  "startColumn": 7,
                   "startLine": 1
                 }
               }
             }
           ],
           "message": {
-            "text": "7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            "text": "Expected an identifier, an array pattern, or an object pattern but instead found '= 1'."
           },
           "properties": {
             "linter_name": "biome"
           },
-          "ruleId": "biome/diagnostic"
+          "ruleId": "parse"
         }
       ],
       "tool": {
@@ -59,10 +63,10 @@
           "name": "linter-service/biome",
           "rules": [
             {
-              "id": "biome/diagnostic",
-              "name": "biome/diagnostic",
+              "helpUri": "",
+              "id": "parse",
               "shortDescription": {
-                "text": "biome/diagnostic"
+                "text": ""
               }
             }
           ]

--- a/biome/tests/pass/result.json
+++ b/biome/tests/pass/result.json
@@ -1,7 +1,7 @@
 {
   "checked_projects": [],
   "result": {
-    "details": "Checked 1 file in <duration>. No fixes applied.",
+    "details": "",
     "exit_code": 0
   },
   "selected_files": [


### PR DESCRIPTION
## Summary
- run Biome in native SARIF mode from the start with `--reporter=sarif --reporter-file`
- load native Biome SARIF results and rule metadata through a linter-specific SARIF hook
- update Biome fixtures, focused tests, and README notes for the SARIF-first flow