### PR TITLE
fix(cargo-deny): respect documented duplicate warning semantics

### DIFF
--- a/.github/scripts/render-combined-report.js
+++ b/.github/scripts/render-combined-report.js
@@ -50,74 +50,39 @@ function renderCombinedReport({
 	summaryRoot,
 }) {
 	const summaries = readLinterSummaries(summaryRoot);
-	const rows = [];
-	const detailSections = [];
-	let failed = 0;
-	let warned = 0;
-
-	for (const linterName of selectedLinters) {
-		const summary = normalizeSummary(
-			summaries.get(linterName) ??
-				buildFallbackSummary({
-					decryptOutcome,
-					linterName,
-				}),
-			linterName,
-		);
-
-		if (summary.conclusion !== "success") {
-			failed += 1;
-		} else if (summary.status === "warning") {
-			warned += 1;
-		}
-
-		rows.push(summary);
-
-		const detailSection = buildDetailSection(summary);
-		if (detailSection) {
-			detailSections.push(detailSection);
-		}
-	}
-
-	const total = selectedLinters.length;
-	const overallConclusion =
-		failed === 0 && decryptOutcome !== "failure" ? "success" : "failure";
-	const overallStatus =
-		decryptOutcome === "failure" || failed > 0
-			? "failure"
-			: warned > 0
-				? "warning"
-				: "success";
-	let overallSummary;
-
-	if (decryptOutcome === "failure") {
-		overallSummary =
-			"One or more encrypted linter summaries could not be read. See the workflow logs.";
-	} else if (failed === 0 && warned === 0) {
-		overallSummary = `All ${total} selected linter(s) completed successfully.`;
-	} else if (failed === 0) {
-		overallSummary = `All ${total} selected linter(s) completed successfully; ${warned} reported warnings.`;
-	} else if (warned === 0) {
-		overallSummary = `${failed} of ${total} selected linter(s) reported issues or failed.`;
-	} else {
-		overallSummary = `${failed} of ${total} selected linter(s) reported issues or failed; ${warned} additional linter(s) reported warnings.`;
-	}
-
-	const commentLines = [
-		COMMENT_MARKER,
-		"## linter-service",
-		"",
+	const { detailSections, failedCount, rows, warningCount } = collectRows({
+		decryptOutcome,
+		selectedLinters,
+		summaries,
+	});
+	const totalCount = selectedLinters.length;
+	const overallConclusion = determineOverallConclusion({
+		decryptOutcome,
+		failedCount,
+	});
+	const overallStatus = determineOverallStatus({
+		decryptOutcome,
+		failedCount,
+		warningCount,
+	});
+	const overallSummary = buildOverallSummary({
+		decryptOutcome,
+		failedCount,
+		totalCount,
+		warningCount,
+	});
+	const commentLines = buildReportLines({
+		detailSections,
+		includeMarker: true,
 		overallSummary,
-		"",
-	];
-	const checkRunLines = ["## linter-service", "", overallSummary, ""];
-
-	appendSummaryTable(commentLines, rows);
-	appendSummaryTable(checkRunLines, rows);
-	appendTargetDetails(commentLines, rows);
-	appendTargetDetails(checkRunLines, rows);
-	appendDetailSections(commentLines, detailSections);
-	appendDetailSections(checkRunLines, detailSections);
+		rows,
+	});
+	const checkRunLines = buildReportLines({
+		detailSections,
+		includeMarker: false,
+		overallSummary,
+		rows,
+	});
 
 	return {
 		checkRunText: `${checkRunLines.join("\n")}\n`,
@@ -126,6 +91,108 @@ function renderCombinedReport({
 		overallStatus,
 		overallSummary,
 	};
+}
+
+function collectRows({ decryptOutcome, selectedLinters, summaries }) {
+	const rows = [];
+	const detailSections = [];
+	let failedCount = 0;
+	let warningCount = 0;
+
+	for (const linterName of selectedLinters) {
+		const row = readSummaryRow({
+			decryptOutcome,
+			linterName,
+			summaries,
+		});
+		rows.push(row);
+
+		if (row.conclusion !== "success") {
+			failedCount += 1;
+		} else if (row.status === "warning") {
+			warningCount += 1;
+		}
+
+		const detailSection = buildDetailSection(row);
+		if (detailSection) {
+			detailSections.push(detailSection);
+		}
+	}
+
+	return {
+		detailSections,
+		failedCount,
+		rows,
+		warningCount,
+	};
+}
+
+function readSummaryRow({ decryptOutcome, linterName, summaries }) {
+	return normalizeSummary(
+		summaries.get(linterName) ??
+			buildFallbackSummary({
+				decryptOutcome,
+				linterName,
+			}),
+		linterName,
+	);
+}
+
+function determineOverallConclusion({ decryptOutcome, failedCount }) {
+	return failedCount === 0 && decryptOutcome !== "failure"
+		? "success"
+		: "failure";
+}
+
+function determineOverallStatus({ decryptOutcome, failedCount, warningCount }) {
+	if (decryptOutcome === "failure" || failedCount > 0) {
+		return "failure";
+	}
+
+	return warningCount > 0 ? "warning" : "success";
+}
+
+function buildOverallSummary({
+	decryptOutcome,
+	failedCount,
+	totalCount,
+	warningCount,
+}) {
+	if (decryptOutcome === "failure") {
+		return "One or more encrypted linter summaries could not be read. See the workflow logs.";
+	}
+
+	if (failedCount === 0 && warningCount === 0) {
+		return `All ${totalCount} selected linter(s) completed successfully.`;
+	}
+
+	if (failedCount === 0) {
+		return `All ${totalCount} selected linter(s) completed successfully; ${warningCount} reported warnings.`;
+	}
+
+	if (warningCount === 0) {
+		return `${failedCount} of ${totalCount} selected linter(s) reported issues or failed.`;
+	}
+
+	return `${failedCount} of ${totalCount} selected linter(s) reported issues or failed; ${warningCount} additional linter(s) reported warnings.`;
+}
+
+function buildReportLines({
+	detailSections,
+	includeMarker,
+	overallSummary,
+	rows,
+}) {
+	const lines = [];
+	if (includeMarker) {
+		lines.push(COMMENT_MARKER);
+	}
+
+	lines.push("## linter-service", "", overallSummary, "");
+	appendSummaryTable(lines, rows);
+	appendTargetDetails(lines, rows);
+	appendDetailSections(lines, detailSections);
+	return lines;
 }
 
 function writeCombinedReportFiles({ checkRunText, commentBody, runnerTemp }) {

--- a/.github/scripts/render-combined-report.js
+++ b/.github/scripts/render-combined-report.js
@@ -33,6 +33,7 @@ function runFromEnv(env = process.env) {
 			env.GITHUB_OUTPUT,
 			[
 				`overall_conclusion=${report.overallConclusion}`,
+				`overall_status=${report.overallStatus}`,
 				`overall_summary=${report.overallSummary}`,
 				"",
 			].join("\n"),
@@ -52,6 +53,7 @@ function renderCombinedReport({
 	const rows = [];
 	const detailSections = [];
 	let failed = 0;
+	let warned = 0;
 
 	for (const linterName of selectedLinters) {
 		const summary = normalizeSummary(
@@ -65,6 +67,8 @@ function renderCombinedReport({
 
 		if (summary.conclusion !== "success") {
 			failed += 1;
+		} else if (summary.status === "warning") {
+			warned += 1;
 		}
 
 		rows.push(summary);
@@ -78,15 +82,25 @@ function renderCombinedReport({
 	const total = selectedLinters.length;
 	const overallConclusion =
 		failed === 0 && decryptOutcome !== "failure" ? "success" : "failure";
+	const overallStatus =
+		decryptOutcome === "failure" || failed > 0
+			? "failure"
+			: warned > 0
+				? "warning"
+				: "success";
 	let overallSummary;
 
 	if (decryptOutcome === "failure") {
 		overallSummary =
 			"One or more encrypted linter summaries could not be read. See the workflow logs.";
-	} else if (overallConclusion === "success") {
+	} else if (failed === 0 && warned === 0) {
 		overallSummary = `All ${total} selected linter(s) completed successfully.`;
-	} else {
+	} else if (failed === 0) {
+		overallSummary = `All ${total} selected linter(s) completed successfully; ${warned} reported warnings.`;
+	} else if (warned === 0) {
 		overallSummary = `${failed} of ${total} selected linter(s) reported issues or failed.`;
+	} else {
+		overallSummary = `${failed} of ${total} selected linter(s) reported issues or failed; ${warned} additional linter(s) reported warnings.`;
 	}
 
 	const commentLines = [
@@ -102,13 +116,14 @@ function renderCombinedReport({
 	appendSummaryTable(checkRunLines, rows);
 	appendTargetDetails(commentLines, rows);
 	appendTargetDetails(checkRunLines, rows);
-	appendFailureDetails(commentLines, detailSections);
-	appendFailureDetails(checkRunLines, detailSections);
+	appendDetailSections(commentLines, detailSections);
+	appendDetailSections(checkRunLines, detailSections);
 
 	return {
 		checkRunText: `${checkRunLines.join("\n")}\n`,
 		commentBody: `${commentLines.join("\n")}\n`,
 		overallConclusion,
+		overallStatus,
 		overallSummary,
 	};
 }
@@ -174,14 +189,14 @@ function appendTargetDetails(lines, rows) {
 	}
 }
 
-function appendFailureDetails(lines, detailSections) {
+function appendDetailSections(lines, detailSections) {
 	if (detailSections.length === 0) {
 		return;
 	}
 
 	lines.push(
 		"",
-		`<details><summary>Show details for ${detailSections.length} failing linter(s)</summary>`,
+		`<details><summary>Show details for ${detailSections.length} linter(s) with warnings or failures</summary>`,
 		"",
 	);
 
@@ -196,13 +211,16 @@ function appendFailureDetails(lines, detailSections) {
 }
 
 function buildDetailSection(summary) {
-	if (!isFailureLikeStatus(summary.status)) {
+	if (!isProblemLikeStatus(summary.status)) {
 		return "";
 	}
 
 	const lines = [`### ${summary.linterName}`, ""];
 
-	if (summary.status === "failure" && summary.detailsText.length > 0) {
+	if (
+		(summary.status === "warning" || summary.status === "failure") &&
+		summary.detailsText.length > 0
+	) {
 		lines.push("```text", summary.detailsText, "```");
 		return lines.join("\n");
 	}
@@ -282,6 +300,8 @@ function buildResultLabel(status) {
 	switch (status) {
 		case "success":
 			return "✅ Pass";
+		case "warning":
+			return "⚠️ Warning";
 		case "no_targets":
 			return "⚪ No targets";
 		case "infra_failure":
@@ -364,8 +384,10 @@ function extractSummaryText(commentBody) {
 	return "";
 }
 
-function isFailureLikeStatus(status) {
-	return ["failure", "infra_failure", "missing_summary"].includes(status);
+function isProblemLikeStatus(status) {
+	return ["warning", "failure", "infra_failure", "missing_summary"].includes(
+		status,
+	);
 }
 
 function readLinterSummaries(summaryRoot) {

--- a/.github/scripts/render-combined-report.test.js
+++ b/.github/scripts/render-combined-report.test.js
@@ -129,7 +129,7 @@ test("writes comment and check-run reports from detailed linter summaries", () =
 				"",
 				"</details>",
 				"",
-				"<details><summary>Show details for 1 failing linter(s)</summary>",
+				"<details><summary>Show details for 1 linter(s) with warnings or failures</summary>",
 				"",
 				"### rustfmt",
 				"",
@@ -173,7 +173,7 @@ test("writes comment and check-run reports from detailed linter summaries", () =
 				"",
 				"</details>",
 				"",
-				"<details><summary>Show details for 1 failing linter(s)</summary>",
+				"<details><summary>Show details for 1 linter(s) with warnings or failures</summary>",
 				"",
 				"### rustfmt",
 				"",
@@ -186,9 +186,127 @@ test("writes comment and check-run reports from detailed linter summaries", () =
 			].join("\n"),
 		);
 		assert.match(githubOutput, /^overall_conclusion=failure$/m);
+		assert.match(githubOutput, /^overall_status=failure$/m);
 		assert.match(
 			githubOutput,
 			/^overall_summary=1 of 2 selected linter\(s\) reported issues or failed\.$/m,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("treats warning summaries as non-blocking findings in combined output", () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "render-combined-report-warning-"),
+	);
+	const runnerTemp = path.join(tempDir, "runner-temp");
+	const summaryRoot = path.join(tempDir, "summaries");
+	const githubOutputPath = path.join(tempDir, "github-output.txt");
+
+	fs.mkdirSync(runnerTemp, { recursive: true });
+	fs.mkdirSync(summaryRoot, { recursive: true });
+	fs.writeFileSync(
+		path.join(summaryRoot, "linter-summary-actionlint.json"),
+		JSON.stringify(
+			{
+				comment_body: "### actionlint\n\n✅ 1 / 1 file passed.\n",
+				checked_project_count: 0,
+				checked_projects: [],
+				conclusion: "success",
+				counts_known: true,
+				details_text: "",
+				issue_count: 0,
+				issue_target_count: 0,
+				linter_name: "actionlint",
+				passed_target_count: 1,
+				selected_files: [".github/workflows/ci.yml"],
+				selected_file_count: 1,
+				status: "success",
+				summary_text: "✅ 1 / 1 file passed.",
+				target_count: 1,
+				target_kind: "file",
+			},
+			null,
+			2,
+		),
+		"utf8",
+	);
+	fs.writeFileSync(
+		path.join(summaryRoot, "linter-summary-cargo-deny.json"),
+		JSON.stringify(
+			{
+				comment_body:
+					"### cargo-deny\n\n⚠️ Checked 1 Cargo project; 1 Cargo project reported warnings.\n\n<details><summary>Details</summary>\n\n```text\nwarning[duplicate]: found 2 duplicate entries for crate 'block-buffer'\n```\n</details>\n",
+				checked_project_count: 1,
+				checked_projects: ["Cargo.toml"],
+				conclusion: "success",
+				counts_known: true,
+				details_text:
+					"warning[duplicate]: found 2 duplicate entries for crate 'block-buffer'",
+				issue_count: 1,
+				issue_target_count: 1,
+				linter_name: "cargo-deny",
+				passed_target_count: 0,
+				selected_files: ["Cargo.lock"],
+				selected_file_count: 1,
+				status: "warning",
+				summary_text:
+					"⚠️ Checked 1 Cargo project; 1 Cargo project reported warnings.",
+				target_count: 1,
+				target_kind: "cargo-project",
+			},
+			null,
+			2,
+		),
+		"utf8",
+	);
+
+	try {
+		const report = runFromEnv({
+			DECRYPT_SUMMARIES_OUTCOME: "success",
+			GITHUB_OUTPUT: githubOutputPath,
+			LINTER_SUMMARY_PATH: summaryRoot,
+			RUNNER_TEMP: runnerTemp,
+			SELECTED_LINTERS_JSON: JSON.stringify(["actionlint", "cargo-deny"]),
+		});
+		const commentBody = fs.readFileSync(
+			path.join(runnerTemp, "combined-linter-comment.md"),
+			"utf8",
+		);
+		const checkRunText = fs.readFileSync(
+			path.join(runnerTemp, "combined-linter-check-run.md"),
+			"utf8",
+		);
+		const githubOutput = fs.readFileSync(githubOutputPath, "utf8");
+
+		assert.equal(report.overallConclusion, "success");
+		assert.equal(report.overallStatus, "warning");
+		assert.equal(
+			report.overallSummary,
+			"All 2 selected linter(s) completed successfully; 1 reported warnings.",
+		);
+		assert.match(
+			commentBody,
+			/\| `cargo-deny` \| ⚠️ Warning \| 1 Cargo project \| 0 \| 1 \|/,
+		);
+		assert.match(
+			commentBody,
+			/<details><summary>Show details for 1 linter\(s\) with warnings or failures<\/summary>/,
+		);
+		assert.match(
+			commentBody,
+			/### cargo-deny\n\n```text\nwarning\[duplicate\]: found 2 duplicate entries for crate 'block-buffer'\n```/,
+		);
+		assert.match(
+			checkRunText,
+			/\| `cargo-deny` \| ⚠️ Warning \| 1 Cargo project \| 0 \| 1 \|/,
+		);
+		assert.match(githubOutput, /^overall_conclusion=success$/m);
+		assert.match(githubOutput, /^overall_status=warning$/m);
+		assert.match(
+			githubOutput,
+			/^overall_summary=All 2 selected linter\(s\) completed successfully; 1 reported warnings\.$/m,
 		);
 	} finally {
 		fs.rmSync(tempDir, { force: true, recursive: true });

--- a/.github/scripts/render-linter-report.js
+++ b/.github/scripts/render-linter-report.js
@@ -67,21 +67,28 @@ function renderReport({
 	const hasStepFailure = [selectOutcome, installOutcome, runOutcome].includes(
 		"failure",
 	);
-	const success =
-		!hasStepFailure && (selectedFiles.length === 0 || exitCodeRaw === "0");
-	const conclusion = success ? "success" : "failure";
 	let detailsText = "";
 	const status =
 		hasStepFailure && result === null
 			? "infra_failure"
 			: selectedFiles.length === 0 && exitCodeRaw === ""
 				? "no_targets"
-				: success
-					? "success"
-					: "failure";
+				: !hasStepFailure &&
+						exitCodeRaw === "0" &&
+						hasNonBlockingFindings(result)
+					? "warning"
+					: !hasStepFailure &&
+							(selectedFiles.length === 0 || exitCodeRaw === "0")
+						? "success"
+						: "failure";
+	const conclusion =
+		status === "failure" || status === "infra_failure" ? "failure" : "success";
 
-	if (status === "failure") {
-		detailsText = resolveDetails(result, buildDetailsFallback(linterName));
+	if (status === "failure" || status === "warning") {
+		detailsText = resolveDetails(
+			result,
+			buildDetailsFallback(linterName, status),
+		);
 	}
 
 	const normalizedTargetStats = normalizeTargetStats({
@@ -102,7 +109,7 @@ function renderReport({
 		appendTargetLines(lines, targetLines);
 	}
 
-	if (status === "failure") {
+	if (status === "failure" || status === "warning") {
 		lines.push(
 			"",
 			"<details><summary>Details</summary>",
@@ -142,8 +149,22 @@ function resolveDetails(result, fallback) {
 	return details;
 }
 
-function buildDetailsFallback(linterName) {
+function buildDetailsFallback(linterName, status = "failure") {
+	if (status === "warning") {
+		return `The \`${linterName}\` run completed with warnings but did not produce diagnostic output.`;
+	}
+
 	return `The \`${linterName}\` run exited with issues but did not produce diagnostic output.`;
+}
+
+function countNonBlockingFindings(result) {
+	return Number.isInteger(result?.warning_count) && result.warning_count > 0
+		? result.warning_count
+		: 0;
+}
+
+function hasNonBlockingFindings(result) {
+	return countNonBlockingFindings(result) > 0;
 }
 
 function buildSummaryText({ linterName, status, targetStats }) {
@@ -152,6 +173,18 @@ function buildSummaryText({ linterName, status, targetStats }) {
 			return `✅ ${formatRatio(targetStats.passedTargetCount, targetStats.targetCount)} ${formatTargetLabel(targetStats.targetKind, targetStats.targetCount)} passed.`;
 		case "no_targets":
 			return `⚪ 0 ${formatTargetLabel(targetStats.targetKind, 0)} checked.`;
+		case "warning":
+			if (
+				targetStats.countsKnown &&
+				targetStats.issueTargetCount !== null &&
+				targetStats.targetCount !== null
+			) {
+				return `⚠️ Checked ${formatTargetQuantity(targetStats.targetCount, targetStats.targetKind)}; ${formatTargetQuantity(targetStats.issueTargetCount, targetStats.targetKind)} reported warnings.`;
+			}
+
+			return targetStats.targetCount === null
+				? `⚠️ The \`${linterName}\` run completed with warnings.`
+				: `⚠️ Checked ${formatTargetQuantity(targetStats.targetCount, targetStats.targetKind)}; warning counts are unavailable.`;
 		case "infra_failure":
 			return targetStats.targetCount === null
 				? `❌ The \`${linterName}\` workflow failed before diagnostics were produced. See the workflow logs.`

--- a/.github/scripts/render-linter-report.js
+++ b/.github/scripts/render-linter-report.js
@@ -168,44 +168,78 @@ function hasNonBlockingFindings(result) {
 }
 
 function buildSummaryText({ linterName, status, targetStats }) {
-	switch (status) {
-		case "success":
-			return `✅ ${formatRatio(targetStats.passedTargetCount, targetStats.targetCount)} ${formatTargetLabel(targetStats.targetKind, targetStats.targetCount)} passed.`;
-		case "no_targets":
-			return `⚪ 0 ${formatTargetLabel(targetStats.targetKind, 0)} checked.`;
-		case "warning":
-			if (
-				targetStats.countsKnown &&
-				targetStats.issueTargetCount !== null &&
-				targetStats.targetCount !== null
-			) {
-				return `⚠️ Checked ${formatTargetQuantity(targetStats.targetCount, targetStats.targetKind)}; ${formatTargetQuantity(targetStats.issueTargetCount, targetStats.targetKind)} reported warnings.`;
-			}
-
-			return targetStats.targetCount === null
-				? `⚠️ The \`${linterName}\` run completed with warnings.`
-				: `⚠️ Checked ${formatTargetQuantity(targetStats.targetCount, targetStats.targetKind)}; warning counts are unavailable.`;
-		case "infra_failure":
-			return targetStats.targetCount === null
-				? `❌ The \`${linterName}\` workflow failed before diagnostics were produced. See the workflow logs.`
-				: `❌ Matched ${formatTargetQuantity(targetStats.targetCount, targetStats.targetKind)}, but the workflow failed before diagnostics were produced.`;
-		case "failure":
-			if (
-				targetStats.countsKnown &&
-				targetStats.passedTargetCount !== null &&
-				targetStats.issueTargetCount !== null &&
-				targetStats.targetCount !== null
-			) {
-				return `❌ ${formatRatio(targetStats.passedTargetCount, targetStats.targetCount)} ${formatTargetLabel(targetStats.targetKind, targetStats.targetCount)} passed; ${formatTargetQuantity(targetStats.issueTargetCount, targetStats.targetKind)} reported issues.`;
-			}
-
-			return targetStats.targetCount === null
-				? `❌ The \`${linterName}\` run reported issues. See the workflow logs.`
-				: `❌ Checked ${formatTargetQuantity(targetStats.targetCount, targetStats.targetKind)}; issue counts are unavailable.`;
-		default:
-			return `❌ The \`${linterName}\` workflow failed before producing a detailed report. See the workflow logs.`;
-	}
+	const builder = SUMMARY_TEXT_BUILDERS[status] ?? buildUnknownSummaryText;
+	return builder({ linterName, targetStats });
 }
+
+function buildSuccessSummaryText({ targetStats }) {
+	return `✅ ${formatRatio(targetStats.passedTargetCount, targetStats.targetCount)} ${formatTargetLabel(targetStats.targetKind, targetStats.targetCount)} passed.`;
+}
+
+function buildNoTargetsSummaryText({ targetStats }) {
+	return `⚪ 0 ${formatTargetLabel(targetStats.targetKind, 0)} checked.`;
+}
+
+function buildWarningSummaryText({ linterName, targetStats }) {
+	if (hasKnownWarningCounts(targetStats)) {
+		return `⚠️ Checked ${formatTargetQuantity(targetStats.targetCount, targetStats.targetKind)}; ${formatTargetQuantity(targetStats.issueTargetCount, targetStats.targetKind)} reported warnings.`;
+	}
+
+	if (targetStats.targetCount === null) {
+		return `⚠️ The \`${linterName}\` run completed with warnings.`;
+	}
+
+	return `⚠️ Checked ${formatTargetQuantity(targetStats.targetCount, targetStats.targetKind)}; warning counts are unavailable.`;
+}
+
+function buildInfraFailureSummaryText({ linterName, targetStats }) {
+	if (targetStats.targetCount === null) {
+		return `❌ The \`${linterName}\` workflow failed before diagnostics were produced. See the workflow logs.`;
+	}
+
+	return `❌ Matched ${formatTargetQuantity(targetStats.targetCount, targetStats.targetKind)}, but the workflow failed before diagnostics were produced.`;
+}
+
+function buildFailureSummaryText({ linterName, targetStats }) {
+	if (hasKnownFailureCounts(targetStats)) {
+		return `❌ ${formatRatio(targetStats.passedTargetCount, targetStats.targetCount)} ${formatTargetLabel(targetStats.targetKind, targetStats.targetCount)} passed; ${formatTargetQuantity(targetStats.issueTargetCount, targetStats.targetKind)} reported issues.`;
+	}
+
+	if (targetStats.targetCount === null) {
+		return `❌ The \`${linterName}\` run reported issues. See the workflow logs.`;
+	}
+
+	return `❌ Checked ${formatTargetQuantity(targetStats.targetCount, targetStats.targetKind)}; issue counts are unavailable.`;
+}
+
+function buildUnknownSummaryText({ linterName }) {
+	return `❌ The \`${linterName}\` workflow failed before producing a detailed report. See the workflow logs.`;
+}
+
+function hasKnownWarningCounts(targetStats) {
+	return (
+		targetStats.countsKnown &&
+		targetStats.issueTargetCount !== null &&
+		targetStats.targetCount !== null
+	);
+}
+
+function hasKnownFailureCounts(targetStats) {
+	return (
+		targetStats.countsKnown &&
+		targetStats.passedTargetCount !== null &&
+		targetStats.issueTargetCount !== null &&
+		targetStats.targetCount !== null
+	);
+}
+
+const SUMMARY_TEXT_BUILDERS = Object.freeze({
+	failure: buildFailureSummaryText,
+	infra_failure: buildInfraFailureSummaryText,
+	no_targets: buildNoTargetsSummaryText,
+	success: buildSuccessSummaryText,
+	warning: buildWarningSummaryText,
+});
 
 function normalizeTargetStats({
 	checkedProjects,

--- a/.github/scripts/render-linter-report.test.js
+++ b/.github/scripts/render-linter-report.test.js
@@ -307,6 +307,59 @@ test("includes checked targets before diagnostic details on failure", () => {
 	}
 });
 
+test("renders warning summaries and details without failing the report", () => {
+	const context = makeTempRepo("render-linter-report-warning-");
+
+	try {
+		fs.writeFileSync(
+			path.join(context.runnerTemp, "selected-files.txt"),
+			`${["src/app.js"].join("\n")}\n`,
+			"utf8",
+		);
+		fs.writeFileSync(
+			path.join(context.runnerTemp, "linter-result.json"),
+			JSON.stringify({
+				details: "warning[EX123]: unexpected thing",
+				exit_code: 0,
+				warning_count: 1,
+			}),
+			"utf8",
+		);
+
+		const report = renderReport({
+			configPath,
+			exitCodeRaw: "0",
+			installOutcome: "success",
+			linterName: "actionlint",
+			resultPath: path.join(context.runnerTemp, "linter-result.json"),
+			runOutcome: "success",
+			selectedFilesPath: path.join(context.runnerTemp, "selected-files.txt"),
+			selectOutcome: "success",
+			sourceRepositoryPath: context.repoDir,
+			targetStats: {
+				counts_known: true,
+				issue_count: 1,
+				issue_target_count: 1,
+				passed_target_count: 0,
+				target_count: 1,
+				target_kind: "file",
+			},
+		});
+
+		assert.equal(report.conclusion, "success");
+		assert.equal(report.status, "warning");
+		assert.equal(
+			report.summaryText,
+			"⚠️ Checked 1 file; 1 file reported warnings.",
+		);
+		assert.match(report.body, /⚠️ Checked 1 file; 1 file reported warnings\./);
+		assert.match(report.body, /<details><summary>Details<\/summary>/);
+		assert.match(report.body, /warning\[EX123\]: unexpected thing/);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
 test("renders rustfmt failure summaries from issue target counts instead of echoed checks", () => {
 	const context = makeTempRepo("render-linter-report-rustfmt-failure-");
 	const selectedFiles = [

--- a/.github/scripts/render-linter-sarif.js
+++ b/.github/scripts/render-linter-sarif.js
@@ -102,7 +102,7 @@ function renderSarif({
 
 	const details = resolveDiagnosticDetails(
 		result,
-		buildDetailsFallback(linterName),
+		buildDetailsFallback(linterName, result),
 	);
 	const reportedPathRoots = buildReportedPathRoots({
 		linterName,
@@ -110,7 +110,7 @@ function renderSarif({
 		sourceRepositoryPath,
 	});
 	const results =
-		result.exit_code === 0
+		result.exit_code === 0 && !hasNonBlockingFindings(result)
 			? []
 			: buildSarifResults({
 					configPath,
@@ -179,7 +179,25 @@ function resolveDiagnosticDetails(result, fallback) {
 	return exitCode === 0 ? "" : fallback;
 }
 
-function buildDetailsFallback(linterName) {
+function countNonBlockingFindings(result) {
+	return Number.isInteger(result?.warning_count) && result.warning_count > 0
+		? result.warning_count
+		: 0;
+}
+
+function hasNonBlockingFindings(result) {
+	return countNonBlockingFindings(result) > 0;
+}
+
+function buildDetailsFallback(linterName, result) {
+	if (
+		hasNonBlockingFindings(result) &&
+		Number.isInteger(result?.exit_code) &&
+		result.exit_code === 0
+	) {
+		return `The \`${linterName}\` run completed with warnings but did not produce diagnostic output.`;
+	}
+
 	return `The \`${linterName}\` run exited with issues but did not produce diagnostic output.`;
 }
 

--- a/.github/scripts/render-linter-sarif.test.js
+++ b/.github/scripts/render-linter-sarif.test.js
@@ -116,6 +116,67 @@ test("emits empty SARIF when an enabled linter succeeds", () => {
 	}
 });
 
+test("emits SARIF when a successful run reports non-blocking warnings", () => {
+	const context = makeTempRepo("render-linter-sarif-warning-success-");
+	const configPath = path.join(context.tempDir, "config.json");
+
+	writeFile(path.join(context.repoDir, "src/app.js"), "console.log('ok');\n");
+	writeFile(
+		configPath,
+		JSON.stringify(
+			{
+				linters: {
+					example: {
+						sarif: {
+							enabled: true,
+						},
+					},
+				},
+			},
+			null,
+			2,
+		),
+	);
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"src/app.js\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details: "warning[EX123]: unexpected thing",
+			exit_code: 0,
+			warning_count: 1,
+		}),
+	);
+
+	try {
+		const report = renderSarif({
+			configPath,
+			installOutcome: "success",
+			linterName: "example",
+			outputPath: path.join(context.runnerTemp, "example.sarif"),
+			resultPath: path.join(context.runnerTemp, "linter-result.json"),
+			runOutcome: "success",
+			selectedFilesPath: path.join(context.runnerTemp, "selected-files.txt"),
+			selectOutcome: "success",
+			sourceRepositoryPath: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.equal(report.sarif.runs[0].results.length, 1);
+		assert.equal(report.sarif.runs[0].results[0].level, "warning");
+		assert.equal(report.sarif.runs[0].results[0].ruleId, "EX123");
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"src/app.js",
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
 test("does not emit SARIF when the linter run failed before producing a result", () => {
 	const context = makeTempRepo("render-linter-sarif-run-failed-");
 	const configPath = path.join(context.tempDir, "config.json");

--- a/.github/scripts/run-linter-batch.test.js
+++ b/.github/scripts/run-linter-batch.test.js
@@ -280,6 +280,62 @@ printf '{"details":"beta ok","exit_code":0}\\n'
 	}
 });
 
+test("runLinterBatch preserves warning-only summaries as successful conclusions", () => {
+	const workspace = createTempWorkspace();
+	writeFile(path.join(workspace.sourceRepositoryPath, "alpha.txt"), "alpha\n");
+	writeLinterConfig(workspace.linterConfigPath, {
+		alpha: {
+			sarif: {
+				enabled: true,
+			},
+		},
+	});
+	writeFakeLinter(workspace.linterServicePath, {
+		name: "alpha",
+		installScript: `#!/usr/bin/env bash
+set -euo pipefail
+:`,
+		pattern: "^alpha\\.txt$",
+		runScript: `#!/usr/bin/env bash
+set -euo pipefail
+printf '{"details":"warning[ALPHA1]: alpha warning","exit_code":0,"warning_count":1}\\n'
+`,
+	});
+
+	try {
+		const result = runLinterBatch({
+			baseEnv: {
+				...process.env,
+				PATH: process.env.PATH || "",
+			},
+			contextPath: workspace.contextPath,
+			linterConfigPath: workspace.linterConfigPath,
+			linterNames: ["alpha"],
+			linterServicePath: workspace.linterServicePath,
+			runnerTemp: workspace.runnerTemp,
+			sourceRepositoryPath: workspace.sourceRepositoryPath,
+		});
+
+		assert.equal(result.infrastructureFailures, 0);
+		assert.equal(result.linters[0].conclusion, "success");
+
+		const alphaSummary = JSON.parse(
+			fs.readFileSync(
+				path.join(workspace.runnerTemp, "linter-summary-alpha.json"),
+				"utf8",
+			),
+		);
+		assert.equal(alphaSummary.conclusion, "success");
+		assert.equal(alphaSummary.status, "warning");
+		assert.match(
+			alphaSummary.comment_body,
+			/⚠️ Checked 1 file; 1 file reported warnings\./u,
+		);
+	} finally {
+		cleanupTempWorkspace(workspace.tempDir);
+	}
+});
+
 test("formatExecError suppresses raw stdout and stderr contents", () => {
 	const formatted = formatExecError({
 		message: "Command failed: bash run.sh\nsecret stderr",

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -892,6 +892,7 @@ jobs:
         if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' }}
         env:
           OVERALL_CONCLUSION: ${{ steps.prepare_report.outcome == 'success' && steps.prepare_report.outputs.overall_conclusion || 'failure' }}
+          OVERALL_STATUS: ${{ steps.prepare_report.outcome == 'success' && steps.prepare_report.outputs.overall_status || 'failure' }}
           OVERALL_SUMMARY: ${{ steps.prepare_report.outcome == 'success' && steps.prepare_report.outputs.overall_summary || 'The linter-service workflow failed to generate a combined report.' }}
           UPLOAD_SARIF_OUTCOME: ${{ steps.upload_sarif.outcome }}
         run: |
@@ -900,16 +901,20 @@ jobs:
           from pathlib import Path
 
           overall_conclusion = os.environ["OVERALL_CONCLUSION"]
+          overall_status = os.environ["OVERALL_STATUS"]
           overall_summary = os.environ["OVERALL_SUMMARY"]
           upload_sarif_outcome = os.environ.get("UPLOAD_SARIF_OUTCOME", "")
 
           conclusion = overall_conclusion
           summary = overall_summary
-          title = (
-              "linter-service completed"
-              if conclusion == "success"
-              else "linter-service found issues"
-          )
+          if conclusion == "success" and overall_status == "warning":
+              title = "linter-service completed with warnings"
+          else:
+              title = (
+                  "linter-service completed"
+                  if conclusion == "success"
+                  else "linter-service found issues"
+              )
 
           if upload_sarif_outcome == "failure":
               summary = f"{overall_summary} Warning: SARIF upload failed; see the workflow logs."

--- a/cargo-deny/cargo-deny-result.js
+++ b/cargo-deny/cargo-deny-result.js
@@ -10,6 +10,7 @@ const {
 
 const ADVISORY_WARNING_KINDS = new Set(["notice", "unmaintained", "unsound"]);
 const DEFAULT_CARGO_DENY_MESSAGE = "cargo-deny reported an issue";
+const IGNORED_WARNING_CODES = new Set(["duplicate"]);
 
 function parseJsonLines(text) {
 	const items = [];
@@ -52,6 +53,37 @@ function isCargoDenyConfigLikeDiagnostic(diagnostic) {
 	const haystack = [fields?.message, code, ...notes].join("\n");
 
 	return /config|deny\.toml|failed to parse/i.test(haystack);
+}
+
+function isCargoDenyStructuredDiagnostic(item) {
+	return item && item.type === "diagnostic" && item.fields;
+}
+
+function normalizeCargoDenySeverityName(fields) {
+	return typeof fields?.severity === "string"
+		? fields.severity.toLowerCase()
+		: "";
+}
+
+function normalizeCargoDenyDiagnosticCodeName(fields) {
+	return typeof fields?.code === "string" ? fields.code.toLowerCase() : "";
+}
+
+function isIgnorableCargoDenyDiagnostic(diagnostic) {
+	const fields = diagnostic?.fields || {};
+
+	return (
+		normalizeCargoDenySeverityName(fields) === "warning" &&
+		IGNORED_WARNING_CODES.has(normalizeCargoDenyDiagnosticCodeName(fields))
+	);
+}
+
+function normalizeCargoDenyVulnerabilities(vulnerabilities) {
+	if (Array.isArray(vulnerabilities)) {
+		return vulnerabilities;
+	}
+
+	return Array.isArray(vulnerabilities?.list) ? vulnerabilities.list : [];
 }
 
 function guessCargoDenyDisplayPath(run, diagnostic) {
@@ -109,9 +141,9 @@ function formatCargoDenyWarningLine(kind, entry) {
 }
 
 function formatCargoDenyAuditReport(report) {
-	const vulnerabilities = Array.isArray(report?.vulnerabilities)
-		? report.vulnerabilities
-		: [];
+	const vulnerabilities = normalizeCargoDenyVulnerabilities(
+		report?.vulnerabilities,
+	);
 	const warnings = normalizeCargoDenyWarnings(report?.warnings);
 
 	return [
@@ -210,6 +242,9 @@ function normalizeCargoDenyRun(run) {
 	const stderrText = String(run?.stderr || "");
 	const stdoutParsed = parseJsonLines(stdoutText);
 	const stderrParsed = parseJsonLines(stderrText);
+	const diagnostics = stderrParsed.items
+		.filter(isCargoDenyStructuredDiagnostic)
+		.filter((diagnostic) => !isIgnorableCargoDenyDiagnostic(diagnostic));
 
 	return {
 		command: String(run?.command || "").trim(),
@@ -221,12 +256,38 @@ function normalizeCargoDenyRun(run) {
 		audit_reports: stdoutParsed.items.filter(
 			(item) => item && typeof item === "object",
 		),
-		diagnostics: stderrParsed.items.filter(
-			(item) => item && item.type === "diagnostic" && item.fields,
+		diagnostics,
+		stderr_other_items: stderrParsed.items.filter(
+			(item) =>
+				item &&
+				typeof item === "object" &&
+				!isCargoDenyStructuredDiagnostic(item),
 		),
 		stdout_raw_lines: stdoutParsed.rawLines,
 		stderr_raw_lines: stderrParsed.rawLines,
 	};
+}
+
+function hasCargoDenyAuditFindings(report) {
+	const warnings = normalizeCargoDenyWarnings(report?.warnings);
+
+	return (
+		normalizeCargoDenyVulnerabilities(report?.vulnerabilities).length > 0 ||
+		listCargoDenyWarningKinds(warnings).some(
+			(kind) => normalizeCargoDenyWarningEntries(warnings[kind]).length > 0,
+		)
+	);
+}
+
+function hasCargoDenyActionableRun(run) {
+	return (
+		run.audit_reports.some(hasCargoDenyAuditFindings) ||
+		run.diagnostics.length > 0 ||
+		run.stderr_other_items.some((item) => item?.type !== "summary") ||
+		[...run.stdout_raw_lines, ...run.stderr_raw_lines].some(
+			(line) => String(line).trim().length > 0,
+		)
+	);
 }
 
 function renderCargoDenyRunDetails(run) {
@@ -294,6 +355,7 @@ function buildCargoDenyResult({ entriesDir, exitCode, runs = null }) {
 	const normalizedRuns = (runs || readCargoDenyRunEntries(entriesDir)).map(
 		normalizeCargoDenyRun,
 	);
+	const requestedExitCode = Number.parseInt(String(exitCode), 10) || 0;
 	const details = normalizedRuns
 		.flatMap((run) => [...renderCargoDenyRunDetails(run), ""])
 		.join("\n")
@@ -318,7 +380,10 @@ function buildCargoDenyResult({ entriesDir, exitCode, runs = null }) {
 			}),
 		),
 		details,
-		exit_code: Number.parseInt(String(exitCode), 10) || 0,
+		exit_code:
+			requestedExitCode === 0 || normalizedRuns.some(hasCargoDenyActionableRun)
+				? requestedExitCode
+				: 0,
 	};
 }
 
@@ -341,5 +406,6 @@ module.exports = {
 	guessCargoDenyDisplayPath,
 	isCargoDenyAdvisoryLikeDiagnostic,
 	isCargoDenyConfigLikeDiagnostic,
+	isIgnorableCargoDenyDiagnostic,
 	parseJsonLines,
 };

--- a/cargo-deny/cargo-deny-result.js
+++ b/cargo-deny/cargo-deny-result.js
@@ -242,9 +242,15 @@ function normalizeCargoDenyRun(run) {
 	const stderrText = String(run?.stderr || "");
 	const stdoutParsed = parseJsonLines(stdoutText);
 	const stderrParsed = parseJsonLines(stderrText);
-	const diagnostics = stderrParsed.items
-		.filter(isCargoDenyStructuredDiagnostic)
-		.filter((diagnostic) => !isIgnorableCargoDenyDiagnostic(diagnostic));
+	const structuredDiagnostics = stderrParsed.items.filter(
+		isCargoDenyStructuredDiagnostic,
+	);
+	const diagnostics = structuredDiagnostics.filter(
+		(diagnostic) => !isIgnorableCargoDenyDiagnostic(diagnostic),
+	);
+	const warning_diagnostics = structuredDiagnostics.filter(
+		isIgnorableCargoDenyDiagnostic,
+	);
 
 	return {
 		command: String(run?.command || "").trim(),
@@ -257,6 +263,7 @@ function normalizeCargoDenyRun(run) {
 			(item) => item && typeof item === "object",
 		),
 		diagnostics,
+		warning_diagnostics,
 		stderr_other_items: stderrParsed.items.filter(
 			(item) =>
 				item &&
@@ -304,12 +311,22 @@ function renderCargoDenyRunDetails(run) {
 					(diagnostic) => !isCargoDenyAdvisoryLikeDiagnostic(diagnostic),
 				)
 			: run.diagnostics;
+	const filteredWarningDiagnostics =
+		run.audit_reports.length > 0
+			? run.warning_diagnostics.filter(
+					(diagnostic) => !isCargoDenyAdvisoryLikeDiagnostic(diagnostic),
+				)
+			: run.warning_diagnostics;
 
 	for (const line of auditLines) {
 		lines.push(line);
 	}
 
 	for (const diagnostic of filteredDiagnostics) {
+		lines.push(...formatCargoDenyDiagnostic(run, diagnostic));
+	}
+
+	for (const diagnostic of filteredWarningDiagnostics) {
 		lines.push(...formatCargoDenyDiagnostic(run, diagnostic));
 	}
 
@@ -356,6 +373,10 @@ function buildCargoDenyResult({ entriesDir, exitCode, runs = null }) {
 		normalizeCargoDenyRun,
 	);
 	const requestedExitCode = Number.parseInt(String(exitCode), 10) || 0;
+	const warningCount = normalizedRuns.reduce(
+		(count, run) => count + run.warning_diagnostics.length,
+		0,
+	);
 	const details = normalizedRuns
 		.flatMap((run) => [...renderCargoDenyRunDetails(run), ""])
 		.join("\n")
@@ -370,6 +391,7 @@ function buildCargoDenyResult({ entriesDir, exitCode, runs = null }) {
 				exit_code: runExitCode,
 				audit_reports,
 				diagnostics,
+				warning_diagnostics,
 			}) => ({
 				command,
 				manifest_path,
@@ -377,6 +399,7 @@ function buildCargoDenyResult({ entriesDir, exitCode, runs = null }) {
 				exit_code: runExitCode,
 				audit_reports,
 				diagnostics,
+				...(warning_diagnostics.length > 0 ? { warning_diagnostics } : {}),
 			}),
 		),
 		details,
@@ -384,6 +407,7 @@ function buildCargoDenyResult({ entriesDir, exitCode, runs = null }) {
 			requestedExitCode === 0 || normalizedRuns.some(hasCargoDenyActionableRun)
 				? requestedExitCode
 				: 0,
+		...(warningCount > 0 ? { warning_count: warningCount } : {}),
 	};
 }
 

--- a/cargo-deny/cargo-deny-result.test.js
+++ b/cargo-deny/cargo-deny-result.test.js
@@ -133,3 +133,65 @@ test("buildCargoDenyResult renders warning advisories and diagnostic fallbacks",
 	);
 	assert.match(result.details, /note: fix deny\.toml/);
 });
+
+test("buildCargoDenyResult ignores warning-only duplicate diagnostics", () => {
+	const result = buildCargoDenyResult({
+		exitCode: 1,
+		runs: [
+			{
+				command:
+					"cargo-deny --format json --color never --log-level warn --all-features --manifest-path Cargo.toml check --audit-compatible-output",
+				config_path: "",
+				exit_code: 1,
+				manifest_path: "Cargo.toml",
+				stderr: [
+					JSON.stringify({
+						type: "diagnostic",
+						fields: {
+							code: "duplicate",
+							labels: [
+								{
+									column: 1,
+									line: 10,
+									message: "lock entries",
+									span: [
+										"block-buffer 0.10.4 registry+https://github.com/rust-lang/crates.io-index",
+										"block-buffer 0.12.0 registry+https://github.com/rust-lang/crates.io-index",
+									].join("\n"),
+								},
+							],
+							message: "found 2 duplicate entries for crate 'block-buffer'",
+							notes: [],
+							severity: "warning",
+						},
+					}),
+					JSON.stringify({
+						type: "summary",
+						fields: {
+							advisories: { errors: 0, helps: 0, notes: 0, warnings: 0 },
+							bans: { errors: 0, helps: 0, notes: 0, warnings: 1 },
+							licenses: { errors: 0, helps: 0, notes: 0, warnings: 0 },
+							sources: { errors: 0, helps: 0, notes: 0, warnings: 0 },
+						},
+					}),
+				].join("\n"),
+				stdout: JSON.stringify({
+					lockfile: { "dependency-count": 1 },
+					settings: {},
+					vulnerabilities: {
+						count: 0,
+						found: false,
+						list: [],
+					},
+					warnings: {},
+				}),
+			},
+		],
+	});
+
+	assert.equal(result.exit_code, 0);
+	assert.equal(result.cargo_deny_runs.length, 1);
+	assert.equal(result.cargo_deny_runs[0].exit_code, 1);
+	assert.equal(result.cargo_deny_runs[0].diagnostics.length, 0);
+	assert.doesNotMatch(result.details, /warning\[duplicate\]/);
+});

--- a/cargo-deny/cargo-deny-result.test.js
+++ b/cargo-deny/cargo-deny-result.test.js
@@ -190,8 +190,13 @@ test("buildCargoDenyResult ignores warning-only duplicate diagnostics", () => {
 	});
 
 	assert.equal(result.exit_code, 0);
+	assert.equal(result.warning_count, 1);
 	assert.equal(result.cargo_deny_runs.length, 1);
 	assert.equal(result.cargo_deny_runs[0].exit_code, 1);
 	assert.equal(result.cargo_deny_runs[0].diagnostics.length, 0);
-	assert.doesNotMatch(result.details, /warning\[duplicate\]/);
+	assert.equal(result.cargo_deny_runs[0].warning_diagnostics.length, 1);
+	assert.match(
+		result.details,
+		/warning\[duplicate\]: found 2 duplicate entries/,
+	);
 });

--- a/cargo-deny/cargo-deny.test.js
+++ b/cargo-deny/cargo-deny.test.js
@@ -757,10 +757,15 @@ edition = "2021"
 		const result = JSON.parse(output);
 
 		assert.equal(result.exit_code, 0);
+		assert.equal(result.warning_count, 1);
 		assert.equal(result.cargo_deny_runs.length, 1);
 		assert.equal(result.cargo_deny_runs[0].exit_code, 1);
 		assert.equal(result.cargo_deny_runs[0].diagnostics.length, 0);
-		assert.doesNotMatch(result.details, /warning\[duplicate\]/);
+		assert.equal(result.cargo_deny_runs[0].warning_diagnostics.length, 1);
+		assert.match(
+			result.details,
+			/warning\[duplicate\]: found 2 duplicate entries for crate 'demo'/,
+		);
 		assert.deepEqual(fs.readFileSync(argsLog, "utf8").trim().split("\n"), [
 			"--format json --color never --log-level warn --all-features --manifest-path Cargo.toml check --audit-compatible-output --config deny.toml",
 		]);

--- a/cargo-deny/cargo-deny.test.js
+++ b/cargo-deny/cargo-deny.test.js
@@ -242,6 +242,61 @@ process.stdout.write(
 process.stdout.write("\\n");
 NODE
 fi
+if [ -n "\${DUPLICATE_WARNING_MANIFEST:-}" ] && [ "$manifest" = "$DUPLICATE_WARNING_MANIFEST" ]; then
+  if [ "$audit_mode" -eq 1 ]; then
+    node <<'NODE'
+process.stdout.write(
+  JSON.stringify({
+    settings: {},
+    lockfile: { "dependency-count": 1 },
+    vulnerabilities: {
+      count: 0,
+      found: false,
+      list: [],
+    },
+    warnings: {},
+  }),
+);
+process.stdout.write("\\n");
+process.stderr.write(
+  JSON.stringify({
+    type: "diagnostic",
+    fields: {
+      code: "duplicate",
+      labels: [
+        {
+          column: 1,
+          line: 1,
+          message: "lock entries",
+          span: [
+            "demo 0.1.0 registry+https://github.com/rust-lang/crates.io-index",
+            "demo 0.2.0 registry+https://github.com/rust-lang/crates.io-index",
+          ].join("\\n"),
+        },
+      ],
+      message: "found 2 duplicate entries for crate 'demo'",
+      notes: [],
+      severity: "warning",
+    },
+  }),
+);
+process.stderr.write("\\n");
+process.stderr.write(
+  JSON.stringify({
+    type: "summary",
+    fields: {
+      advisories: { errors: 0, helps: 0, notes: 0, warnings: 0 },
+      bans: { errors: 0, helps: 0, notes: 0, warnings: 1 },
+      licenses: { errors: 0, helps: 0, notes: 0, warnings: 0 },
+      sources: { errors: 0, helps: 0, notes: 0, warnings: 0 },
+    },
+  }),
+);
+process.stderr.write("\\n");
+NODE
+  fi
+  exit 1
+fi
 if [ -n "\${FAIL_MANIFEST:-}" ] && [ "$manifest" = "$FAIL_MANIFEST" ]; then
   if [ "$audit_mode" -eq 1 ]; then
     node - "$manifest" "$config" <<'NODE'
@@ -666,6 +721,49 @@ test("cargo-deny.sh reports selected files outside Cargo packages", () => {
 		assert.match(result.details, /No Cargo\.toml found for:/);
 		assert.match(result.details, /policies\/deny\.toml/);
 		assert.equal(fs.existsSync(argsLog), false);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("cargo-deny.sh ignores warning-only duplicate diagnostics", () => {
+	const context = makeTempRepo("cargo-deny-duplicate-warning-");
+	const argsLog = path.join(context.tempDir, "cargo-deny-args.log");
+
+	createCargoDenyStub(context.binDir);
+	writeFile(
+		path.join(context.repoDir, "Cargo.toml"),
+		`[package]
+name = "root"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(path.join(context.repoDir, "Cargo.lock"), "version = 3\n");
+	writeFile(
+		path.join(context.repoDir, "deny.toml"),
+		"[graph]\nall-features = true\n",
+	);
+
+	try {
+		const output = execFileSync("bash", [runPath, "Cargo.lock"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createEnv(context, {
+				CARGO_DENY_ARGS_LOG: argsLog,
+				DUPLICATE_WARNING_MANIFEST: "Cargo.toml",
+			}),
+		});
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 0);
+		assert.equal(result.cargo_deny_runs.length, 1);
+		assert.equal(result.cargo_deny_runs[0].exit_code, 1);
+		assert.equal(result.cargo_deny_runs[0].diagnostics.length, 0);
+		assert.doesNotMatch(result.details, /warning\[duplicate\]/);
+		assert.deepEqual(fs.readFileSync(argsLog, "utf8").trim().split("\n"), [
+			"--format json --color never --log-level warn --all-features --manifest-path Cargo.toml check --audit-compatible-output --config deny.toml",
+		]);
 	} finally {
 		cleanupTempRepo(context.tempDir);
 	}

--- a/cargo-deny/render-linter-sarif.js
+++ b/cargo-deny/render-linter-sarif.js
@@ -76,7 +76,10 @@ function normalizeCargoDenyVulnerabilities(report) {
 }
 
 function normalizeCargoDenyDiagnostics(run) {
-	return Array.isArray(run?.diagnostics) ? run.diagnostics : [];
+	return [
+		...(Array.isArray(run?.diagnostics) ? run.diagnostics : []),
+		...(Array.isArray(run?.warning_diagnostics) ? run.warning_diagnostics : []),
+	];
 }
 
 function resolveCargoDenyAuditMessage({

--- a/cargo-deny/render-linter-sarif.test.js
+++ b/cargo-deny/render-linter-sarif.test.js
@@ -256,6 +256,104 @@ test("emits SARIF for cargo-deny audit-compatible warnings in sorted kind order"
 	}
 });
 
+test("emits SARIF for non-blocking cargo-deny duplicate warnings", () => {
+	const context = makeTempRepo("render-linter-sarif-cargo-deny-duplicate-");
+
+	writeFile(
+		path.join(context.repoDir, "Cargo.toml"),
+		'[package]\nname = "demo"\nversion = "0.1.0"\nedition = "2021"\n',
+	);
+	writeFile(path.join(context.repoDir, "Cargo.lock"), "version = 3\n");
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"Cargo.lock\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			cargo_deny_runs: [
+				{
+					audit_reports: [
+						{
+							lockfile: { "dependency-count": 1 },
+							settings: {},
+							vulnerabilities: {
+								count: 0,
+								found: false,
+								list: [],
+							},
+							warnings: {},
+						},
+					],
+					command:
+						"cargo-deny --format json --color never --log-level warn --all-features --manifest-path Cargo.toml check --audit-compatible-output",
+					config_path: null,
+					diagnostics: [],
+					warning_diagnostics: [
+						{
+							fields: {
+								code: "duplicate",
+								labels: [
+									{
+										column: 1,
+										line: 10,
+										message: "lock entries",
+										span: [
+											"block-buffer 0.10.4 registry+https://github.com/rust-lang/crates.io-index",
+											"block-buffer 0.12.0 registry+https://github.com/rust-lang/crates.io-index",
+										].join("\n"),
+									},
+								],
+								message: "found 2 duplicate entries for crate 'block-buffer'",
+								notes: [],
+								severity: "warning",
+							},
+							type: "diagnostic",
+						},
+					],
+					exit_code: 1,
+					manifest_path: "Cargo.toml",
+				},
+			],
+			details:
+				"warning[duplicate]: found 2 duplicate entries for crate 'block-buffer'",
+			exit_code: 0,
+			warning_count: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "cargo-deny",
+			OUTPUT_PATH: path.join(context.runnerTemp, "cargo-deny.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.equal(report.targetStats.issue_target_count, 1);
+		assert.equal(report.sarif.runs[0].results.length, 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].ruleId,
+			"cargo-deny/duplicate",
+		);
+		assert.equal(report.sarif.runs[0].results[0].level, "warning");
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"Cargo.toml",
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
 test("emits SARIF for cargo-deny structured config diagnostics", () => {
 	const context = makeTempRepo("render-linter-sarif-cargo-deny-config-");
 


### PR DESCRIPTION
## Summary

This fixes the `cargo-deny` handling that blocked `https://github.com/chalharu/copilot-sandbox-container/pull/284`.

The failing report was not caused by exact duplicate `Cargo.lock` entries. `cargo-deny` was reporting **warning-level `duplicate` diagnostics** because the workspace legitimately resolves multiple versions of the same crate name (for example `block-buffer 0.10.4` and `0.12.0`, `cpufeatures 0.2.17` and `0.3.0`, `sha2 0.10.9` and `0.11.0`).

This PR makes the shared linter respect that warning/error distinction:

- keep **warning-level** `cargo-deny` diagnostics whose code is `duplicate` as visible warnings
- stop those warning-only `duplicate` diagnostics from failing the shared linter result
- surface them in PR comments, SARIF, and the processing summary as warnings instead of failures
- keep failing on advisories, config errors, and every other actionable `cargo-deny` diagnostic
- add regression coverage for the warning-only duplicate case

## Root cause

The source repository's `deny.toml` for PR 284 is:

```toml
[licenses]
version = 2
allow = [
  "AGPL-3.0-only",
  "Apache-2.0",
  "BSD-3-Clause",
  "BSL-1.0",
  "ISC",
  "MIT",
  "Unicode-3.0",
  "Unlicense",
  "Zlib",
]
```

It does **not** define a `[bans]` section, so the repository did not opt into treating duplicate crate versions as a blocking failure.

The current shared linter path was still turning warning-only `duplicate` diagnostics into a failed result, which made Renovate PRs fail even though the repository had not configured duplicates as `deny`.

## Why warning-level `duplicate` is non-blocking here

I agree with the general point that warnings should ideally be fixed. The key distinction here is:

1. **"Should be looked at"** is not the same as **"must fail CI right now"**.
2. In `cargo-deny`, that distinction is part of the documented policy model.
3. A shared linter service should preserve the source repository's configured policy instead of silently escalating it.

### Primary documentation

Upstream `cargo-deny` documentation for the `[bans]` section says:

> The `multiple-versions` field (optional) determines what happens when multiple versions of the same crate are encountered.
>
> - `deny` - Will emit an error for each crate with duplicates and fail the check.
> - `warn` (**default**) - Prints a warning for each crate with duplicates, but does **not** fail the check.
> - `allow` - Ignores duplicate versions of the same crate.

Source:  
https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html#the-multiple-versions-field-optional

Upstream `cargo-deny` documentation also explains the intent of duplicate detection:

> The intention of duplicate detection in cargo-deny is not to "correct" cargo's behavior, but rather to draw your attention to duplicates so that you can make an informed decision about how to handle the situation.

Source:  
https://embarkstudios.github.io/cargo-deny/checks/bans/index.html#use-case---duplicate-version-detection

That matters here because the observed diagnostics are exactly that case: **attention-drawing duplicate-version warnings**, not a configured policy violation.

### Why this shared-service behavior is correct

If linter-service fails the check on warning-only `duplicate` diagnostics, it overrides the source repository's documented `cargo-deny` semantics:

- the repository did **not** configure `[bans] multiple-versions = "deny"`
- upstream says the default is `warn`
- upstream says `warn` does **not** fail the check

So the shared service would be inventing stricter policy than the repository declared.

If the source repository wants duplicate versions to become blocking, the documented and explicit way to do that is to add:

```toml
[bans]
multiple-versions = "deny"
```

That keeps the policy decision in the source repository, where it belongs.

## Why this change is narrowly safe

This PR does **not** make `cargo-deny` warnings generally disappear, and it does **not** make duplicate warnings invisible.

It only special-cases:

- diagnostic code: `duplicate`
- severity: `warning`

Those warning-only duplicates are still emitted to the user-facing reporting surfaces:

- per-linter PR comment details
- uploaded SARIF as warning-level results
- the overall processing summary as a warning-bearing successful run

The implementation still fails on:

- advisory findings from audit-compatible output
- config / parse errors
- non-duplicate diagnostics
- unexpected stderr/stdout content that indicates actionable output

So this is not "ignore warnings broadly"; it is "stop converting one documented non-failing warning class into a failing shared-service result".

## Validation

- focused Node tests for `cargo-deny` result parsing and runner behavior
- `cargo-deny` fixture tests
- critical review after validation