### PR TITLE
test(lizard): add metric threshold coverage

### DIFF
--- a/.github/scripts/linter-service-config.test.js
+++ b/.github/scripts/linter-service-config.test.js
@@ -15,6 +15,7 @@ const {
 const {
 	buildThresholdArguments,
 	normalizeLizardOutput,
+	runConfiguredLizard,
 } = require("../../lizard/run-lizard.js");
 
 function makeTempRepo() {
@@ -519,6 +520,91 @@ test("maps lizard thresholds to CLI arguments", () => {
 			"-L",
 			"30",
 		],
+	);
+});
+
+test("runConfiguredLizard applies metric-specific thresholds per language group", () => {
+	const calls = [];
+	const result = runConfiguredLizard({
+		filePaths: ["src/app.js", "src/tool.py"],
+		repositoryPath: "/tmp/lizard-metric-thresholds",
+		serviceConfig: {
+			global: {
+				exclude_paths: [],
+			},
+			linters: {
+				lizard: {
+					disabled: false,
+					disabled_explicit: true,
+					exclude_paths: [],
+					languages: ["javascript", "python"],
+					thresholds: {
+						javascript: {
+							token_count: 20,
+							length: 7,
+						},
+						python: {
+							nloc: 3,
+							cyclomatic_complexity: 2,
+							parameter_count: 1,
+						},
+					},
+				},
+			},
+		},
+		spawnSyncImpl: (command, args, options) => {
+			calls.push({
+				args,
+				command,
+				cwd: options.cwd,
+			});
+
+			const hasJavascript = args.includes("src/app.js");
+			const hasPython = args.includes("src/tool.py");
+
+			if (hasJavascript === hasPython) {
+				throw new Error(
+					`unexpected mock invocation arguments: ${JSON.stringify(args)}`,
+				);
+			}
+
+			if (hasJavascript) {
+				return {
+					status: 1,
+					stderr: "",
+					stdout:
+						"src/app.js:1: warning: renderNames has 8 NLOC, 2 CCN, 35 token, 1 PARAM, 9 length, 0 ND",
+				};
+			}
+
+			return {
+				status: 1,
+				stderr: "",
+				stdout:
+					"src/tool.py:1: warning: describe_value has 5 NLOC, 3 CCN, 19 token, 2 PARAM, 6 length, 0 ND",
+			};
+		},
+	});
+
+	assert.deepEqual(calls, [
+		{
+			args: ["-w", "-T", "token_count=20", "-L", "7", "src/app.js"],
+			command: "lizard",
+			cwd: "/tmp/lizard-metric-thresholds",
+		},
+		{
+			args: ["-w", "-T", "nloc=3", "-C", "2", "-a", "1", "src/tool.py"],
+			command: "lizard",
+			cwd: "/tmp/lizard-metric-thresholds",
+		},
+	]);
+	assert.equal(result.exitCode, 1);
+	assert.equal(
+		result.details,
+		[
+			"src/app.js:1: renderNames exceeds configured lizard thresholds with 8 NLOC, 2 CCN, 35 token, 1 PARAM, 9 length, 0 ND",
+			"src/tool.py:1: describe_value exceeds configured lizard thresholds with 5 NLOC, 3 CCN, 19 token, 2 PARAM, 6 length, 0 ND",
+		].join("\n"),
 	);
 });
 

--- a/lizard/tests/cyclomatic-complexity-thresholds/result.json
+++ b/lizard/tests/cyclomatic-complexity-thresholds/result.json
@@ -1,0 +1,11 @@
+{
+  "checked_projects": [],
+  "result": {
+    "details": "src/app.js:1: isReady exceeds configured lizard thresholds with 11 NLOC, 4 CCN, 38 token, 1 PARAM, 11 length, 0 ND",
+    "exit_code": 1
+  },
+  "selected_files": [
+    "src/app.js",
+    "src/tool.py"
+  ]
+}

--- a/lizard/tests/cyclomatic-complexity-thresholds/sarif.json
+++ b/lizard/tests/cyclomatic-complexity-thresholds/sarif.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "runs": [
+    {
+      "automationDetails": {
+        "id": "linter-service/lizard"
+      },
+      "results": [
+        {
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/app.js"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "isReady exceeds configured lizard thresholds with 11 NLOC, 4 CCN, 38 token, 1 PARAM, 11 length, 0 ND"
+          },
+          "properties": {
+            "linter_name": "lizard"
+          },
+          "ruleId": "lizard/diagnostic"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/chalharu/linter-service",
+          "name": "linter-service/lizard",
+          "rules": [
+            {
+              "id": "lizard/diagnostic",
+              "name": "lizard/diagnostic",
+              "shortDescription": {
+                "text": "lizard/diagnostic"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/lizard/tests/cyclomatic-complexity-thresholds/target/.github/linter-service.yaml
+++ b/lizard/tests/cyclomatic-complexity-thresholds/target/.github/linter-service.yaml
@@ -1,0 +1,11 @@
+linters:
+  lizard:
+    disabled: false
+    languages:
+      - javascript
+      - python
+    thresholds:
+      javascript:
+        cyclomatic_complexity: 2
+      python:
+        cyclomatic_complexity: 4

--- a/lizard/tests/cyclomatic-complexity-thresholds/target/src/app.js
+++ b/lizard/tests/cyclomatic-complexity-thresholds/target/src/app.js
@@ -1,0 +1,11 @@
+function isReady(flags) {
+	if (flags.a) {
+		if (flags.b) {
+			return true;
+		}
+	}
+	if (flags.c) {
+		return true;
+	}
+	return false;
+}

--- a/lizard/tests/cyclomatic-complexity-thresholds/target/src/tool.py
+++ b/lizard/tests/cyclomatic-complexity-thresholds/target/src/tool.py
@@ -1,0 +1,4 @@
+def is_ready(flag):
+    if flag:
+        return True
+    return False

--- a/lizard/tests/length-thresholds/result.json
+++ b/lizard/tests/length-thresholds/result.json
@@ -1,0 +1,11 @@
+{
+  "checked_projects": [],
+  "result": {
+    "details": "src/app.js:1: renderNames exceeds configured lizard thresholds with 10 NLOC, 3 CCN, 58 token, 1 PARAM, 10 length, 0 ND",
+    "exit_code": 1
+  },
+  "selected_files": [
+    "src/app.js",
+    "src/tool.py"
+  ]
+}

--- a/lizard/tests/length-thresholds/sarif.json
+++ b/lizard/tests/length-thresholds/sarif.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "runs": [
+    {
+      "automationDetails": {
+        "id": "linter-service/lizard"
+      },
+      "results": [
+        {
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/app.js"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "renderNames exceeds configured lizard thresholds with 10 NLOC, 3 CCN, 58 token, 1 PARAM, 10 length, 0 ND"
+          },
+          "properties": {
+            "linter_name": "lizard"
+          },
+          "ruleId": "lizard/diagnostic"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/chalharu/linter-service",
+          "name": "linter-service/lizard",
+          "rules": [
+            {
+              "id": "lizard/diagnostic",
+              "name": "lizard/diagnostic",
+              "shortDescription": {
+                "text": "lizard/diagnostic"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/lizard/tests/length-thresholds/target/.github/linter-service.yaml
+++ b/lizard/tests/length-thresholds/target/.github/linter-service.yaml
@@ -1,0 +1,11 @@
+linters:
+  lizard:
+    disabled: false
+    languages:
+      - javascript
+      - python
+    thresholds:
+      javascript:
+        length: 7
+      python:
+        length: 10

--- a/lizard/tests/length-thresholds/target/src/app.js
+++ b/lizard/tests/length-thresholds/target/src/app.js
@@ -1,0 +1,10 @@
+function renderNames(names) {
+	const rendered = [];
+	for (const name of names) {
+		const normalized = name.trim();
+		if (normalized.length > 0) {
+			rendered.push(normalized.toUpperCase());
+		}
+	}
+	return rendered.join(", ");
+}

--- a/lizard/tests/length-thresholds/target/src/tool.py
+++ b/lizard/tests/length-thresholds/target/src/tool.py
@@ -1,0 +1,2 @@
+def identity(value):
+    return value

--- a/lizard/tests/nloc-thresholds/result.json
+++ b/lizard/tests/nloc-thresholds/result.json
@@ -1,0 +1,11 @@
+{
+  "checked_projects": [],
+  "result": {
+    "details": "src/tool.py:1: describe_value exceeds configured lizard thresholds with 6 NLOC, 3 CCN, 22 token, 1 PARAM, 6 length, 0 ND",
+    "exit_code": 1
+  },
+  "selected_files": [
+    "src/app.js",
+    "src/tool.py"
+  ]
+}

--- a/lizard/tests/nloc-thresholds/sarif.json
+++ b/lizard/tests/nloc-thresholds/sarif.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "runs": [
+    {
+      "automationDetails": {
+        "id": "linter-service/lizard"
+      },
+      "results": [
+        {
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/tool.py"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "describe_value exceeds configured lizard thresholds with 6 NLOC, 3 CCN, 22 token, 1 PARAM, 6 length, 0 ND"
+          },
+          "properties": {
+            "linter_name": "lizard"
+          },
+          "ruleId": "lizard/diagnostic"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/chalharu/linter-service",
+          "name": "linter-service/lizard",
+          "rules": [
+            {
+              "id": "lizard/diagnostic",
+              "name": "lizard/diagnostic",
+              "shortDescription": {
+                "text": "lizard/diagnostic"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/lizard/tests/nloc-thresholds/target/.github/linter-service.yaml
+++ b/lizard/tests/nloc-thresholds/target/.github/linter-service.yaml
@@ -1,0 +1,11 @@
+linters:
+  lizard:
+    disabled: false
+    languages:
+      - javascript
+      - python
+    thresholds:
+      javascript:
+        nloc: 4
+      python:
+        nloc: 3

--- a/lizard/tests/nloc-thresholds/target/src/app.js
+++ b/lizard/tests/nloc-thresholds/target/src/app.js
@@ -1,0 +1,3 @@
+function identity(value) {
+	return value;
+}

--- a/lizard/tests/nloc-thresholds/target/src/tool.py
+++ b/lizard/tests/nloc-thresholds/target/src/tool.py
@@ -1,0 +1,6 @@
+def describe_value(value):
+    if value is None:
+        return "none"
+    if value == 0:
+        return "zero"
+    return f"value={value}"

--- a/lizard/tests/token-count-thresholds/result.json
+++ b/lizard/tests/token-count-thresholds/result.json
@@ -1,0 +1,11 @@
+{
+  "checked_projects": [],
+  "result": {
+    "details": "src/app.js:1: formatOrder exceeds configured lizard thresholds with 6 NLOC, 2 CCN, 65 token, 4 PARAM, 6 length, 0 ND",
+    "exit_code": 1
+  },
+  "selected_files": [
+    "src/app.js",
+    "src/tool.py"
+  ]
+}

--- a/lizard/tests/token-count-thresholds/sarif.json
+++ b/lizard/tests/token-count-thresholds/sarif.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "runs": [
+    {
+      "automationDetails": {
+        "id": "linter-service/lizard"
+      },
+      "results": [
+        {
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/app.js"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "formatOrder exceeds configured lizard thresholds with 6 NLOC, 2 CCN, 65 token, 4 PARAM, 6 length, 0 ND"
+          },
+          "properties": {
+            "linter_name": "lizard"
+          },
+          "ruleId": "lizard/diagnostic"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/chalharu/linter-service",
+          "name": "linter-service/lizard",
+          "rules": [
+            {
+              "id": "lizard/diagnostic",
+              "name": "lizard/diagnostic",
+              "shortDescription": {
+                "text": "lizard/diagnostic"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/lizard/tests/token-count-thresholds/target/.github/linter-service.yaml
+++ b/lizard/tests/token-count-thresholds/target/.github/linter-service.yaml
@@ -1,0 +1,11 @@
+linters:
+  lizard:
+    disabled: false
+    languages:
+      - javascript
+      - python
+    thresholds:
+      javascript:
+        token_count: 20
+      python:
+        token_count: 30

--- a/lizard/tests/token-count-thresholds/target/src/app.js
+++ b/lizard/tests/token-count-thresholds/target/src/app.js
@@ -1,0 +1,6 @@
+function formatOrder(customerName, orderNumber, shippingRegion, couponCode) {
+	const normalizedName = customerName.trim().toUpperCase();
+	const regionLabel = shippingRegion.toLowerCase();
+	const couponLabel = couponCode ? couponCode.toLowerCase() : "none";
+	return `${normalizedName}:${orderNumber}:${regionLabel}:${couponLabel}`;
+}

--- a/lizard/tests/token-count-thresholds/target/src/tool.py
+++ b/lizard/tests/token-count-thresholds/target/src/tool.py
@@ -1,0 +1,2 @@
+def identity(value):
+    return value

--- a/taplo/tests/fail/result.json
+++ b/taplo/tests/fail/result.json
@@ -1,7 +1,7 @@
 {
   "checked_projects": [],
   "result": {
-    "details": "INFO taplo:format_files:collect_files: found files total=1 excluded=0 files=[\"config.toml\"] cwd=\".\"\nerror: invalid TOML\n  ┌─ config.toml:3:9\n  │  \n3 │   [package\n  │ ╭────────^\n4 │ │ name = \"demo\"\n  │ ╰^ expected \"]\"\n\nERROR operation failed error=some files were not formatted due to syntax errors",
+    "details": "INFO taplo:format_files:collect_files: found files total=1 excluded=0 files=[\"config.toml\"] cwd=\".\"\nerror: invalid TOML\n  ┌─ config.toml:3:9\n  │  \n3 │   [package\n  │ ╭────────^\n4 │ │ name = \"demo\"\n  │ ╰^ expected \"]\"",
     "exit_code": 1
   },
   "selected_files": [

--- a/taplo/tests/fail/result.json
+++ b/taplo/tests/fail/result.json
@@ -1,7 +1,7 @@
 {
   "checked_projects": [],
   "result": {
-    "details": "INFO taplo:format_files:collect_files: found files total=1 excluded=0 files=[\"config.toml\"] cwd=\".\"\nerror: invalid TOML\n  ┌─ config.toml:3:9\n  │  \n3 │   [package\n  │ ╭────────^\n4 │ │ name = \"demo\"\n  │ ╰^ expected \"]\"",
+    "details": "INFO taplo:format_files:collect_files: found files total=1 excluded=0 files=[\"config.toml\"] cwd=\".\"\nerror: invalid TOML\n  ┌─ config.toml:3:9\n  │  \n3 │   [package\n  │ ╭────────^\n4 │ │ name = \"demo\"\n  │ ╰^ expected \"]\"\n\nERROR operation failed error=some files were not formatted due to syntax errors",
     "exit_code": 1
   },
   "selected_files": [


### PR DESCRIPTION
## Summary
- add a focused unit test for `runConfiguredLizard` so all threshold metrics are exercised through per-language grouping and CLI flag construction
- add lizard runtime fixtures for `nloc`, `cyclomatic_complexity`, `token_count`, and `length`
- keep the existing `parameter_count` fixture coverage and close the metric coverage gaps left after PR #102 merged
- refresh the `taplo` fail fixture expectation to match the current CI output and keep hosted validation green

## Testing
- node --test .github/scripts/aggregate-sarif.test.js .github/scripts/prune-renovate-cache-images.test.js .github/scripts/validate-linters-config.test.js .github/scripts/validate-linter-service-config.test.js .github/scripts/linter-service-config.test.js .github/scripts/linter-targeting.test.js .github/scripts/select-lint-targets.test.js .github/scripts/installer-version-pins.test.js .github/scripts/upload-sarif.test.js
- node .github/scripts/run-fixture-tests.js lizard

## Notes
- /workspace/worker npm ci hangs in this environment, so worker npm run check could not be completed locally
- local `taplo` fixture run is also environment-blocked here because `curl` is missing from the host, so the refresh was verified through hosted CI