### PR TITLE
fix(rustfmt): count issue files from diff paths

### DIFF
--- a/.github/scripts/render-linter-sarif.js
+++ b/.github/scripts/render-linter-sarif.js
@@ -731,6 +731,8 @@ function buildFallbackResults({
 		configPath,
 		details,
 		linterName,
+		reportedPathRoots,
+		sourceRepositoryPath,
 		targetPaths,
 	});
 	const fallbackPaths =
@@ -768,12 +770,16 @@ function collectFallbackPaths({
 	configPath,
 	details,
 	linterName,
+	reportedPathRoots,
+	sourceRepositoryPath,
 	targetPaths,
 }) {
 	const explicitPaths = extractFallbackPaths({
 		configPath,
 		details,
 		linterName,
+		reportedPathRoots,
+		sourceRepositoryPath,
 		targetPaths,
 	});
 
@@ -788,6 +794,8 @@ function extractFallbackPaths({
 	configPath,
 	details,
 	linterName,
+	reportedPathRoots,
+	sourceRepositoryPath,
 	targetPaths,
 }) {
 	const hook = loadLinterHook({
@@ -802,6 +810,13 @@ function extractFallbackPaths({
 
 	const fallbackPaths = hook.collectFallbackPaths({
 		details,
+		normalizeReportedPath: (reportedPath) =>
+			normalizeReportedPath(
+				sourceRepositoryPath,
+				reportedPath,
+				targetPaths,
+				reportedPathRoots,
+			),
 		targetPaths,
 	});
 

--- a/.github/scripts/render-linter-sarif.test.js
+++ b/.github/scripts/render-linter-sarif.test.js
@@ -537,3 +537,53 @@ test("counts rustfmt issue targets from at-line diff lines instead of echoed che
 		cleanupTempRepo(context.tempDir);
 	}
 });
+
+test("counts rustfmt issue targets from absolute diff lines instead of echoed checked paths", () => {
+	const context = makeTempRepo("render-linter-sarif-rustfmt-absolute-");
+	const selectedFiles = ["src/lib.rs", "src/main.rs"];
+
+	for (const filePath of selectedFiles) {
+		writeFile(path.join(context.repoDir, filePath), "fn demo() {}\n");
+	}
+
+	const details = `${selectedFiles
+		.map((filePath) => `==> rustfmt --check ${filePath}`)
+		.join("\n")}\nDiff in ${path.join(context.repoDir, "src/lib.rs")}:1:\n`;
+
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		`${selectedFiles.join("\n")}\n`,
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			details,
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = renderSarif({
+			configPath: rootConfigPath,
+			installOutcome: "success",
+			linterName: "rustfmt",
+			outputPath: path.join(context.runnerTemp, "rustfmt.sarif"),
+			resultPath: path.join(context.runnerTemp, "linter-result.json"),
+			runOutcome: "success",
+			selectedFilesPath: path.join(context.runnerTemp, "selected-files.txt"),
+			selectOutcome: "success",
+			sourceRepositoryPath: context.repoDir,
+		});
+
+		assert.equal(report.targetStats.issue_target_count, 1);
+		assert.equal(report.targetStats.passed_target_count, 1);
+		assert.equal(report.sarif.runs[0].results.length, 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"src/lib.rs",
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/rustfmt/render-linter-sarif.js
+++ b/rustfmt/render-linter-sarif.js
@@ -1,4 +1,8 @@
-function collectFallbackPaths({ details, targetPaths }) {
+function collectFallbackPaths({
+	details,
+	normalizeReportedPath: normalizePath = (reportedPath) => reportedPath,
+	targetPaths,
+}) {
 	const targetSet = new Set(targetPaths);
 	const fallbackPaths = [];
 
@@ -6,15 +10,16 @@ function collectFallbackPaths({ details, targetPaths }) {
 		/^Diff in (?<filePath>.+?)(?::\d+| at line \d+):\s*$/gmu,
 	)) {
 		const filePath = match.groups?.filePath;
+		const normalizedPath = filePath ? normalizePath(filePath) : null;
 		if (
-			!filePath ||
-			!targetSet.has(filePath) ||
-			fallbackPaths.includes(filePath)
+			!normalizedPath ||
+			!targetSet.has(normalizedPath) ||
+			fallbackPaths.includes(normalizedPath)
 		) {
 			continue;
 		}
 
-		fallbackPaths.push(filePath);
+		fallbackPaths.push(normalizedPath);
 	}
 
 	return fallbackPaths;


### PR DESCRIPTION
## Summary
- normalize rustfmt fallback diff paths before matching selected targets
- thread shared path normalization into linter-specific fallback extraction
- add regression coverage for absolute `Diff in ...` paths

## Testing
- `node --test .github/scripts/render-linter-sarif.test.js .github/scripts/render-linter-report.test.js rustfmt/render-linter-sarif.test.js`
- `node .github/scripts/run-fixture-tests.js rustfmt`