### PR TITLE
chore(renovate): enable lock file maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,9 @@
   ],
   "labels": ["dependencies", "renovate", "renovate-gate-wait-3d"],
   "dependencyDashboard": true,
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "prCreation": "immediate",
   "rebaseWhen": "behind-base-branch",
   "timezone": "Asia/Tokyo",


### PR DESCRIPTION
## Summary
- enable Renovate's `lockFileMaintenance` feature in the root `renovate.json`
- keep the existing Renovate configuration intact and only add the minimal top-level option

## Validation
- `node -e 'const fs=require("node:fs"); const c=JSON.parse(fs.readFileSync("renovate.json","utf8")); if (c.lockFileMaintenance?.enabled !== true) process.exit(1);'`
- `bash renovate/install.sh && bash renovate/run.sh renovate.json` (blocked locally: Docker daemon unavailable)
- `node .github/scripts/run-fixture-tests.js renovate` (blocked locally: Docker daemon unavailable)
