### PR TITLE
feat(lizard): add language-specific thresholds

### DIFF
--- a/.github/linter-service.schema.json
+++ b/.github/linter-service.schema.json
@@ -120,6 +120,42 @@
         "$ref": "#/$defs/lizardLanguage"
       }
     },
+    "lizardThresholdValue": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "lizardThresholdConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "nloc": {
+          "$ref": "#/$defs/lizardThresholdValue"
+        },
+        "cyclomatic_complexity": {
+          "$ref": "#/$defs/lizardThresholdValue"
+        },
+        "token_count": {
+          "$ref": "#/$defs/lizardThresholdValue"
+        },
+        "parameter_count": {
+          "$ref": "#/$defs/lizardThresholdValue"
+        },
+        "length": {
+          "$ref": "#/$defs/lizardThresholdValue"
+        }
+      }
+    },
+    "lizardLanguageThresholds": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/lizardThresholdConfig"
+      },
+      "minProperties": 1,
+      "propertyNames": {
+        "$ref": "#/$defs/lizardLanguage"
+      }
+    },
     "lizardLinterConfig": {
       "type": "object",
       "additionalProperties": false,
@@ -132,6 +168,9 @@
         },
         "languages": {
           "$ref": "#/$defs/lizardLanguageArray"
+        },
+        "thresholds": {
+          "$ref": "#/$defs/lizardLanguageThresholds"
         }
       },
       "allOf": [

--- a/.github/scripts/linter-service-config.test.js
+++ b/.github/scripts/linter-service-config.test.js
@@ -12,6 +12,10 @@ const {
 	loadLinterServiceConfig,
 	normalizeGlobPattern,
 } = require("./linter-service-config.js");
+const {
+	buildThresholdArguments,
+	normalizeLizardOutput,
+} = require("../../lizard/run-lizard.js");
 
 function makeTempRepo() {
 	const tempDir = fs.mkdtempSync(
@@ -76,6 +80,10 @@ function isYamlCollection(value) {
 function serializeSimpleYamlScalar(value) {
 	if (typeof value === "string") {
 		return JSON.stringify(value);
+	}
+
+	if (typeof value === "number" && Number.isFinite(value)) {
+		return String(value);
 	}
 
 	if (typeof value === "boolean") {
@@ -382,6 +390,158 @@ test("rejects unknown lizard languages", () => {
 	} finally {
 		cleanupTempRepo(context.tempDir);
 	}
+});
+
+test("supports lizard per-language thresholds when lizard is explicitly enabled", () => {
+	const context = makeTempRepo();
+
+	writeLinterServiceConfig(context.repoDir, {
+		linters: {
+			lizard: {
+				disabled: false,
+				languages: ["javascript", "python"],
+				thresholds: {
+					javascript: {
+						nloc: 20,
+						cyclomatic_complexity: 10,
+						token_count: 150,
+						parameter_count: 6,
+						length: 30,
+					},
+					python: {
+						parameter_count: 4,
+					},
+				},
+			},
+		},
+	});
+
+	try {
+		const config = loadLinterServiceConfig({
+			repositoryPath: context.repoDir,
+		});
+
+		assert.deepEqual(getLinterConfig(config, "lizard").thresholds, {
+			javascript: {
+				nloc: 20,
+				cyclomatic_complexity: 10,
+				token_count: 150,
+				parameter_count: 6,
+				length: 30,
+			},
+			python: {
+				parameter_count: 4,
+			},
+		});
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("rejects invalid lizard threshold values", () => {
+	const context = makeTempRepo();
+
+	writeLinterServiceConfig(context.repoDir, {
+		linters: {
+			lizard: {
+				disabled: false,
+				languages: ["javascript"],
+				thresholds: {
+					javascript: {
+						parameter_count: -1,
+					},
+				},
+			},
+		},
+	});
+
+	try {
+		assert.throws(
+			() =>
+				loadLinterServiceConfig({
+					repositoryPath: context.repoDir,
+				}),
+			/non-negative integer/u,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("rejects lizard thresholds for languages outside the lizard language list", () => {
+	const context = makeTempRepo();
+
+	writeLinterServiceConfig(context.repoDir, {
+		linters: {
+			lizard: {
+				disabled: false,
+				languages: ["javascript"],
+				thresholds: {
+					python: {
+						parameter_count: 4,
+					},
+				},
+			},
+		},
+	});
+
+	try {
+		assert.throws(
+			() =>
+				loadLinterServiceConfig({
+					repositoryPath: context.repoDir,
+				}),
+			/languages must include every language configured in .*thresholds/u,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("maps lizard thresholds to CLI arguments", () => {
+	assert.deepEqual(
+		buildThresholdArguments({
+			nloc: 12,
+			cyclomatic_complexity: 8,
+			token_count: 120,
+			parameter_count: 5,
+			length: 30,
+		}),
+		[
+			"-T",
+			"nloc=12",
+			"-C",
+			"8",
+			"-T",
+			"token_count=120",
+			"-a",
+			"5",
+			"-L",
+			"30",
+		],
+	);
+});
+
+test("normalizes lizard warning output for default and custom thresholds", () => {
+	assert.equal(
+		normalizeLizardOutput(
+			"./src/app.js:1: warning: complex has 17 NLOC, 16 CCN, 120 token, 1 PARAM, 18 length, 0 ND",
+		),
+		"src/app.js:1: complex exceeds the CCN limit with 16 CCN",
+	);
+	assert.equal(
+		normalizeLizardOutput(
+			"./src/tool.py:1: warning: configure_python has 2 NLOC, 1 CCN, 24 token, 5 PARAM, 3 length, 0 ND",
+			{ usesCustomThresholds: true },
+		),
+		"src/tool.py:1: configure_python exceeds configured lizard thresholds with 2 NLOC, 1 CCN, 24 token, 5 PARAM, 3 length, 0 ND",
+	);
+	assert.equal(
+		normalizeLizardOutput(
+			"./src/tool.py:1: warning: configure_python has 2 NLOC, 24 token, 5 PARAM, 3 length, 0 ND",
+		),
+		"src/tool.py:1: warning: configure_python has 2 NLOC, 24 token, 5 PARAM, 3 length, 0 ND",
+	);
 });
 
 test("supports textlint preset_packages when textlint is enabled", () => {

--- a/.github/scripts/validate-linter-service-config.test.js
+++ b/.github/scripts/validate-linter-service-config.test.js
@@ -220,6 +220,186 @@ test("rejects unsupported lizard languages", () => {
 	}
 });
 
+test("accepts per-language lizard thresholds", () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "linter-service-schema-"),
+	);
+	const configPath = path.join(tempDir, "linter-service.yaml");
+
+	writeConfig(configPath, {
+		linters: {
+			lizard: {
+				disabled: false,
+				languages: ["javascript", "python"],
+				thresholds: {
+					javascript: {
+						parameter_count: 6,
+						length: 30,
+					},
+					python: {
+						nloc: 10,
+					},
+				},
+			},
+		},
+	});
+
+	try {
+		const report = validateLinterServiceConfig({
+			configPath,
+			schemaPath: rootSchemaPath,
+		});
+
+		assert.deepEqual(report.normalizedConfig.linters.lizard.thresholds, {
+			javascript: {
+				parameter_count: 6,
+				length: 30,
+			},
+			python: {
+				nloc: 10,
+			},
+		});
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("rejects unsupported lizard threshold languages", () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "linter-service-schema-"),
+	);
+	const configPath = path.join(tempDir, "linter-service.yaml");
+
+	writeConfig(configPath, {
+		linters: {
+			lizard: {
+				disabled: false,
+				languages: ["javascript"],
+				thresholds: {
+					brainfuck: {
+						parameter_count: 4,
+					},
+				},
+			},
+		},
+	});
+
+	try {
+		assert.throws(
+			() =>
+				validateLinterServiceConfig({
+					configPath,
+					schemaPath: rootSchemaPath,
+				}),
+			/allowed values|must be one of/u,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("rejects unsupported lizard threshold metrics", () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "linter-service-schema-"),
+	);
+	const configPath = path.join(tempDir, "linter-service.yaml");
+
+	writeConfig(configPath, {
+		linters: {
+			lizard: {
+				disabled: false,
+				languages: ["javascript"],
+				thresholds: {
+					javascript: {
+						foo: 1,
+					},
+				},
+			},
+		},
+	});
+
+	try {
+		assert.throws(
+			() =>
+				validateLinterServiceConfig({
+					configPath,
+					schemaPath: rootSchemaPath,
+				}),
+			/unexpected property|additional properties/u,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("rejects lizard thresholds for languages outside linters.lizard.languages", () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "linter-service-schema-"),
+	);
+	const configPath = path.join(tempDir, "linter-service.yaml");
+
+	writeConfig(configPath, {
+		linters: {
+			lizard: {
+				disabled: false,
+				languages: ["javascript"],
+				thresholds: {
+					python: {
+						parameter_count: 4,
+					},
+				},
+			},
+		},
+	});
+
+	try {
+		assert.throws(
+			() =>
+				validateLinterServiceConfig({
+					configPath,
+					schemaPath: rootSchemaPath,
+				}),
+			/languages must include every language configured in .*thresholds/u,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("rejects negative lizard threshold values", () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "linter-service-schema-"),
+	);
+	const configPath = path.join(tempDir, "linter-service.yaml");
+
+	writeConfig(configPath, {
+		linters: {
+			lizard: {
+				disabled: false,
+				languages: ["javascript"],
+				thresholds: {
+					javascript: {
+						parameter_count: -1,
+					},
+				},
+			},
+		},
+	});
+
+	try {
+		assert.throws(
+			() =>
+				validateLinterServiceConfig({
+					configPath,
+					schemaPath: rootSchemaPath,
+				}),
+			/must be >= 0|minimum/u,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
 test("rejects explicitly enabled textlint without preset_packages", () => {
 	const tempDir = fs.mkdtempSync(
 		path.join(os.tmpdir(), "linter-service-schema-"),

--- a/lizard/language-config.js
+++ b/lizard/language-config.js
@@ -33,6 +33,13 @@ const LANGUAGE_PATTERNS = Object.freeze({
 });
 
 const SUPPORTED_LANGUAGES = Object.freeze(Object.keys(LANGUAGE_PATTERNS));
+const SUPPORTED_THRESHOLD_KEYS = Object.freeze([
+	"nloc",
+	"cyclomatic_complexity",
+	"token_count",
+	"parameter_count",
+	"length",
+]);
 
 function normalizeLanguages({ label, languages }) {
 	if (languages === undefined) {
@@ -76,6 +83,72 @@ function normalizeLanguage(value, label) {
 	return value;
 }
 
+function normalizeThresholds({ label, thresholds }) {
+	if (thresholds === undefined) {
+		return {};
+	}
+
+	if (
+		!thresholds ||
+		typeof thresholds !== "object" ||
+		Array.isArray(thresholds)
+	) {
+		throw new Error(`${label} must be an object`);
+	}
+
+	const entries = Object.entries(thresholds);
+	if (entries.length === 0) {
+		throw new Error(`${label} must not be empty`);
+	}
+
+	return Object.fromEntries(
+		entries.map(([language, value]) => [
+			normalizeLanguage(language, `${label}.${language}`),
+			normalizeThresholdConfig({
+				label: `${label}.${language}`,
+				thresholdConfig: value,
+			}),
+		]),
+	);
+}
+
+function normalizeThresholdConfig({ label, thresholdConfig }) {
+	if (
+		!thresholdConfig ||
+		typeof thresholdConfig !== "object" ||
+		Array.isArray(thresholdConfig)
+	) {
+		throw new Error(`${label} must be an object`);
+	}
+
+	const entries = Object.entries(thresholdConfig);
+	if (entries.length === 0) {
+		throw new Error(`${label} must define at least one threshold`);
+	}
+
+	const normalized = {};
+
+	for (const [metric, value] of entries) {
+		if (!SUPPORTED_THRESHOLD_KEYS.includes(metric)) {
+			throw new Error(
+				`${label}.${metric} must be one of: ${SUPPORTED_THRESHOLD_KEYS.join(", ")}`,
+			);
+		}
+
+		normalized[metric] = normalizeThresholdValue(value, `${label}.${metric}`);
+	}
+
+	return normalized;
+}
+
+function normalizeThresholdValue(value, label) {
+	if (!Number.isInteger(value) || value < 0) {
+		throw new Error(`${label} must be a non-negative integer`);
+	}
+
+	return value;
+}
+
 function filterFilesByLanguages(filePaths, languages) {
 	const normalizedLanguages = Array.isArray(languages) ? languages : [];
 	const compiledPatterns = normalizedLanguages.flatMap((language) =>
@@ -94,6 +167,22 @@ function filterFilesByLanguages(filePaths, languages) {
 	});
 }
 
+function detectLanguage(filePath, languages = SUPPORTED_LANGUAGES) {
+	const normalizedPath = normalizePath(filePath);
+	const candidateLanguages =
+		Array.isArray(languages) && languages.length > 0
+			? languages
+			: SUPPORTED_LANGUAGES;
+
+	for (const language of candidateLanguages) {
+		if (matchesLanguage(normalizedPath, language)) {
+			return language;
+		}
+	}
+
+	return null;
+}
+
 function getAllPatternStrings() {
 	return [...new Set(Object.values(LANGUAGE_PATTERNS).flat())];
 }
@@ -108,6 +197,14 @@ function getPatternStringsForLanguage(language) {
 	return patterns;
 }
 
+function matchesLanguage(filePath, language) {
+	const normalizedPath = normalizePath(filePath);
+
+	return getPatternStringsForLanguage(language).some((patternString) =>
+		new RegExp(patternString, "iu").test(normalizedPath),
+	);
+}
+
 function isConfigTriggerPath(filePath) {
 	const normalizedPath = normalizePath(filePath);
 	return CONFIG_TRIGGER_PATTERNS.some((pattern) =>
@@ -120,9 +217,12 @@ function normalizePath(filePath) {
 }
 
 module.exports = {
+	detectLanguage,
 	filterFilesByLanguages,
 	getAllPatternStrings,
 	isConfigTriggerPath,
 	normalizeLanguages,
+	normalizeThresholds,
 	SUPPORTED_LANGUAGES,
+	SUPPORTED_THRESHOLD_KEYS,
 };

--- a/lizard/linter-service-config.js
+++ b/lizard/linter-service-config.js
@@ -1,18 +1,36 @@
-const { normalizeLanguages } = require("./language-config.js");
+const {
+	normalizeLanguages,
+	normalizeThresholds,
+} = require("./language-config.js");
 
 function normalizeConfig({ currentConfig, entry, label }) {
 	const languages = normalizeLanguages({
 		label: `${label}.languages`,
 		languages: currentConfig.languages,
 	});
+	const thresholds = normalizeThresholds({
+		label: `${label}.thresholds`,
+		thresholds: currentConfig.thresholds,
+	});
 
 	if (currentConfig.disabled === false && languages.length === 0) {
 		throw new Error(`${label}.languages is required when lizard is enabled`);
 	}
 
+	const missingThresholdLanguages = Object.keys(thresholds).filter(
+		(language) => !languages.includes(language),
+	);
+
+	if (missingThresholdLanguages.length > 0) {
+		throw new Error(
+			`${label}.languages must include every language configured in ${label}.thresholds: ${missingThresholdLanguages.join(", ")}`,
+		);
+	}
+
 	return {
 		...entry,
 		languages,
+		thresholds,
 	};
 }
 

--- a/lizard/run-lizard.js
+++ b/lizard/run-lizard.js
@@ -1,0 +1,297 @@
+const { spawnSync } = require("node:child_process");
+
+const {
+	getLinterConfig,
+	loadLinterServiceConfig,
+	normalizeRelativePath,
+} = require("../.github/scripts/linter-service-config.js");
+const { detectLanguage, SUPPORTED_LANGUAGES } = require("./language-config.js");
+
+const THRESHOLD_KEYS = Object.freeze([
+	"nloc",
+	"cyclomatic_complexity",
+	"token_count",
+	"parameter_count",
+	"length",
+]);
+const WARNING_PATTERN =
+	/^(?<path>.+?):(?<line>\d+): warning: (?<function>.+?) has (?<metrics>.+)$/u;
+
+function runFromCli(argv = process.argv.slice(2), env = process.env) {
+	const repositoryPath = resolveRepositoryPath(env);
+	const result = runConfiguredLizard({
+		env,
+		filePaths: argv,
+		repositoryPath,
+	});
+
+	if (result.details.length > 0) {
+		process.stdout.write(`${result.details}\n`);
+	}
+
+	process.exitCode = result.exitCode;
+	return result;
+}
+
+function resolveRepositoryPath(env = process.env) {
+	if (
+		typeof env.SOURCE_REPOSITORY_PATH === "string" &&
+		env.SOURCE_REPOSITORY_PATH.length > 0
+	) {
+		return env.SOURCE_REPOSITORY_PATH;
+	}
+
+	return process.cwd();
+}
+
+function runConfiguredLizard({
+	env = process.env,
+	filePaths,
+	repositoryPath = resolveRepositoryPath(env),
+	serviceConfig,
+	spawnSyncImpl = spawnSync,
+}) {
+	const normalizedFilePaths = Array.isArray(filePaths)
+		? filePaths.map((filePath) => normalizeRelativePath(filePath))
+		: [];
+
+	if (normalizedFilePaths.length === 0) {
+		return {
+			details: "",
+			exitCode: 0,
+		};
+	}
+
+	const loadedConfig =
+		serviceConfig || loadLinterServiceConfig({ repositoryPath });
+	const lizardConfig = getLinterConfig(loadedConfig, "lizard");
+	const runPlan = buildLanguageRunPlan({
+		configuredLanguages: lizardConfig.languages,
+		filePaths: normalizedFilePaths,
+		thresholdsByLanguage: lizardConfig.thresholds || {},
+	});
+	const details = [];
+	let exitCode = 0;
+
+	for (const currentPlan of runPlan) {
+		const result = runLizardGroup({
+			env,
+			filePaths: currentPlan.filePaths,
+			repositoryPath,
+			spawnSyncImpl,
+			thresholds: currentPlan.thresholds,
+		});
+		const normalizedOutput = normalizeLizardOutput(result.output, {
+			usesCustomThresholds: Object.keys(currentPlan.thresholds).length > 0,
+		});
+
+		if (normalizedOutput.length > 0) {
+			details.push(normalizedOutput);
+		}
+
+		exitCode = Math.max(exitCode, result.exitCode);
+	}
+
+	return {
+		details: details.join("\n"),
+		exitCode,
+	};
+}
+
+function buildLanguageRunPlan({
+	configuredLanguages,
+	filePaths,
+	thresholdsByLanguage = {},
+}) {
+	const candidateLanguages =
+		Array.isArray(configuredLanguages) && configuredLanguages.length > 0
+			? configuredLanguages
+			: SUPPORTED_LANGUAGES;
+	const groupedFiles = new Map(
+		candidateLanguages.map((language) => [language, []]),
+	);
+	const fallbackFiles = [];
+
+	for (const filePath of Array.isArray(filePaths) ? filePaths : []) {
+		const normalizedPath = normalizeRelativePath(filePath);
+		const language = detectLanguage(normalizedPath, candidateLanguages);
+
+		if (!language) {
+			fallbackFiles.push(normalizedPath);
+			continue;
+		}
+
+		groupedFiles.get(language).push(normalizedPath);
+	}
+
+	const runPlan = [];
+
+	for (const language of candidateLanguages) {
+		const languageFiles = groupedFiles.get(language);
+
+		if (!Array.isArray(languageFiles) || languageFiles.length === 0) {
+			continue;
+		}
+
+		runPlan.push({
+			filePaths: languageFiles,
+			language,
+			thresholds: thresholdsByLanguage[language] || {},
+		});
+	}
+
+	if (fallbackFiles.length > 0) {
+		runPlan.push({
+			filePaths: fallbackFiles,
+			language: null,
+			thresholds: {},
+		});
+	}
+
+	return runPlan;
+}
+
+function buildThresholdArguments(thresholds = {}) {
+	if (!thresholds || typeof thresholds !== "object") {
+		return [];
+	}
+
+	const argumentsList = [];
+
+	for (const thresholdKey of THRESHOLD_KEYS) {
+		if (!Number.isInteger(thresholds[thresholdKey])) {
+			continue;
+		}
+
+		switch (thresholdKey) {
+			case "nloc":
+				argumentsList.push("-T", `nloc=${thresholds[thresholdKey]}`);
+				break;
+			case "cyclomatic_complexity":
+				argumentsList.push("-C", String(thresholds[thresholdKey]));
+				break;
+			case "token_count":
+				argumentsList.push("-T", `token_count=${thresholds[thresholdKey]}`);
+				break;
+			case "parameter_count":
+				argumentsList.push("-a", String(thresholds[thresholdKey]));
+				break;
+			case "length":
+				argumentsList.push("-L", String(thresholds[thresholdKey]));
+				break;
+			default:
+				break;
+		}
+	}
+
+	return argumentsList;
+}
+
+function runLizardGroup({
+	env = process.env,
+	filePaths,
+	repositoryPath,
+	spawnSyncImpl = spawnSync,
+	thresholds = {},
+}) {
+	if (!Array.isArray(filePaths) || filePaths.length === 0) {
+		return {
+			exitCode: 0,
+			output: "",
+		};
+	}
+
+	const result = spawnSyncImpl(
+		"lizard",
+		["-w", ...buildThresholdArguments(thresholds), ...filePaths],
+		{
+			cwd: repositoryPath,
+			encoding: "utf8",
+			env,
+		},
+	);
+
+	if (result.error) {
+		throw result.error;
+	}
+
+	if (!Number.isInteger(result.status)) {
+		throw new Error("lizard did not produce an exit status");
+	}
+
+	const output = [result.stdout, result.stderr]
+		.filter((entry) => typeof entry === "string" && entry.length > 0)
+		.join("\n")
+		.trim();
+
+	if (result.status > 1) {
+		throw new Error(
+			output.length > 0 ? output : `lizard exited with status ${result.status}`,
+		);
+	}
+
+	return {
+		exitCode: result.status,
+		output,
+	};
+}
+
+function normalizeLizardOutput(output, { usesCustomThresholds = false } = {}) {
+	return String(output)
+		.split(/\r?\n/u)
+		.map((line) => normalizeLizardWarning(line, { usesCustomThresholds }))
+		.filter(Boolean)
+		.join("\n");
+}
+
+function normalizeLizardWarning(line, { usesCustomThresholds = false } = {}) {
+	const trimmed = String(line).trim();
+
+	if (trimmed.length === 0) {
+		return "";
+	}
+
+	const match = WARNING_PATTERN.exec(trimmed);
+
+	if (!match?.groups) {
+		return trimmed;
+	}
+
+	const filePath = normalizeRelativePath(match.groups.path);
+
+	if (usesCustomThresholds) {
+		return `${filePath}:${match.groups.line}: ${match.groups.function} exceeds configured lizard thresholds with ${match.groups.metrics}`;
+	}
+
+	const ccnMatch = /\b(?<ccn>\d+) CCN\b/u.exec(match.groups.metrics);
+	if (!ccnMatch?.groups) {
+		return `${filePath}:${match.groups.line}: warning: ${match.groups.function} has ${match.groups.metrics}`;
+	}
+
+	return `${filePath}:${match.groups.line}: ${match.groups.function} exceeds the CCN limit with ${ccnMatch.groups.ccn} CCN`;
+}
+
+if (require.main === module) {
+	try {
+		runFromCli(process.argv.slice(2), process.env);
+	} catch (error) {
+		const message =
+			error instanceof Error && error.message.length > 0
+				? error.message
+				: String(error);
+
+		if (message.length > 0) {
+			process.stderr.write(`${message}\n`);
+		}
+
+		process.exitCode = 2;
+	}
+}
+
+module.exports = {
+	buildLanguageRunPlan,
+	buildThresholdArguments,
+	normalizeLizardOutput,
+	runConfiguredLizard,
+	runFromCli,
+};

--- a/lizard/run.sh
+++ b/lizard/run.sh
@@ -10,31 +10,7 @@ source "$script_dir/common.sh"
 output_file="$RUNNER_TEMP/linter-output.txt"
 
 run_lizard() {
-  # shellcheck disable=SC2016
-  lizard -w "$@" | node -e '
-const fs = require("node:fs");
-
-const source = fs.readFileSync(0, "utf8");
-const normalized = source
-  .split(/\r?\n/u)
-  .map((line) => line.trim())
-  .filter(Boolean)
-  .map((line) => {
-    const match =
-      /^(?<path>.+?):(?<line>\d+): warning: (?<function>.+?) has .*?(?<ccn>\d+) CCN\b/u.exec(
-        line,
-      );
-
-    if (!match?.groups) {
-      return line;
-    }
-
-    const filePath = match.groups.path.replace(/^\.\//u, "");
-    return `${filePath}:${match.groups.line}: ${match.groups.function} exceeds the CCN limit with ${match.groups.ccn} CCN`;
-  });
-
-process.stdout.write(normalized.join("\n"));
-'
+  node "$script_dir/run-lizard.js" "$@"
 }
 
 linter_lib::run_and_emit_json "$output_file" run_lizard "$@"

--- a/lizard/tests/language-thresholds/result.json
+++ b/lizard/tests/language-thresholds/result.json
@@ -1,0 +1,11 @@
+{
+  "checked_projects": [],
+  "result": {
+    "details": "src/tool.py:1: configure_python exceeds configured lizard thresholds with 2 NLOC, 1 CCN, 30 token, 5 PARAM, 2 length, 0 ND",
+    "exit_code": 1
+  },
+  "selected_files": [
+    "src/app.js",
+    "src/tool.py"
+  ]
+}

--- a/lizard/tests/language-thresholds/sarif.json
+++ b/lizard/tests/language-thresholds/sarif.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "runs": [
+    {
+      "automationDetails": {
+        "id": "linter-service/lizard"
+      },
+      "results": [
+        {
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/tool.py"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "configure_python exceeds configured lizard thresholds with 2 NLOC, 1 CCN, 30 token, 5 PARAM, 2 length, 0 ND"
+          },
+          "properties": {
+            "linter_name": "lizard"
+          },
+          "ruleId": "lizard/diagnostic"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/chalharu/linter-service",
+          "name": "linter-service/lizard",
+          "rules": [
+            {
+              "id": "lizard/diagnostic",
+              "name": "lizard/diagnostic",
+              "shortDescription": {
+                "text": "lizard/diagnostic"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/lizard/tests/language-thresholds/target/.github/linter-service.yaml
+++ b/lizard/tests/language-thresholds/target/.github/linter-service.yaml
@@ -1,0 +1,11 @@
+linters:
+  lizard:
+    disabled: false
+    languages:
+      - javascript
+      - python
+    thresholds:
+      javascript:
+        parameter_count: 6
+      python:
+        parameter_count: 4

--- a/lizard/tests/language-thresholds/target/src/app.js
+++ b/lizard/tests/language-thresholds/target/src/app.js
@@ -1,0 +1,3 @@
+function configureJavascript(a, b, c, d, e) {
+	return [a, b, c, d, e].join(",");
+}

--- a/lizard/tests/language-thresholds/target/src/tool.py
+++ b/lizard/tests/language-thresholds/target/src/tool.py
@@ -1,0 +1,2 @@
+def configure_python(a, b, c, d, e):
+    return ",".join([a, b, c, d, e])


### PR DESCRIPTION
## Summary
- add per-language lizard thresholds for nloc, cyclomatic_complexity, token_count, parameter_count, and length
- run lizard per language so configured thresholds apply to the matching files while preserving existing default behavior
- add schema/config regression tests and a mixed-language fixture that proves different languages can use different thresholds

## Testing
- node --test .github/scripts/aggregate-sarif.test.js .github/scripts/prune-renovate-cache-images.test.js .github/scripts/validate-linters-config.test.js .github/scripts/validate-linter-service-config.test.js .github/scripts/linter-service-config.test.js .github/scripts/linter-targeting.test.js .github/scripts/select-lint-targets.test.js .github/scripts/installer-version-pins.test.js .github/scripts/upload-sarif.test.js
- node .github/scripts/run-fixture-tests.js lizard

## Notes
- /workspace/worker npm ci hangs in this environment, so worker npm run check could not be completed locally