### PR TITLE
feat(cargo-coupling): add shared linter

### DIFF
--- a/.github/linter-service.schema.json
+++ b/.github/linter-service.schema.json
@@ -1,279 +1,264 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "linter-service .github/linter-service.yaml",
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "global": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "exclude_paths": {
-          "$ref": "#/$defs/nonEmptyStringArray"
-        }
-      }
-    },
-    "linters": {
-      "type": "object",
-      "propertyNames": {
-        "$ref": "#/$defs/knownLinterName"
-      },
-      "properties": {
-        "lizard": {
-          "$ref": "#/$defs/lizardLinterConfig"
-        },
-        "textlint": {
-          "$ref": "#/$defs/textlintLinterConfig"
-        },
-        "cargo-coupling": {
-          "$ref": "#/$defs/cargoCouplingLinterConfig"
-        }
-      },
-      "additionalProperties": {
-        "$ref": "#/$defs/linterConfig"
-      }
-    }
-  },
-  "$defs": {
-    "knownLinterName": {
-      "type": "string",
-      "enum": [
-        "actionlint",
-        "ghalint",
-        "hadolint",
-        "helmlint",
-        "lizard",
-        "trivy",
-        "dotenv-linter",
-        "spectral",
-        "yamllint",
-        "yamlfmt",
-        "markdownlint-cli2",
-        "renovate",
-        "textlint",
-        "ruff",
-        "rustfmt",
-        "cargo-clippy",
-        "cargo-deny",
-        "cargo-coupling",
-        "taplo",
-        "biome",
-        "editorconfig-checker",
-        "shellcheck",
-        "zizmor"
-      ]
-    },
-    "nonEmptyString": {
-      "type": "string",
-      "pattern": "\\S"
-    },
-    "nonEmptyStringArray": {
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/nonEmptyString"
-      }
-    },
-    "linterConfig": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "disabled": {
-          "type": "boolean"
-        },
-        "exclude_paths": {
-          "$ref": "#/$defs/nonEmptyStringArray"
-        }
-      }
-    },
-    "lizardLanguage": {
-      "type": "string",
-      "enum": [
-        "cpp",
-        "csharp",
-        "erlang",
-        "fortran",
-        "gdscript",
-        "go",
-        "java",
-        "javascript",
-        "kotlin",
-        "lua",
-        "objectivec",
-        "perl",
-        "php",
-        "plsql",
-        "python",
-        "r",
-        "ruby",
-        "rust",
-        "scala",
-        "solidity",
-        "st",
-        "swift",
-        "ttcn",
-        "typescript",
-        "vue",
-        "zig"
-      ]
-    },
-    "lizardLanguageArray": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/$defs/lizardLanguage"
-      }
-    },
-    "lizardThresholdValue": {
-      "type": "integer",
-      "minimum": 0
-    },
-    "lizardThresholdConfig": {
-      "type": "object",
-      "additionalProperties": false,
-      "minProperties": 1,
-      "properties": {
-        "nloc": {
-          "$ref": "#/$defs/lizardThresholdValue"
-        },
-        "cyclomatic_complexity": {
-          "$ref": "#/$defs/lizardThresholdValue"
-        },
-        "token_count": {
-          "$ref": "#/$defs/lizardThresholdValue"
-        },
-        "parameter_count": {
-          "$ref": "#/$defs/lizardThresholdValue"
-        },
-        "length": {
-          "$ref": "#/$defs/lizardThresholdValue"
-        }
-      }
-    },
-    "lizardLanguageThresholds": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/$defs/lizardThresholdConfig"
-      },
-      "minProperties": 1,
-      "propertyNames": {
-        "$ref": "#/$defs/lizardLanguage"
-      }
-    },
-    "lizardLinterConfig": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "disabled": {
-          "type": "boolean"
-        },
-        "exclude_paths": {
-          "$ref": "#/$defs/nonEmptyStringArray"
-        },
-        "languages": {
-          "$ref": "#/$defs/lizardLanguageArray"
-        },
-        "thresholds": {
-          "$ref": "#/$defs/lizardLanguageThresholds"
-        }
-      },
-      "allOf": [
-        {
-          "if": {
-            "properties": {
-              "disabled": {
-                "const": false
-              }
-            },
-            "required": [
-              "disabled"
-            ]
-          },
-          "then": {
-            "required": [
-              "languages"
-            ]
-          }
-        }
-      ]
-    },
-    "textlintPresetPackage": {
-      "type": "string",
-      "pattern": "^(?:@[a-z0-9][a-z0-9._-]*\\/)?textlint-rule-preset-[a-z0-9][a-z0-9._-]*@\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$"
-    },
-    "textlintLinterConfig": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "disabled": {
-          "type": "boolean"
-        },
-        "exclude_paths": {
-          "$ref": "#/$defs/nonEmptyStringArray"
-        },
-        "preset_packages": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/textlintPresetPackage"
-          }
-        }
-      },
-      "allOf": [
-        {
-          "if": {
-            "properties": {
-              "disabled": {
-                "const": false
-              }
-            },
-            "required": [
-              "disabled"
-            ]
-          },
-          "then": {
-            "required": [
-              "preset_packages"
-            ]
-          }
-        }
-      ]
-    },
-    "cargoCouplingMinGrade": {
-      "type": "string",
-      "enum": [
-        "S",
-        "A",
-        "B",
-        "C",
-        "D",
-        "F"
-      ]
-    },
-    "cargoCouplingThreshold": {
-      "type": "integer",
-      "minimum": 0
-    },
-    "cargoCouplingLinterConfig": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "disabled": {
-          "type": "boolean"
-        },
-        "exclude_paths": {
-          "$ref": "#/$defs/nonEmptyStringArray"
-        },
-        "min_grade": {
-          "$ref": "#/$defs/cargoCouplingMinGrade"
-        },
-        "max_critical": {
-          "$ref": "#/$defs/cargoCouplingThreshold"
-        },
-        "max_circular": {
-          "$ref": "#/$defs/cargoCouplingThreshold"
-        }
-      }
-    }
-  }
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"title": "linter-service .github/linter-service.yaml",
+	"type": "object",
+	"additionalProperties": false,
+	"properties": {
+		"global": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"exclude_paths": {
+					"$ref": "#/$defs/nonEmptyStringArray"
+				}
+			}
+		},
+		"linters": {
+			"type": "object",
+			"propertyNames": {
+				"$ref": "#/$defs/knownLinterName"
+			},
+			"properties": {
+				"lizard": {
+					"$ref": "#/$defs/lizardLinterConfig"
+				},
+				"textlint": {
+					"$ref": "#/$defs/textlintLinterConfig"
+				},
+				"cargo-coupling": {
+					"$ref": "#/$defs/cargoCouplingLinterConfig"
+				}
+			},
+			"additionalProperties": {
+				"$ref": "#/$defs/linterConfig"
+			}
+		}
+	},
+	"$defs": {
+		"knownLinterName": {
+			"type": "string",
+			"enum": [
+				"actionlint",
+				"ghalint",
+				"hadolint",
+				"helmlint",
+				"lizard",
+				"trivy",
+				"dotenv-linter",
+				"spectral",
+				"yamllint",
+				"yamlfmt",
+				"markdownlint-cli2",
+				"renovate",
+				"textlint",
+				"ruff",
+				"rustfmt",
+				"cargo-clippy",
+				"cargo-deny",
+				"cargo-coupling",
+				"taplo",
+				"biome",
+				"editorconfig-checker",
+				"shellcheck",
+				"zizmor"
+			]
+		},
+		"nonEmptyString": {
+			"type": "string",
+			"pattern": "\\S"
+		},
+		"nonEmptyStringArray": {
+			"type": "array",
+			"items": {
+				"$ref": "#/$defs/nonEmptyString"
+			}
+		},
+		"linterConfig": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"disabled": {
+					"type": "boolean"
+				},
+				"exclude_paths": {
+					"$ref": "#/$defs/nonEmptyStringArray"
+				}
+			}
+		},
+		"lizardLanguage": {
+			"type": "string",
+			"enum": [
+				"cpp",
+				"csharp",
+				"erlang",
+				"fortran",
+				"gdscript",
+				"go",
+				"java",
+				"javascript",
+				"kotlin",
+				"lua",
+				"objectivec",
+				"perl",
+				"php",
+				"plsql",
+				"python",
+				"r",
+				"ruby",
+				"rust",
+				"scala",
+				"solidity",
+				"st",
+				"swift",
+				"ttcn",
+				"typescript",
+				"vue",
+				"zig"
+			]
+		},
+		"lizardLanguageArray": {
+			"type": "array",
+			"minItems": 1,
+			"uniqueItems": true,
+			"items": {
+				"$ref": "#/$defs/lizardLanguage"
+			}
+		},
+		"lizardThresholdValue": {
+			"type": "integer",
+			"minimum": 0
+		},
+		"lizardThresholdConfig": {
+			"type": "object",
+			"additionalProperties": false,
+			"minProperties": 1,
+			"properties": {
+				"nloc": {
+					"$ref": "#/$defs/lizardThresholdValue"
+				},
+				"cyclomatic_complexity": {
+					"$ref": "#/$defs/lizardThresholdValue"
+				},
+				"token_count": {
+					"$ref": "#/$defs/lizardThresholdValue"
+				},
+				"parameter_count": {
+					"$ref": "#/$defs/lizardThresholdValue"
+				},
+				"length": {
+					"$ref": "#/$defs/lizardThresholdValue"
+				}
+			}
+		},
+		"lizardLanguageThresholds": {
+			"type": "object",
+			"additionalProperties": {
+				"$ref": "#/$defs/lizardThresholdConfig"
+			},
+			"minProperties": 1,
+			"propertyNames": {
+				"$ref": "#/$defs/lizardLanguage"
+			}
+		},
+		"lizardLinterConfig": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"disabled": {
+					"type": "boolean"
+				},
+				"exclude_paths": {
+					"$ref": "#/$defs/nonEmptyStringArray"
+				},
+				"languages": {
+					"$ref": "#/$defs/lizardLanguageArray"
+				},
+				"thresholds": {
+					"$ref": "#/$defs/lizardLanguageThresholds"
+				}
+			},
+			"allOf": [
+				{
+					"if": {
+						"properties": {
+							"disabled": {
+								"const": false
+							}
+						},
+						"required": ["disabled"]
+					},
+					"then": {
+						"required": ["languages"]
+					}
+				}
+			]
+		},
+		"textlintPresetPackage": {
+			"type": "string",
+			"pattern": "^(?:@[a-z0-9][a-z0-9._-]*\\/)?textlint-rule-preset-[a-z0-9][a-z0-9._-]*@\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$"
+		},
+		"textlintLinterConfig": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"disabled": {
+					"type": "boolean"
+				},
+				"exclude_paths": {
+					"$ref": "#/$defs/nonEmptyStringArray"
+				},
+				"preset_packages": {
+					"type": "array",
+					"minItems": 1,
+					"items": {
+						"$ref": "#/$defs/textlintPresetPackage"
+					}
+				}
+			},
+			"allOf": [
+				{
+					"if": {
+						"properties": {
+							"disabled": {
+								"const": false
+							}
+						},
+						"required": ["disabled"]
+					},
+					"then": {
+						"required": ["preset_packages"]
+					}
+				}
+			]
+		},
+		"cargoCouplingMinGrade": {
+			"type": "string",
+			"enum": ["S", "A", "B", "C", "D", "F"]
+		},
+		"cargoCouplingThreshold": {
+			"type": "integer",
+			"minimum": 0
+		},
+		"cargoCouplingLinterConfig": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"disabled": {
+					"type": "boolean"
+				},
+				"exclude_paths": {
+					"$ref": "#/$defs/nonEmptyStringArray"
+				},
+				"min_grade": {
+					"$ref": "#/$defs/cargoCouplingMinGrade"
+				},
+				"max_critical": {
+					"$ref": "#/$defs/cargoCouplingThreshold"
+				},
+				"max_circular": {
+					"$ref": "#/$defs/cargoCouplingThreshold"
+				}
+			}
+		}
+	}
 }

--- a/.github/linter-service.schema.json
+++ b/.github/linter-service.schema.json
@@ -24,6 +24,9 @@
         },
         "textlint": {
           "$ref": "#/$defs/textlintLinterConfig"
+        },
+        "cargo-coupling": {
+          "$ref": "#/$defs/cargoCouplingLinterConfig"
         }
       },
       "additionalProperties": {
@@ -52,6 +55,7 @@
         "rustfmt",
         "cargo-clippy",
         "cargo-deny",
+        "cargo-coupling",
         "taplo",
         "biome",
         "editorconfig-checker",
@@ -234,6 +238,42 @@
           }
         }
       ]
+    },
+    "cargoCouplingMinGrade": {
+      "type": "string",
+      "enum": [
+        "S",
+        "A",
+        "B",
+        "C",
+        "D",
+        "F"
+      ]
+    },
+    "cargoCouplingThreshold": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "cargoCouplingLinterConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "disabled": {
+          "type": "boolean"
+        },
+        "exclude_paths": {
+          "$ref": "#/$defs/nonEmptyStringArray"
+        },
+        "min_grade": {
+          "$ref": "#/$defs/cargoCouplingMinGrade"
+        },
+        "max_critical": {
+          "$ref": "#/$defs/cargoCouplingThreshold"
+        },
+        "max_circular": {
+          "$ref": "#/$defs/cargoCouplingThreshold"
+        }
+      }
     }
   }
 }

--- a/.github/scripts/installer-version-pins.test.js
+++ b/.github/scripts/installer-version-pins.test.js
@@ -290,15 +290,19 @@ test("cargo-coupling Dockerfile.full uses renovate-managed pinned build inputs",
 	);
 	assert.ok(
 		dockerfile.indexOf("ARG CARGO_COUPLING_BUILD_BASE_IMAGE=") <
-			dockerfile.indexOf("FROM ${CARGO_COUPLING_BUILD_BASE_IMAGE} AS chef"),
+			dockerfile.indexOf(`FROM \${CARGO_COUPLING_BUILD_BASE_IMAGE} AS chef`),
 		"build base image ARG must be declared before its FROM",
 	);
 	assert.ok(
 		dockerfile.indexOf("ARG CARGO_COUPLING_RUNTIME_BASE_IMAGE=") <
 			dockerfile.indexOf(
-				"FROM ${CARGO_COUPLING_RUNTIME_BASE_IMAGE} AS runtime",
+				`FROM \${CARGO_COUPLING_RUNTIME_BASE_IMAGE} AS runtime`,
 			),
 		"runtime base image ARG must be declared before its FROM",
+	);
+	assert.match(
+		dockerfile,
+		/HEALTHCHECK --interval=5m --timeout=3s --start-period=5s --retries=1 CMD \["\/app\/cargo-coupling", "--help"\]/u,
 	);
 	assert.match(
 		dockerfile,

--- a/.github/scripts/installer-version-pins.test.js
+++ b/.github/scripts/installer-version-pins.test.js
@@ -84,6 +84,16 @@ const installerExpectations = [
 		],
 	},
 	{
+		path: "cargo-coupling/install.sh",
+		required: [
+			/# renovate: datasource=github-tags depName=nwiizo\/cargo-coupling/u,
+			/cargo_coupling_version="[^"\n]+"/u,
+			/cargo_coupling_source_archive_sha256="[a-f0-9]{64}"/u,
+			/archive\/refs\/tags\/\$\{cargo_coupling_version\}\.tar\.gz/u,
+			/CARGO_COUPLING_SOURCE_ARCHIVE_SHA256:-\$cargo_coupling_source_archive_sha256/u,
+		],
+	},
+	{
 		path: "cargo-deny/install.sh",
 		required: [
 			/# renovate: datasource=rust depName=rust versioning=semver/u,
@@ -213,7 +223,10 @@ test("renovate manages installer pins with a three day hold", () => {
 				manager.customType === "regex" &&
 				Array.isArray(manager.managerFilePatterns) &&
 				manager.managerFilePatterns.includes("/(^|/)[^/]+/install\\.sh$/") &&
-				manager.managerFilePatterns.includes("/(^|/)renovate/Dockerfile$/"),
+				manager.managerFilePatterns.includes("/(^|/)renovate/Dockerfile$/") &&
+				manager.managerFilePatterns.includes(
+					"/(^|/)cargo-coupling/Dockerfile\\.full$/",
+				),
 		),
 	);
 	assert.ok(
@@ -241,6 +254,44 @@ test("renovate Dockerfile uses a renovate-managed pinned slim base image", () =>
 		/ARG RENOVATE_BASE_IMAGE=docker\.io\/library\/node:24-bookworm-slim@sha256:[a-f0-9]{64}/u,
 	);
 	assert.match(dockerfile, /FROM \$\{RENOVATE_BASE_IMAGE\}/u);
+});
+
+test("cargo-coupling Dockerfile.full uses renovate-managed pinned build inputs", () => {
+	const dockerfile = fs.readFileSync(
+		path.join(repoRoot, "cargo-coupling", "Dockerfile.full"),
+		"utf8",
+	);
+
+	assert.match(
+		dockerfile,
+		/# renovate: datasource=docker depName=library\/rust versioning=docker/u,
+	);
+	assert.match(
+		dockerfile,
+		/ARG CARGO_COUPLING_BUILD_BASE_IMAGE=docker\.io\/library\/rust:slim-bookworm@sha256:[a-f0-9]{64}/u,
+	);
+	assert.match(dockerfile, /# renovate: datasource=crate depName=cargo-chef/u);
+	assert.match(dockerfile, /ARG CARGO_CHEF_VERSION=\d+\.\d+\.\d+/u);
+	assert.match(
+		dockerfile,
+		/cargo install cargo-chef --locked --version \$\{CARGO_CHEF_VERSION\}/u,
+	);
+	assert.match(
+		dockerfile,
+		/FROM \$\{CARGO_COUPLING_BUILD_BASE_IMAGE\} AS chef/u,
+	);
+	assert.match(
+		dockerfile,
+		/# renovate: datasource=docker depName=library\/debian versioning=docker/u,
+	);
+	assert.match(
+		dockerfile,
+		/ARG CARGO_COUPLING_RUNTIME_BASE_IMAGE=docker\.io\/library\/debian:bookworm-slim@sha256:[a-f0-9]{64}/u,
+	);
+	assert.match(
+		dockerfile,
+		/FROM \$\{CARGO_COUPLING_RUNTIME_BASE_IMAGE\} AS runtime/u,
+	);
 });
 
 test("renovate enables npm package manifest updates", () => {
@@ -355,7 +406,7 @@ test("renovate textlint preset regex matches all YAML preset packages", () => {
 	]);
 });
 
-test("renovate installer regex matches both Renovate and the pinned base image", () => {
+test("renovate installer regex matches installer versions and pinned Docker base images", () => {
 	const config = JSON.parse(
 		fs.readFileSync(path.join(repoRoot, "renovate.json"), "utf8"),
 	);
@@ -364,12 +415,23 @@ test("renovate installer regex matches both Renovate and the pinned base image",
 			candidate.customType === "regex" &&
 			Array.isArray(candidate.managerFilePatterns) &&
 			candidate.managerFilePatterns.includes("/(^|/)[^/]+/install\\.sh$/") &&
-			candidate.managerFilePatterns.includes("/(^|/)renovate/Dockerfile$/"),
+			candidate.managerFilePatterns.includes("/(^|/)renovate/Dockerfile$/") &&
+			candidate.managerFilePatterns.includes(
+				"/(^|/)cargo-coupling/Dockerfile\\.full$/",
+			),
 	);
 
 	assert.ok(manager, "expected installer regex custom manager");
 	assert.ok(Array.isArray(manager.matchStrings), "expected regex matchStrings");
 
+	const cargoCouplingInstallScript = fs.readFileSync(
+		path.join(repoRoot, "cargo-coupling", "install.sh"),
+		"utf8",
+	);
+	const cargoCouplingDockerfile = fs.readFileSync(
+		path.join(repoRoot, "cargo-coupling", "Dockerfile.full"),
+		"utf8",
+	);
 	const installScript = fs.readFileSync(
 		path.join(repoRoot, "renovate", "install.sh"),
 		"utf8",
@@ -380,6 +442,12 @@ test("renovate installer regex matches both Renovate and the pinned base image",
 	);
 	const matches = manager.matchStrings
 		.flatMap((pattern) => [
+			...cargoCouplingInstallScript.matchAll(
+				createJavaScriptRegExpFromRenovatePattern(pattern),
+			),
+			...cargoCouplingDockerfile.matchAll(
+				createJavaScriptRegExpFromRenovatePattern(pattern),
+			),
 			...installScript.matchAll(
 				createJavaScriptRegExpFromRenovatePattern(pattern),
 			),
@@ -387,12 +455,20 @@ test("renovate installer regex matches both Renovate and the pinned base image",
 				createJavaScriptRegExpFromRenovatePattern(pattern),
 			),
 		])
-		.map(({ groups }) => `${groups.depName}@${groups.currentValue}`);
+		.map(({ groups }) => `${groups.depName}@${groups.currentValue}`)
+		.sort();
 
-	assert.deepEqual(matches, [
-		"renovate@43.104.4",
-		"library/node@docker.io/library/node:24-bookworm-slim@sha256:b506e7321f176aae77317f99d67a24b272c1f09f1d10f1761f2773447d8da26c",
-	]);
+	assert.deepEqual(
+		matches,
+		[
+			"cargo-chef@0.1.77",
+			"library/debian@docker.io/library/debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252",
+			"library/node@docker.io/library/node:24-bookworm-slim@sha256:b506e7321f176aae77317f99d67a24b272c1f09f1d10f1761f2773447d8da26c",
+			"library/rust@docker.io/library/rust:slim-bookworm@sha256:caaf9ca7acd474892186860307d6f28e51fdbc1a4eada459fcff81517cf46a36",
+			"nwiizo/cargo-coupling@v0.3.2",
+			"renovate@43.104.4",
+		].sort(),
+	);
 });
 
 test("root shared Node dependencies use exact version pins", () => {

--- a/.github/scripts/installer-version-pins.test.js
+++ b/.github/scripts/installer-version-pins.test.js
@@ -288,6 +288,18 @@ test("cargo-coupling Dockerfile.full uses renovate-managed pinned build inputs",
 		dockerfile,
 		/ARG CARGO_COUPLING_RUNTIME_BASE_IMAGE=docker\.io\/library\/debian:bookworm-slim@sha256:[a-f0-9]{64}/u,
 	);
+	assert.ok(
+		dockerfile.indexOf("ARG CARGO_COUPLING_BUILD_BASE_IMAGE=") <
+			dockerfile.indexOf("FROM ${CARGO_COUPLING_BUILD_BASE_IMAGE} AS chef"),
+		"build base image ARG must be declared before its FROM",
+	);
+	assert.ok(
+		dockerfile.indexOf("ARG CARGO_COUPLING_RUNTIME_BASE_IMAGE=") <
+			dockerfile.indexOf(
+				"FROM ${CARGO_COUPLING_RUNTIME_BASE_IMAGE} AS runtime",
+			),
+		"runtime base image ARG must be declared before its FROM",
+	);
 	assert.match(
 		dockerfile,
 		/FROM \$\{CARGO_COUPLING_RUNTIME_BASE_IMAGE\} AS runtime/u,

--- a/.github/scripts/installer-version-pins.test.js
+++ b/.github/scripts/installer-version-pins.test.js
@@ -282,11 +282,11 @@ test("cargo-coupling Dockerfile.full uses renovate-managed pinned build inputs",
 	);
 	assert.match(
 		dockerfile,
-		/# renovate: datasource=docker depName=library\/debian versioning=docker/u,
+		/# renovate: datasource=docker depName=library\/rust versioning=docker/u,
 	);
 	assert.match(
 		dockerfile,
-		/ARG CARGO_COUPLING_RUNTIME_BASE_IMAGE=docker\.io\/library\/debian:bookworm-slim@sha256:[a-f0-9]{64}/u,
+		/ARG CARGO_COUPLING_RUNTIME_BASE_IMAGE=docker\.io\/library\/rust:slim-bookworm@sha256:[a-f0-9]{64}/u,
 	);
 	assert.ok(
 		dockerfile.indexOf("ARG CARGO_COUPLING_BUILD_BASE_IMAGE=") <
@@ -474,8 +474,8 @@ test("renovate installer regex matches installer versions and pinned Docker base
 		matches,
 		[
 			"cargo-chef@0.1.77",
-			"library/debian@docker.io/library/debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252",
 			"library/node@docker.io/library/node:24-bookworm-slim@sha256:b506e7321f176aae77317f99d67a24b272c1f09f1d10f1761f2773447d8da26c",
+			"library/rust@docker.io/library/rust:slim-bookworm@sha256:caaf9ca7acd474892186860307d6f28e51fdbc1a4eada459fcff81517cf46a36",
 			"library/rust@docker.io/library/rust:slim-bookworm@sha256:caaf9ca7acd474892186860307d6f28e51fdbc1a4eada459fcff81517cf46a36",
 			"nwiizo/cargo-coupling@v0.3.2",
 			"renovate@43.104.4",

--- a/.github/scripts/linter-service-config.test.js
+++ b/.github/scripts/linter-service-config.test.js
@@ -656,6 +656,111 @@ test("supports textlint preset_packages when textlint is enabled", () => {
 	}
 });
 
+test("supports cargo-coupling quality gate thresholds", () => {
+	const context = makeTempRepo();
+
+	writeLinterServiceConfig(context.repoDir, {
+		linters: {
+			"cargo-coupling": {
+				max_circular: 2,
+				max_critical: 1,
+				min_grade: "C",
+			},
+		},
+	});
+
+	try {
+		const config = loadLinterServiceConfig({
+			repositoryPath: context.repoDir,
+		});
+
+		assert.deepEqual(getLinterConfig(config, "cargo-coupling"), {
+			disabled: false,
+			disabled_explicit: false,
+			exclude_paths: [],
+			max_circular: 2,
+			max_critical: 1,
+			min_grade: "C",
+		});
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("defaults cargo-coupling thresholds when omitted", () => {
+	const context = makeTempRepo();
+
+	writeLinterServiceConfig(
+		context.repoDir,
+		{
+			linters: {
+				"cargo-coupling": {},
+			},
+		},
+		"linter-service.json",
+	);
+
+	try {
+		const config = loadLinterServiceConfig({
+			repositoryPath: context.repoDir,
+		});
+
+		assert.equal(getLinterConfig(config, "cargo-coupling").min_grade, "B");
+		assert.equal(getLinterConfig(config, "cargo-coupling").max_critical, 0);
+		assert.equal(getLinterConfig(config, "cargo-coupling").max_circular, 0);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("rejects invalid cargo-coupling grade thresholds", () => {
+	const context = makeTempRepo();
+
+	writeLinterServiceConfig(context.repoDir, {
+		linters: {
+			"cargo-coupling": {
+				min_grade: "Z",
+			},
+		},
+	});
+
+	try {
+		assert.throws(
+			() =>
+				loadLinterServiceConfig({
+					repositoryPath: context.repoDir,
+				}),
+			/must be one of/u,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("rejects negative cargo-coupling thresholds", () => {
+	const context = makeTempRepo();
+
+	writeLinterServiceConfig(context.repoDir, {
+		linters: {
+			"cargo-coupling": {
+				max_critical: -1,
+			},
+		},
+	});
+
+	try {
+		assert.throws(
+			() =>
+				loadLinterServiceConfig({
+					repositoryPath: context.repoDir,
+				}),
+			/non-negative integer/u,
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
 test("requires textlint preset_packages when textlint is enabled", () => {
 	const context = makeTempRepo();
 

--- a/.github/scripts/select-lint-targets.test.js
+++ b/.github/scripts/select-lint-targets.test.js
@@ -388,6 +388,72 @@ test("lizard config trigger expands to repository files even when config paths a
 		cleanupTempRepo(context.tempDir);
 	}
 });
+
+test("cargo-coupling threshold config trigger expands to repository Rust files", () => {
+	const context = makeTempRepo();
+	const contextPath = path.join(context.runnerTemp, "context.json");
+	const linterServicePath = path.join(__dirname, "..", "..");
+	const outputPath = path.join(context.runnerTemp, "selected-files.txt");
+	const patternPath = path.join(context.runnerTemp, "patterns.txt");
+
+	fs.mkdirSync(path.join(context.repoDir, "src"), { recursive: true });
+	writeLinterServiceConfig(
+		context.repoDir,
+		[
+			"global:",
+			"  exclude_paths:",
+			'    - ".github/**"',
+			"",
+			"linters:",
+			'  "cargo-coupling":',
+			"    min_grade: C",
+			"",
+		].join("\n"),
+	);
+	fs.writeFileSync(
+		path.join(context.repoDir, "Cargo.toml"),
+		'[package]\nname = "fixture"\nversion = "0.1.0"\nedition = "2021"\n',
+		"utf8",
+	);
+	fs.writeFileSync(
+		path.join(context.repoDir, "src", "lib.rs"),
+		"pub fn ok() {}\n",
+		"utf8",
+	);
+	fs.writeFileSync(
+		path.join(context.repoDir, "src", "main.rs"),
+		"fn main() {}\n",
+		"utf8",
+	);
+	fs.writeFileSync(
+		contextPath,
+		JSON.stringify({
+			changed_files: [".github/linter-service.yaml"],
+		}),
+		"utf8",
+	);
+	fs.writeFileSync(patternPath, "\\.(?:rs)$\n", "utf8");
+
+	try {
+		const result = runFromEnv({
+			CONTEXT_PATH: contextPath,
+			LINTER_NAME: "cargo-coupling",
+			LINTER_SERVICE_PATH: linterServicePath,
+			OUTPUT_PATH: outputPath,
+			PATTERN_PATH: patternPath,
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.deepEqual(result.selectedFiles, ["src/lib.rs", "src/main.rs"]);
+		assert.equal(
+			fs.readFileSync(outputPath, "utf8"),
+			"src/lib.rs\nsrc/main.rs\n",
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
 test("listRepositoryFiles skips directory symlinks in filesystem fallback mode", () => {
 	const context = makeTempRepo();
 	const realDir = path.join(context.repoDir, "docs");

--- a/.github/scripts/validate-linter-service-config.test.js
+++ b/.github/scripts/validate-linter-service-config.test.js
@@ -86,6 +86,11 @@ test("accepts supported linter-service config fields", () => {
 					exclude_paths: ["docs/drafts/**"],
 					preset_packages: ["textlint-rule-preset-ja-technical-writing@12.0.2"],
 				},
+				"cargo-coupling": {
+					max_circular: 1,
+					max_critical: 0,
+					min_grade: "B",
+				},
 				yamllint: {
 					disabled: true,
 					exclude_paths: ["fixtures/**"],
@@ -101,6 +106,97 @@ test("accepts supported linter-service config fields", () => {
 				configPath,
 				schemaPath: rootSchemaPath,
 			}),
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("accepts cargo-coupling quality gate thresholds", () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "linter-service-schema-"),
+	);
+	const configPath = path.join(tempDir, "linter-service.yaml");
+
+	writeConfig(configPath, {
+		linters: {
+			"cargo-coupling": {
+				max_circular: 1,
+				max_critical: 2,
+				min_grade: "C",
+			},
+		},
+	});
+
+	try {
+		const report = validateLinterServiceConfig({
+			configPath,
+			schemaPath: rootSchemaPath,
+		});
+
+		assert.deepEqual(report.normalizedConfig.linters["cargo-coupling"], {
+			disabled: false,
+			disabled_explicit: false,
+			exclude_paths: [],
+			max_circular: 1,
+			max_critical: 2,
+			min_grade: "C",
+		});
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("rejects unsupported cargo-coupling grades", () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "linter-service-schema-"),
+	);
+	const configPath = path.join(tempDir, "linter-service.yaml");
+
+	writeConfig(configPath, {
+		linters: {
+			"cargo-coupling": {
+				min_grade: "Z",
+			},
+		},
+	});
+
+	try {
+		assert.throws(
+			() =>
+				validateLinterServiceConfig({
+					configPath,
+					schemaPath: rootSchemaPath,
+				}),
+			/allowed values|must be one of/u,
+		);
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("rejects negative cargo-coupling thresholds", () => {
+	const tempDir = fs.mkdtempSync(
+		path.join(os.tmpdir(), "linter-service-schema-"),
+	);
+	const configPath = path.join(tempDir, "linter-service.yaml");
+
+	writeConfig(configPath, {
+		linters: {
+			"cargo-coupling": {
+				max_critical: -1,
+			},
+		},
+	});
+
+	try {
+		assert.throws(
+			() =>
+				validateLinterServiceConfig({
+					configPath,
+					schemaPath: rootSchemaPath,
+				}),
+			/must be >= 0|minimum/u,
 		);
 	} finally {
 		fs.rmSync(tempDir, { force: true, recursive: true });

--- a/.github/scripts/validate-linters-config.test.js
+++ b/.github/scripts/validate-linters-config.test.js
@@ -34,6 +34,12 @@ test("accepts the repository linters.json", () => {
 	assert.equal(report.schemaPath, rootSchemaPath);
 });
 
+test("cargo-coupling is isolated in the repository linters.json", () => {
+	const config = JSON.parse(fs.readFileSync(rootConfigPath, "utf8"));
+
+	assert.equal(config.linters["cargo-coupling"].isolated, true);
+});
+
 test("accepts supported optional linter metadata", () => {
 	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "linters-schema-"));
 	const configPath = path.join(tempDir, "linters.json");

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ GitHub App Webhook を Cloudflare Worker が受け、この repository へ
 | `actionlint` | `.github/workflows/*.yml`, `.github/workflows/*.yaml` | `.github/actionlint.yaml`, `.github/actionlint.yml` | ✅ |
 | `biome` | `*.js`, `*.jsx`, `*.ts`, `*.tsx`, `*.json`, `*.jsonc`, `*.cjs`, `*.cts`, `*.mjs`, `*.mts` | `biome.json`, `biome.jsonc`, `.biome.json`, `.biome.jsonc` | ✅ |
 | `cargo-clippy` | `*.rs` | `clippy.toml`, `.clippy.toml`, `rust-toolchain.toml`, `rust-toolchain` | ✅ |
+| `cargo-coupling` | `*.rs` | 対象 `Cargo.toml` の親方向の `.coupling.toml`, `coupling.toml`、repo root の `.github/linter-service.yaml`, `.github/linter-service.yml`, `.github/linter-service.json` | ✅ |
 | `cargo-deny` | `Cargo.toml`, `Cargo.lock`, `deny.toml`, `.cargo/config`, `.cargo/config.toml` | 対象 `Cargo.toml` の親方向の `deny.toml` | ✅ |
 | `dotenv-linter` | `.env`, `.env.*` | なし | ✅ |
 | `editorconfig-checker` | upstream default exclude に含まれない file | 対象 file の親 directory ごとの `.editorconfig`, repo root の `.editorconfig-checker.json`, `.ecrc` | ✅ |
@@ -91,6 +92,7 @@ GitHub App Webhook を Cloudflare Worker が受け、この repository へ
 | linter | 実行メモ |
 | --- | --- |
 | `cargo-clippy` | 最寄り `Cargo.toml` 基準の package 単位実行、`.cargo/config*`, private registry, private git dependency は未対応。 |
+| `cargo-coupling` | checksum-verified な upstream source tarball と repo 同梱の `Dockerfile.full` から local image を build して `--json --no-git` 実行し、quality gate は `linters.cargo-coupling.*` で `min_grade=B`, `max_critical=0`, `max_circular=0` を上書きできる。`.cargo/config*` は未対応。 |
 | `cargo-deny` | 最寄り `Cargo.toml` 基準の package 単位実行、`.cargo/config*`, private registry, private git dependency は未対応。 |
 | `dotenv-linter` | changed `.env` file への upstream default checks 直接適用、`--schema` と ignore-checks 注入は未対応。 |
 | `editorconfig-checker` | `PassedFiles` 制限、`NoColor` 強制。 |
@@ -138,6 +140,10 @@ linters:
   textlint:
     preset_packages:
       - "textlint-rule-preset-ja-technical-writing@12.0.2"
+  cargo-coupling:
+    min_grade: B
+    max_critical: 0
+    max_circular: 0
   zizmor:
     disabled: true
 ```
@@ -147,6 +153,9 @@ linters:
 | `global.exclude_paths` | 全 linter | repo-relative glob pattern。全 linter への適用。 |
 | `linters.<name>.disabled` | 個別 linter | `true` で選択対象外。`false` は明示的な無効化解除として扱う。 |
 | `linters.<name>.exclude_paths` | 個別 linter | repo-relative glob pattern。global exclude との併用。 |
+| `linters.cargo-coupling.min_grade` | `cargo-coupling` | quality gate の最低 grade。既定値は `B`。 |
+| `linters.cargo-coupling.max_critical` | `cargo-coupling` | quality gate で許容する critical issue 数。既定値は `0`。 |
+| `linters.cargo-coupling.max_circular` | `cargo-coupling` | quality gate で許容する circular dependency 数。既定値は `0`。 |
 | `linters.lizard.languages` | `lizard` | `lizard` opt-in 時の対象言語一覧。`disabled: false` と併用する。 |
 | `linters.textlint.preset_packages` | `textlint` | exact version 付き npm package spec の配列。`.textlintrc` と併せて `textlint` 自動選択時の必須項目。 |
 

--- a/cargo-coupling/Dockerfile.full
+++ b/cargo-coupling/Dockerfile.full
@@ -3,9 +3,12 @@
 
 ARG APP_NAME=cargo-coupling
 
-# Build stage with a digest-pinned Rust toolchain
 # renovate: datasource=docker depName=library/rust versioning=docker
 ARG CARGO_COUPLING_BUILD_BASE_IMAGE=docker.io/library/rust:slim-bookworm@sha256:caaf9ca7acd474892186860307d6f28e51fdbc1a4eada459fcff81517cf46a36
+# renovate: datasource=docker depName=library/debian versioning=docker
+ARG CARGO_COUPLING_RUNTIME_BASE_IMAGE=docker.io/library/debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252
+
+# Build stage with a digest-pinned Rust toolchain
 FROM ${CARGO_COUPLING_BUILD_BASE_IMAGE} AS chef
 WORKDIR /app
 
@@ -36,8 +39,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cp ./target/release/${APP_NAME} /bin/server
 
 # 本番ステージ：debian-slim (Git対応版)
-# renovate: datasource=docker depName=library/debian versioning=docker
-ARG CARGO_COUPLING_RUNTIME_BASE_IMAGE=docker.io/library/debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252
 FROM ${CARGO_COUPLING_RUNTIME_BASE_IMAGE} AS runtime
 
 # 非rootユーザー作成

--- a/cargo-coupling/Dockerfile.full
+++ b/cargo-coupling/Dockerfile.full
@@ -5,8 +5,8 @@ ARG APP_NAME=cargo-coupling
 
 # renovate: datasource=docker depName=library/rust versioning=docker
 ARG CARGO_COUPLING_BUILD_BASE_IMAGE=docker.io/library/rust:slim-bookworm@sha256:caaf9ca7acd474892186860307d6f28e51fdbc1a4eada459fcff81517cf46a36
-# renovate: datasource=docker depName=library/debian versioning=docker
-ARG CARGO_COUPLING_RUNTIME_BASE_IMAGE=docker.io/library/debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252
+# renovate: datasource=docker depName=library/rust versioning=docker
+ARG CARGO_COUPLING_RUNTIME_BASE_IMAGE=docker.io/library/rust:slim-bookworm@sha256:caaf9ca7acd474892186860307d6f28e51fdbc1a4eada459fcff81517cf46a36
 
 # Build stage with a digest-pinned Rust toolchain
 FROM ${CARGO_COUPLING_BUILD_BASE_IMAGE} AS chef
@@ -38,7 +38,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo build --release --bin ${APP_NAME} && \
     cp ./target/release/${APP_NAME} /bin/server
 
-# 本番ステージ：debian-slim (Git対応版)
+# 本番ステージ：cargo metadata を使える Rust runtime + Git
 FROM ${CARGO_COUPLING_RUNTIME_BASE_IMAGE} AS runtime
 
 # 非rootユーザー作成

--- a/cargo-coupling/Dockerfile.full
+++ b/cargo-coupling/Dockerfile.full
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1
+# Full version with Git support for volatility analysis
+
+ARG APP_NAME=cargo-coupling
+
+# Build stage with a digest-pinned Rust toolchain
+# renovate: datasource=docker depName=library/rust versioning=docker
+ARG CARGO_COUPLING_BUILD_BASE_IMAGE=docker.io/library/rust:slim-bookworm@sha256:caaf9ca7acd474892186860307d6f28e51fdbc1a4eada459fcff81517cf46a36
+FROM ${CARGO_COUPLING_BUILD_BASE_IMAGE} AS chef
+WORKDIR /app
+
+# Install cargo-chef
+# renovate: datasource=crate depName=cargo-chef
+ARG CARGO_CHEF_VERSION=0.1.77
+RUN cargo install cargo-chef --locked --version ${CARGO_CHEF_VERSION}
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+ARG APP_NAME=cargo-coupling
+
+# 依存関係のビルド（キャッシュ可能）
+COPY --from=planner /app/recipe.json recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    cargo chef cook --release --recipe-path recipe.json
+
+# アプリケーションのビルド
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    cargo build --release --bin ${APP_NAME} && \
+    cp ./target/release/${APP_NAME} /bin/server
+
+# 本番ステージ：debian-slim (Git対応版)
+# renovate: datasource=docker depName=library/debian versioning=docker
+ARG CARGO_COUPLING_RUNTIME_BASE_IMAGE=docker.io/library/debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252
+FROM ${CARGO_COUPLING_RUNTIME_BASE_IMAGE} AS runtime
+
+# 非rootユーザー作成
+ARG UID=10001
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    appuser
+
+# Git (volatility分析用) をインストール
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /bin/server /app/cargo-coupling
+
+USER appuser
+WORKDIR /workspace
+EXPOSE 3000
+ENTRYPOINT ["/app/cargo-coupling"]
+CMD ["--help"]

--- a/cargo-coupling/Dockerfile.full
+++ b/cargo-coupling/Dockerfile.full
@@ -63,6 +63,7 @@ COPY --from=builder /bin/server /app/cargo-coupling
 
 USER appuser
 WORKDIR /workspace
+HEALTHCHECK --interval=5m --timeout=3s --start-period=5s --retries=1 CMD ["/app/cargo-coupling", "--help"]
 EXPOSE 3000
 ENTRYPOINT ["/app/cargo-coupling"]
 CMD ["--help"]

--- a/cargo-coupling/cargo-coupling-config.js
+++ b/cargo-coupling/cargo-coupling-config.js
@@ -1,0 +1,220 @@
+const DEFAULT_CARGO_COUPLING_CONFIG = Object.freeze({
+	max_circular: 0,
+	max_critical: 0,
+	min_grade: "B",
+});
+
+const GRADE_VALUES = new Set(["S", "A", "B", "C", "D", "F"]);
+
+function normalizeCargoCouplingConfig({
+	currentConfig = {},
+	label = "linters.cargo-coupling",
+} = {}) {
+	if (
+		!currentConfig ||
+		typeof currentConfig !== "object" ||
+		Array.isArray(currentConfig)
+	) {
+		throw new Error(`${label} must be an object`);
+	}
+
+	return {
+		max_circular: normalizeNonNegativeInteger(
+			currentConfig.max_circular,
+			`${label}.max_circular`,
+			DEFAULT_CARGO_COUPLING_CONFIG.max_circular,
+		),
+		max_critical: normalizeNonNegativeInteger(
+			currentConfig.max_critical,
+			`${label}.max_critical`,
+			DEFAULT_CARGO_COUPLING_CONFIG.max_critical,
+		),
+		min_grade: normalizeGrade(
+			currentConfig.min_grade,
+			`${label}.min_grade`,
+			DEFAULT_CARGO_COUPLING_CONFIG.min_grade,
+		),
+	};
+}
+
+function normalizeGrade(value, label, fallback) {
+	if (value === undefined) {
+		return fallback;
+	}
+
+	if (typeof value !== "string" || value.trim().length === 0) {
+		throw new Error(`${label} must be a non-empty string`);
+	}
+
+	const normalized = value.trim().toUpperCase();
+	if (!GRADE_VALUES.has(normalized)) {
+		throw new Error(
+			`${label} must be one of: ${Array.from(GRADE_VALUES).join(", ")}`,
+		);
+	}
+
+	return normalized;
+}
+
+function normalizeNonNegativeInteger(value, label, fallback) {
+	if (value === undefined) {
+		return fallback;
+	}
+
+	if (!Number.isInteger(value) || value < 0) {
+		throw new Error(`${label} must be a non-negative integer`);
+	}
+
+	return value;
+}
+
+function evaluateCargoCouplingCheck({ config, jsonOutput }) {
+	const resolvedConfig = normalizeCargoCouplingConfig({
+		currentConfig: config,
+		label: "linters.cargo-coupling",
+	});
+	const summary = normalizeRequiredSummary(jsonOutput);
+	const grade = normalizeRequiredGrade(
+		summary.health_grade,
+		"cargo-coupling JSON summary.health_grade",
+	);
+	const score = normalizeRequiredNumber(
+		summary.health_score,
+		"cargo-coupling JSON summary.health_score",
+	);
+	const criticalCount = normalizeRequiredCount(
+		summary.critical_issues,
+		"cargo-coupling JSON summary.critical_issues",
+	);
+	const highCount = normalizeRequiredCount(
+		summary.high_issues,
+		"cargo-coupling JSON summary.high_issues",
+	);
+	const mediumCount = normalizeRequiredCount(
+		summary.medium_issues,
+		"cargo-coupling JSON summary.medium_issues",
+	);
+	normalizeRequiredCount(
+		summary.total_couplings,
+		"cargo-coupling JSON summary.total_couplings",
+	);
+	normalizeRequiredCount(
+		summary.total_modules,
+		"cargo-coupling JSON summary.total_modules",
+	);
+	const circularCount =
+		normalizeRequiredCircularDependencies(jsonOutput).length;
+	const failures = [];
+
+	if (gradeRank(grade) < gradeRank(resolvedConfig.min_grade)) {
+		failures.push(
+			`Grade ${grade} is below minimum ${resolvedConfig.min_grade}`,
+		);
+	}
+
+	if (criticalCount > resolvedConfig.max_critical) {
+		failures.push(
+			`${criticalCount} critical issues (max: ${resolvedConfig.max_critical})`,
+		);
+	}
+
+	if (circularCount > resolvedConfig.max_circular) {
+		failures.push(
+			`${circularCount} circular dependencies (max: ${resolvedConfig.max_circular})`,
+		);
+	}
+
+	return {
+		circular_count: circularCount,
+		critical_count: criticalCount,
+		failures,
+		grade,
+		high_count: highCount,
+		medium_count: mediumCount,
+		passed: failures.length === 0,
+		score,
+	};
+}
+
+function normalizeRequiredSummary(jsonOutput) {
+	if (
+		!jsonOutput ||
+		typeof jsonOutput !== "object" ||
+		Array.isArray(jsonOutput)
+	) {
+		throw new Error("cargo-coupling JSON output must be an object");
+	}
+
+	if (
+		!jsonOutput.summary ||
+		typeof jsonOutput.summary !== "object" ||
+		Array.isArray(jsonOutput.summary)
+	) {
+		throw new Error("cargo-coupling JSON summary must be an object");
+	}
+
+	return jsonOutput.summary;
+}
+
+function normalizeRequiredGrade(value, label) {
+	if (value === undefined) {
+		throw new Error(`${label} is required`);
+	}
+
+	return normalizeGrade(value, label);
+}
+
+function normalizeRequiredNumber(value, label) {
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		throw new Error(`${label} must be a finite number`);
+	}
+
+	return value;
+}
+
+function normalizeRequiredCount(value, label) {
+	if (!Number.isInteger(value) || value < 0) {
+		throw new Error(`${label} must be a non-negative integer`);
+	}
+
+	return value;
+}
+
+function normalizeRequiredCircularDependencies(jsonOutput) {
+	if (!Array.isArray(jsonOutput?.circular_dependencies)) {
+		throw new Error(
+			"cargo-coupling JSON circular_dependencies must be an array",
+		);
+	}
+
+	return jsonOutput.circular_dependencies;
+}
+
+function normalizeCount(value) {
+	return Number.isInteger(value) && value >= 0 ? value : 0;
+}
+
+function gradeRank(grade) {
+	switch (grade) {
+		case "S":
+			return 6;
+		case "A":
+			return 5;
+		case "B":
+			return 4;
+		case "C":
+			return 3;
+		case "D":
+			return 2;
+		case "F":
+			return 1;
+		default:
+			return 0;
+	}
+}
+
+module.exports = {
+	DEFAULT_CARGO_COUPLING_CONFIG,
+	evaluateCargoCouplingCheck,
+	normalizeCargoCouplingConfig,
+};

--- a/cargo-coupling/cargo-coupling-config.js
+++ b/cargo-coupling/cargo-coupling-config.js
@@ -190,10 +190,6 @@ function normalizeRequiredCircularDependencies(jsonOutput) {
 	return jsonOutput.circular_dependencies;
 }
 
-function normalizeCount(value) {
-	return Number.isInteger(value) && value >= 0 ? value : 0;
-}
-
 function gradeRank(grade) {
 	switch (grade) {
 		case "S":

--- a/cargo-coupling/cargo-coupling-result.js
+++ b/cargo-coupling/cargo-coupling-result.js
@@ -57,7 +57,7 @@ function normalizeCargoCouplingRun(run, config) {
 	const exitCode = normalizeExitCode(run?.exit_code);
 	const stdout = String(run?.stdout || "").trim();
 	const stderr = String(run?.stderr || "").trim();
-	const json_output = parseJsonOutput(stdout);
+	const json_output = normalizeCargoCouplingJsonOutput(parseJsonOutput(stdout));
 	const normalized = {
 		analysis_path: String(run?.analysis_path || "").trim(),
 		command: String(run?.command || "").trim(),
@@ -99,6 +99,85 @@ function parseJsonOutput(stdout) {
 	} catch {
 		return null;
 	}
+}
+
+function normalizeCargoCouplingJsonOutput(jsonOutput) {
+	if (
+		!jsonOutput ||
+		typeof jsonOutput !== "object" ||
+		Array.isArray(jsonOutput)
+	) {
+		return jsonOutput;
+	}
+
+	return {
+		...jsonOutput,
+		...(Array.isArray(jsonOutput.circular_dependencies)
+			? {
+					circular_dependencies: [...jsonOutput.circular_dependencies]
+						.map((cycle) => canonicalizeCargoCouplingCycle(cycle))
+						.sort(compareStringArrays),
+				}
+			: {}),
+		...(Array.isArray(jsonOutput.hotspots)
+			? {
+					hotspots: [...jsonOutput.hotspots]
+						.map((hotspot) => normalizeCargoCouplingHotspot(hotspot))
+						.sort(compareCargoCouplingHotspots),
+				}
+			: {}),
+		...(Array.isArray(jsonOutput.issues)
+			? {
+					issues: [...jsonOutput.issues].sort(compareCargoCouplingIssues),
+				}
+			: {}),
+		...(Array.isArray(jsonOutput.modules)
+			? {
+					modules: [...jsonOutput.modules].sort(compareCargoCouplingModules),
+				}
+			: {}),
+	};
+}
+
+function canonicalizeCargoCouplingCycle(cycle) {
+	const entries = Array.isArray(cycle)
+		? cycle.map((entry) => String(entry))
+		: [];
+	if (entries.length <= 1) {
+		return entries;
+	}
+
+	const normalizedEntries =
+		entries.length > 1 && entries[0] === entries.at(-1)
+			? entries.slice(0, -1)
+			: entries;
+	const candidates = [];
+
+	for (const candidate of [
+		normalizedEntries,
+		[...normalizedEntries].reverse(),
+	]) {
+		for (let index = 0; index < candidate.length; index += 1) {
+			candidates.push(candidate.slice(index).concat(candidate.slice(0, index)));
+		}
+	}
+
+	return candidates.sort(compareStringArrays)[0];
+}
+
+function normalizeCargoCouplingHotspot(hotspot) {
+	if (!hotspot || typeof hotspot !== "object" || Array.isArray(hotspot)) {
+		return hotspot;
+	}
+
+	return {
+		...hotspot,
+		...(Array.isArray(hotspot.issues)
+			? {
+					issues: [...hotspot.issues].sort(compareCargoCouplingHotspotIssues),
+				}
+			: {}),
+	};
 }
 
 function normalizeExitCode(value) {
@@ -306,6 +385,59 @@ function buildModulePathMap(modules) {
 
 function normalizeCount(value) {
 	return Number.isInteger(value) && value >= 0 ? value : 0;
+}
+
+function compareCargoCouplingModules(left, right) {
+	return (
+		compareStrings(left?.file_path, right?.file_path) ||
+		compareStrings(left?.name, right?.name)
+	);
+}
+
+function compareCargoCouplingIssues(left, right) {
+	return (
+		compareStrings(left?.source, right?.source) ||
+		compareStrings(left?.target, right?.target) ||
+		compareStrings(left?.issue_type, right?.issue_type) ||
+		compareStrings(left?.severity, right?.severity) ||
+		compareStrings(left?.description, right?.description)
+	);
+}
+
+function compareCargoCouplingHotspots(left, right) {
+	return (
+		compareStrings(left?.module, right?.module) ||
+		compareNumbers(left?.score, right?.score) ||
+		compareStrings(left?.suggestion, right?.suggestion)
+	);
+}
+
+function compareCargoCouplingHotspotIssues(left, right) {
+	return (
+		compareStrings(left?.severity, right?.severity) ||
+		compareStrings(left?.issue_type, right?.issue_type) ||
+		compareStrings(left?.description, right?.description)
+	);
+}
+
+function compareStringArrays(left, right) {
+	const length = Math.max(left.length, right.length);
+	for (let index = 0; index < length; index += 1) {
+		const comparison = compareStrings(left[index], right[index]);
+		if (comparison !== 0) {
+			return comparison;
+		}
+	}
+
+	return left.length - right.length;
+}
+
+function compareStrings(left, right) {
+	return String(left || "").localeCompare(String(right || ""));
+}
+
+function compareNumbers(left, right) {
+	return Number(left || 0) - Number(right || 0);
 }
 
 function slugifyIssueType(value) {

--- a/cargo-coupling/cargo-coupling-result.js
+++ b/cargo-coupling/cargo-coupling-result.js
@@ -6,6 +6,8 @@ const {
 	normalizeCargoCouplingConfig,
 } = require("./cargo-coupling-config.js");
 
+const WORK_ROOT_PREFIX = "/work/";
+
 function readTextFile(filePath) {
 	if (!fs.existsSync(filePath)) {
 		return "";
@@ -133,7 +135,9 @@ function normalizeCargoCouplingJsonOutput(jsonOutput) {
 			: {}),
 		...(Array.isArray(jsonOutput.modules)
 			? {
-					modules: [...jsonOutput.modules].sort(compareCargoCouplingModules),
+					modules: [...jsonOutput.modules]
+						.map((module) => normalizeCargoCouplingModule(module))
+						.sort(compareCargoCouplingModules),
 				}
 			: {}),
 	};
@@ -172,12 +176,42 @@ function normalizeCargoCouplingHotspot(hotspot) {
 
 	return {
 		...hotspot,
+		...(Object.hasOwn(hotspot, "file_path")
+			? {
+					file_path: normalizeCargoCouplingPath(hotspot.file_path),
+				}
+			: {}),
 		...(Array.isArray(hotspot.issues)
 			? {
 					issues: [...hotspot.issues].sort(compareCargoCouplingHotspotIssues),
 				}
 			: {}),
 	};
+}
+
+function normalizeCargoCouplingModule(module) {
+	if (!module || typeof module !== "object" || Array.isArray(module)) {
+		return module;
+	}
+
+	return {
+		...module,
+		...(Object.hasOwn(module, "file_path")
+			? {
+					file_path: normalizeCargoCouplingPath(module.file_path),
+				}
+			: {}),
+	};
+}
+
+function normalizeCargoCouplingPath(value) {
+	if (typeof value !== "string") {
+		return value ?? null;
+	}
+
+	return value.startsWith(WORK_ROOT_PREFIX)
+		? value.slice(WORK_ROOT_PREFIX.length)
+		: value;
 }
 
 function normalizeExitCode(value) {

--- a/cargo-coupling/cargo-coupling-result.js
+++ b/cargo-coupling/cargo-coupling-result.js
@@ -1,0 +1,343 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const {
+	evaluateCargoCouplingCheck,
+	normalizeCargoCouplingConfig,
+} = require("./cargo-coupling-config.js");
+
+function readTextFile(filePath) {
+	if (!fs.existsSync(filePath)) {
+		return "";
+	}
+
+	return fs.readFileSync(filePath, "utf8");
+}
+
+function readJsonFile(filePath) {
+	if (!fs.existsSync(filePath)) {
+		return null;
+	}
+
+	try {
+		return JSON.parse(fs.readFileSync(filePath, "utf8"));
+	} catch {
+		return null;
+	}
+}
+
+function readCargoCouplingRunEntries(entriesDir) {
+	if (!fs.existsSync(entriesDir)) {
+		return [];
+	}
+
+	return fs
+		.readdirSync(entriesDir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.sort()
+		.map((entryName) => {
+			const entryDir = path.join(entriesDir, entryName);
+			return {
+				analysis_path: readTextFile(
+					path.join(entryDir, "analysis_path.txt"),
+				).trim(),
+				command: readTextFile(path.join(entryDir, "command.txt")).trim(),
+				exit_code: readTextFile(path.join(entryDir, "exit_code.txt")).trim(),
+				manifest_path: readTextFile(
+					path.join(entryDir, "manifest_path.txt"),
+				).trim(),
+				stderr: readTextFile(path.join(entryDir, "stderr.txt")),
+				stdout: readTextFile(path.join(entryDir, "stdout.txt")),
+			};
+		});
+}
+
+function normalizeCargoCouplingRun(run, config) {
+	const exitCode = normalizeExitCode(run?.exit_code);
+	const stdout = String(run?.stdout || "").trim();
+	const stderr = String(run?.stderr || "").trim();
+	const json_output = parseJsonOutput(stdout);
+	const normalized = {
+		analysis_path: String(run?.analysis_path || "").trim(),
+		command: String(run?.command || "").trim(),
+		exit_code: exitCode,
+		manifest_path: String(run?.manifest_path || "").trim(),
+	};
+
+	if (json_output !== null) {
+		normalized.json_output = json_output;
+		try {
+			normalized.check_result = evaluateCargoCouplingCheck({
+				config,
+				jsonOutput: json_output,
+			});
+		} catch (error) {
+			normalized.json_error =
+				error instanceof Error ? error.message : String(error);
+		}
+	}
+
+	if (stderr.length > 0) {
+		normalized.stderr = stderr;
+	}
+
+	if (stdout.length > 0 && (json_output === null || normalized.json_error)) {
+		normalized.stdout = stdout;
+	}
+
+	return normalized;
+}
+
+function parseJsonOutput(stdout) {
+	if (typeof stdout !== "string" || stdout.trim().length === 0) {
+		return null;
+	}
+
+	try {
+		return JSON.parse(stdout);
+	} catch {
+		return null;
+	}
+}
+
+function normalizeExitCode(value) {
+	return Number.isInteger(value)
+		? value
+		: Number.parseInt(String(value || "0"), 10) || 0;
+}
+
+function buildCargoCouplingResult({
+	commandExitCode = 0,
+	config = {},
+	entriesDir,
+	runs = null,
+}) {
+	const resolvedConfig = normalizeCargoCouplingConfig({
+		currentConfig: config,
+		label: "linters.cargo-coupling",
+	});
+	const normalizedRuns = (runs || readCargoCouplingRunEntries(entriesDir)).map(
+		(run) => normalizeCargoCouplingRun(run, resolvedConfig),
+	);
+	const failures = [];
+	const details = normalizedRuns
+		.map((run) => renderCargoCouplingRunDetails(run, resolvedConfig))
+		.filter(Boolean)
+		.join("\n\n")
+		.trim();
+
+	for (const run of normalizedRuns) {
+		if (run.exit_code !== 0) {
+			failures.push(run.command || run.manifest_path || "cargo-coupling run");
+			continue;
+		}
+
+		if (!run.json_output) {
+			failures.push(
+				run.command || run.manifest_path || "cargo-coupling JSON output",
+			);
+			continue;
+		}
+
+		if (run.json_error) {
+			failures.push(run.json_error);
+			continue;
+		}
+
+		if (run.check_result?.passed === false) {
+			failures.push(...run.check_result.failures);
+		}
+	}
+
+	const exit_code =
+		normalizeExitCode(commandExitCode) !== 0 || failures.length > 0 ? 1 : 0;
+
+	return {
+		cargo_coupling_runs: normalizedRuns.map((run) => ({
+			...(run.analysis_path ? { analysis_path: run.analysis_path } : {}),
+			command: run.command,
+			...(run.check_result ? { check_result: run.check_result } : {}),
+			exit_code: run.exit_code,
+			...(run.json_output ? { json_output: run.json_output } : {}),
+			manifest_path: run.manifest_path,
+		})),
+		details,
+		exit_code,
+	};
+}
+
+function renderCargoCouplingRunDetails(run, config) {
+	const lines = [];
+	if (run.command) {
+		lines.push(`==> ${run.command}`);
+	}
+
+	if (run.json_error) {
+		lines.push(`Invalid cargo-coupling JSON: ${run.json_error}`);
+	}
+
+	if (run.json_output && !run.json_error) {
+		lines.push(...formatCargoCouplingSummary(run, config));
+		lines.push(...formatCargoCouplingIssues(run.json_output));
+		lines.push(...formatCircularDependencies(run.json_output));
+	}
+
+	if ((!run.json_output || run.json_error) && run.stdout) {
+		lines.push(run.stdout);
+	}
+
+	if (run.stderr) {
+		lines.push(run.stderr);
+	}
+
+	return lines.filter((line) => String(line).trim().length > 0).join("\n");
+}
+
+function formatCargoCouplingSummary(run, config) {
+	const summary =
+		run.json_output && typeof run.json_output.summary === "object"
+			? run.json_output.summary
+			: {};
+	const checkResult =
+		run.check_result ||
+		evaluateCargoCouplingCheck({
+			config,
+			jsonOutput: run.json_output,
+		});
+
+	return [
+		[
+			`Grade: ${checkResult.grade}`,
+			`Score: ${(checkResult.score * 100).toFixed(0)}%`,
+			checkResult.passed ? "Quality gate: PASSED" : "Quality gate: FAILED",
+		].join(" | "),
+		[
+			`Thresholds: min_grade=${config.min_grade}`,
+			`max_critical=${config.max_critical}`,
+			`max_circular=${config.max_circular}`,
+		].join(", "),
+		[
+			`Modules: ${normalizeCount(summary.total_modules)}`,
+			`Couplings: ${normalizeCount(summary.total_couplings)}`,
+			`Critical: ${checkResult.critical_count}`,
+			`High: ${checkResult.high_count}`,
+			`Medium: ${checkResult.medium_count}`,
+			`Circular: ${checkResult.circular_count}`,
+		].join(" | "),
+		...(checkResult.failures.length > 0
+			? [
+					"Blocking issues:",
+					...checkResult.failures.map((failure) => ` - ${failure}`),
+				]
+			: []),
+	];
+}
+
+function formatCargoCouplingIssues(jsonOutput) {
+	const issues = Array.isArray(jsonOutput?.issues) ? jsonOutput.issues : [];
+	if (issues.length === 0) {
+		return [];
+	}
+
+	const modulePaths = buildModulePathMap(jsonOutput.modules);
+	return [
+		"Issues:",
+		...issues.flatMap((issue) => {
+			const severity = String(issue?.severity || "unknown").toLowerCase();
+			const source = String(issue?.source || "").trim();
+			const target = String(issue?.target || "").trim();
+			const description = String(
+				issue?.description || "cargo-coupling reported an issue",
+			);
+			const issueType =
+				typeof issue?.issue_type === "string" &&
+				issue.issue_type.trim().length > 0
+					? issue.issue_type.trim()
+					: "Diagnostic";
+			const location = modulePaths.get(source) || modulePaths.get(target) || "";
+			const subject = [source, target].filter(Boolean).join(" -> ");
+			const headline = `${severity}[${issueType}]: ${description}`;
+			return [
+				location.length > 0
+					? `${location}: ${subject.length > 0 ? `${subject}: ` : ""}${headline}`
+					: subject.length > 0
+						? `${subject}: ${headline}`
+						: headline,
+				...(typeof issue?.suggestion === "string" &&
+				issue.suggestion.trim().length > 0
+					? [` suggestion: ${issue.suggestion.trim()}`]
+					: []),
+			];
+		}),
+	];
+}
+
+function formatCircularDependencies(jsonOutput) {
+	const cycles = Array.isArray(jsonOutput?.circular_dependencies)
+		? jsonOutput.circular_dependencies
+		: [];
+	if (cycles.length === 0) {
+		return [];
+	}
+
+	return [
+		"Circular dependencies:",
+		...cycles.map(
+			(cycle) => ` - ${cycle.map((entry) => String(entry)).join(" -> ")}`,
+		),
+	];
+}
+
+function buildModulePathMap(modules) {
+	const entries = Array.isArray(modules) ? modules : [];
+	return new Map(
+		entries
+			.filter(
+				(entry) =>
+					entry &&
+					typeof entry.name === "string" &&
+					typeof entry.file_path === "string" &&
+					entry.file_path.length > 0,
+			)
+			.map((entry) => [entry.name, entry.file_path]),
+	);
+}
+
+function normalizeCount(value) {
+	return Number.isInteger(value) && value >= 0 ? value : 0;
+}
+
+function slugifyIssueType(value) {
+	return `cargo-coupling/${
+		String(value || "diagnostic")
+			.trim()
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/gu, "-")
+			.replace(/^-+|-+$/gu, "") || "diagnostic"
+	}`;
+}
+
+if (require.main === module) {
+	const [entriesDir, configPath, commandExitCode] = process.argv.slice(2);
+	if (!entriesDir || !configPath) {
+		throw new Error(
+			"usage: cargo-coupling-result.js <entries-dir> <config-path> [command-exit-code]",
+		);
+	}
+
+	process.stdout.write(
+		`${JSON.stringify(
+			buildCargoCouplingResult({
+				commandExitCode,
+				config: readJsonFile(configPath) || {},
+				entriesDir,
+			}),
+		)}\n`,
+	);
+}
+
+module.exports = {
+	buildCargoCouplingResult,
+	readCargoCouplingRunEntries,
+};

--- a/cargo-coupling/cargo-coupling-result.js
+++ b/cargo-coupling/cargo-coupling-result.js
@@ -474,16 +474,6 @@ function compareNumbers(left, right) {
 	return Number(left || 0) - Number(right || 0);
 }
 
-function slugifyIssueType(value) {
-	return `cargo-coupling/${
-		String(value || "diagnostic")
-			.trim()
-			.toLowerCase()
-			.replace(/[^a-z0-9]+/gu, "-")
-			.replace(/^-+|-+$/gu, "") || "diagnostic"
-	}`;
-}
-
 if (require.main === module) {
 	const [entriesDir, configPath, commandExitCode] = process.argv.slice(2);
 	if (!entriesDir || !configPath) {

--- a/cargo-coupling/cargo-coupling-result.test.js
+++ b/cargo-coupling/cargo-coupling-result.test.js
@@ -1,0 +1,191 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { buildCargoCouplingResult } = require("./cargo-coupling-result.js");
+
+test("buildCargoCouplingResult evaluates default quality gates from JSON output", () => {
+	const result = buildCargoCouplingResult({
+		commandExitCode: 0,
+		config: {},
+		entriesDir: "/unused",
+		runs: [
+			{
+				analysis_path: "src",
+				command: "docker run cargo-coupling --json --no-git src",
+				exit_code: 0,
+				manifest_path: "Cargo.toml",
+				stderr: "",
+				stdout: JSON.stringify({
+					circular_dependencies: [["crate::a", "crate::b", "crate::a"]],
+					hotspots: [],
+					issues: [
+						{
+							description:
+								"Intrusive coupling across a distant module boundary",
+							issue_type: "Global Complexity",
+							severity: "Critical",
+							source: "crate::a",
+							suggestion: "Introduce a trait.",
+							target: "crate::b",
+						},
+					],
+					modules: [
+						{
+							file_path: "src/lib.rs",
+							name: "crate::a",
+						},
+					],
+					summary: {
+						critical_issues: 1,
+						health_grade: "C",
+						health_score: 0.55,
+						high_issues: 0,
+						medium_issues: 0,
+						total_couplings: 1,
+						total_modules: 2,
+					},
+				}),
+			},
+		],
+	});
+
+	assert.equal(result.exit_code, 1);
+	assert.equal(result.cargo_coupling_runs.length, 1);
+	assert.deepEqual(result.cargo_coupling_runs[0].check_result.failures, [
+		"Grade C is below minimum B",
+		"1 critical issues (max: 0)",
+		"1 circular dependencies (max: 0)",
+	]);
+	assert.match(result.details, /Quality gate: FAILED/);
+	assert.match(result.details, /Global Complexity/);
+	assert.match(result.details, /Circular dependencies:/);
+});
+
+test("buildCargoCouplingResult honors repository-configured thresholds", () => {
+	const result = buildCargoCouplingResult({
+		commandExitCode: 0,
+		config: {
+			max_circular: 1,
+			max_critical: 1,
+			min_grade: "C",
+		},
+		entriesDir: "/unused",
+		runs: [
+			{
+				analysis_path: "src",
+				command: "docker run cargo-coupling --json --no-git src",
+				exit_code: 0,
+				manifest_path: "Cargo.toml",
+				stderr: "",
+				stdout: JSON.stringify({
+					circular_dependencies: [["crate::a", "crate::b", "crate::a"]],
+					hotspots: [],
+					issues: [],
+					modules: [],
+					summary: {
+						critical_issues: 1,
+						health_grade: "C",
+						health_score: 0.73,
+						high_issues: 0,
+						medium_issues: 0,
+						total_couplings: 1,
+						total_modules: 2,
+					},
+				}),
+			},
+		],
+	});
+
+	assert.equal(result.exit_code, 0);
+	assert.equal(result.cargo_coupling_runs[0].check_result.passed, true);
+	assert.match(result.details, /Quality gate: PASSED/);
+	assert.match(
+		result.details,
+		/Thresholds: min_grade=C, max_critical=1, max_circular=1/,
+	);
+});
+
+test("buildCargoCouplingResult treats grade S as stricter than grade A", () => {
+	const result = buildCargoCouplingResult({
+		commandExitCode: 0,
+		config: {
+			min_grade: "S",
+		},
+		entriesDir: "/unused",
+		runs: [
+			{
+				analysis_path: "src",
+				command: "docker run cargo-coupling --json --no-git src",
+				exit_code: 0,
+				manifest_path: "Cargo.toml",
+				stderr: "",
+				stdout: JSON.stringify({
+					circular_dependencies: [],
+					hotspots: [],
+					issues: [],
+					modules: [],
+					summary: {
+						critical_issues: 0,
+						health_grade: "A",
+						health_score: 0.98,
+						high_issues: 0,
+						medium_issues: 0,
+						total_couplings: 1,
+						total_modules: 1,
+					},
+				}),
+			},
+		],
+	});
+
+	assert.equal(result.exit_code, 1);
+	assert.deepEqual(result.cargo_coupling_runs[0].check_result.failures, [
+		"Grade A is below minimum S",
+	]);
+});
+
+test("buildCargoCouplingResult preserves runtime failures without JSON output", () => {
+	const result = buildCargoCouplingResult({
+		commandExitCode: 1,
+		config: {},
+		entriesDir: "/unused",
+		runs: [
+			{
+				analysis_path: "src",
+				command: "docker run cargo-coupling --json --no-git src",
+				exit_code: 1,
+				manifest_path: "Cargo.toml",
+				stderr: "cargo-coupling failed to analyze the workspace",
+				stdout: "",
+			},
+		],
+	});
+
+	assert.equal(result.exit_code, 1);
+	assert.equal("check_result" in result.cargo_coupling_runs[0], false);
+	assert.match(result.details, /failed to analyze the workspace/);
+});
+
+test("buildCargoCouplingResult fails closed for incomplete cargo-coupling JSON", () => {
+	const result = buildCargoCouplingResult({
+		commandExitCode: 0,
+		config: {},
+		entriesDir: "/unused",
+		runs: [
+			{
+				analysis_path: "src",
+				command: "docker run cargo-coupling --json --no-git src",
+				exit_code: 0,
+				manifest_path: "Cargo.toml",
+				stderr: "",
+				stdout: "{}",
+			},
+		],
+	});
+
+	assert.equal(result.exit_code, 1);
+	assert.deepEqual(result.cargo_coupling_runs[0].json_output, {});
+	assert.equal("check_result" in result.cargo_coupling_runs[0], false);
+	assert.match(result.details, /Invalid cargo-coupling JSON:/u);
+	assert.match(result.details, /summary must be an object/u);
+});

--- a/cargo-coupling/cargo-coupling-result.test.js
+++ b/cargo-coupling/cargo-coupling-result.test.js
@@ -189,3 +189,117 @@ test("buildCargoCouplingResult fails closed for incomplete cargo-coupling JSON",
 	assert.match(result.details, /Invalid cargo-coupling JSON:/u);
 	assert.match(result.details, /summary must be an object/u);
 });
+
+test("buildCargoCouplingResult normalizes unstable cargo-coupling ordering", () => {
+	const result = buildCargoCouplingResult({
+		commandExitCode: 0,
+		config: {},
+		entriesDir: "/unused",
+		runs: [
+			{
+				analysis_path: "src",
+				command: "docker run cargo-coupling coupling --json --no-git src",
+				exit_code: 0,
+				manifest_path: "Cargo.toml",
+				stderr:
+					"Analyzing project at 'src'...\nAnalysis complete: 3 files, 3 modules\n",
+				stdout: JSON.stringify({
+					circular_dependencies: [
+						["fixture-fail::query", "fixture-fail::handler"],
+					],
+					hotspots: [
+						{
+							file_path: null,
+							in_cycle: true,
+							issues: [
+								{
+									description: "Part of a circular dependency cycle",
+									issue_type: "CircularDependency",
+									severity: "Critical",
+								},
+							],
+							module: "fixture-fail::query",
+							score: 40,
+							suggestion:
+								"Break circular dependency by extracting shared types or inverting with traits",
+						},
+						{
+							file_path: null,
+							in_cycle: true,
+							issues: [
+								{
+									description: "Part of a circular dependency cycle",
+									issue_type: "CircularDependency",
+									severity: "Critical",
+								},
+							],
+							module: "fixture-fail::handler",
+							score: 40,
+							suggestion:
+								"Break circular dependency by extracting shared types or inverting with traits",
+						},
+					],
+					issues: [],
+					modules: [
+						{
+							balance_score: 1,
+							couplings_in: 0,
+							couplings_out: 0,
+							file_path: "src/query.rs",
+							in_cycle: false,
+							name: "query",
+						},
+						{
+							balance_score: 1,
+							couplings_in: 0,
+							couplings_out: 0,
+							file_path: "src/lib.rs",
+							in_cycle: false,
+							name: "lib",
+						},
+						{
+							balance_score: 1,
+							couplings_in: 0,
+							couplings_out: 0,
+							file_path: "src/handler.rs",
+							in_cycle: false,
+							name: "handler",
+						},
+					],
+					summary: {
+						critical_issues: 0,
+						external_couplings: 0,
+						health_grade: "B",
+						health_score: 0.75,
+						high_issues: 0,
+						internal_couplings: 2,
+						medium_issues: 0,
+						total_couplings: 2,
+						total_modules: 3,
+					},
+				}),
+			},
+		],
+	});
+
+	assert.deepEqual(
+		result.cargo_coupling_runs[0].json_output.circular_dependencies,
+		[["fixture-fail::handler", "fixture-fail::query"]],
+	);
+	assert.deepEqual(
+		result.cargo_coupling_runs[0].json_output.modules.map(
+			(entry) => entry.file_path,
+		),
+		["src/handler.rs", "src/lib.rs", "src/query.rs"],
+	);
+	assert.deepEqual(
+		result.cargo_coupling_runs[0].json_output.hotspots.map(
+			(entry) => entry.module,
+		),
+		["fixture-fail::handler", "fixture-fail::query"],
+	);
+	assert.match(
+		result.details,
+		/Circular dependencies:\n - fixture-fail::handler -> fixture-fail::query/u,
+	);
+});

--- a/cargo-coupling/cargo-coupling-result.test.js
+++ b/cargo-coupling/cargo-coupling-result.test.js
@@ -190,7 +190,7 @@ test("buildCargoCouplingResult fails closed for incomplete cargo-coupling JSON",
 	assert.match(result.details, /summary must be an object/u);
 });
 
-test("buildCargoCouplingResult normalizes unstable cargo-coupling ordering", () => {
+test("buildCargoCouplingResult normalizes unstable cargo-coupling ordering and /work paths", () => {
 	const result = buildCargoCouplingResult({
 		commandExitCode: 0,
 		config: {},
@@ -209,7 +209,7 @@ test("buildCargoCouplingResult normalizes unstable cargo-coupling ordering", () 
 					],
 					hotspots: [
 						{
-							file_path: null,
+							file_path: "/work/src/query.rs",
 							in_cycle: true,
 							issues: [
 								{
@@ -224,7 +224,7 @@ test("buildCargoCouplingResult normalizes unstable cargo-coupling ordering", () 
 								"Break circular dependency by extracting shared types or inverting with traits",
 						},
 						{
-							file_path: null,
+							file_path: "/work/src/handler.rs",
 							in_cycle: true,
 							issues: [
 								{
@@ -245,7 +245,7 @@ test("buildCargoCouplingResult normalizes unstable cargo-coupling ordering", () 
 							balance_score: 1,
 							couplings_in: 0,
 							couplings_out: 0,
-							file_path: "src/query.rs",
+							file_path: "/work/src/query.rs",
 							in_cycle: false,
 							name: "query",
 						},
@@ -253,7 +253,7 @@ test("buildCargoCouplingResult normalizes unstable cargo-coupling ordering", () 
 							balance_score: 1,
 							couplings_in: 0,
 							couplings_out: 0,
-							file_path: "src/lib.rs",
+							file_path: "/work/src/lib.rs",
 							in_cycle: false,
 							name: "lib",
 						},
@@ -261,7 +261,7 @@ test("buildCargoCouplingResult normalizes unstable cargo-coupling ordering", () 
 							balance_score: 1,
 							couplings_in: 0,
 							couplings_out: 0,
-							file_path: "src/handler.rs",
+							file_path: "/work/src/handler.rs",
 							in_cycle: false,
 							name: "handler",
 						},
@@ -297,6 +297,12 @@ test("buildCargoCouplingResult normalizes unstable cargo-coupling ordering", () 
 			(entry) => entry.module,
 		),
 		["fixture-fail::handler", "fixture-fail::query"],
+	);
+	assert.deepEqual(
+		result.cargo_coupling_runs[0].json_output.hotspots.map(
+			(entry) => entry.file_path,
+		),
+		["src/handler.rs", "src/query.rs"],
 	);
 	assert.match(
 		result.details,

--- a/cargo-coupling/cargo-coupling-result.test.js
+++ b/cargo-coupling/cargo-coupling-result.test.js
@@ -11,7 +11,7 @@ test("buildCargoCouplingResult evaluates default quality gates from JSON output"
 		runs: [
 			{
 				analysis_path: "src",
-				command: "docker run cargo-coupling --json --no-git src",
+				command: "docker run cargo-coupling coupling --json --no-git src",
 				exit_code: 0,
 				manifest_path: "Cargo.toml",
 				stderr: "",
@@ -73,7 +73,7 @@ test("buildCargoCouplingResult honors repository-configured thresholds", () => {
 		runs: [
 			{
 				analysis_path: "src",
-				command: "docker run cargo-coupling --json --no-git src",
+				command: "docker run cargo-coupling coupling --json --no-git src",
 				exit_code: 0,
 				manifest_path: "Cargo.toml",
 				stderr: "",
@@ -115,7 +115,7 @@ test("buildCargoCouplingResult treats grade S as stricter than grade A", () => {
 		runs: [
 			{
 				analysis_path: "src",
-				command: "docker run cargo-coupling --json --no-git src",
+				command: "docker run cargo-coupling coupling --json --no-git src",
 				exit_code: 0,
 				manifest_path: "Cargo.toml",
 				stderr: "",
@@ -152,7 +152,7 @@ test("buildCargoCouplingResult preserves runtime failures without JSON output", 
 		runs: [
 			{
 				analysis_path: "src",
-				command: "docker run cargo-coupling --json --no-git src",
+				command: "docker run cargo-coupling coupling --json --no-git src",
 				exit_code: 1,
 				manifest_path: "Cargo.toml",
 				stderr: "cargo-coupling failed to analyze the workspace",
@@ -174,7 +174,7 @@ test("buildCargoCouplingResult fails closed for incomplete cargo-coupling JSON",
 		runs: [
 			{
 				analysis_path: "src",
-				command: "docker run cargo-coupling --json --no-git src",
+				command: "docker run cargo-coupling coupling --json --no-git src",
 				exit_code: 0,
 				manifest_path: "Cargo.toml",
 				stderr: "",

--- a/cargo-coupling/cargo-coupling.test.js
+++ b/cargo-coupling/cargo-coupling.test.js
@@ -559,8 +559,8 @@ defineCommonCargoManifestTests({
 		assert.match(runArgs, /--network=none/);
 		assert.match(runArgs, /--read-only/);
 		assert.match(runArgs, /--tmpfs \/tmp/);
-		assert.match(runArgs, /--json --no-git src/);
-		assert.match(runArgs, /--json --no-git crates\/member\/src/);
+		assert.match(runArgs, /coupling --json --no-git src/);
+		assert.match(runArgs, /coupling --json --no-git crates\/member\/src/);
 		assert.deepEqual(
 			fs.readFileSync(tooling.worktreeGitLog, "utf8").trim().split("\n"),
 			["absent", "absent"],
@@ -723,8 +723,8 @@ edition = "2021"
 		const runArgs = fs.readFileSync(tooling.dockerRunArgsLog, "utf8");
 
 		assert.equal(result.exit_code, 0);
-		assert.doesNotMatch(runArgs, /--json --no-git src/u);
-		assert.match(runArgs, /--json --no-git crates\/member\/src/u);
+		assert.doesNotMatch(runArgs, /coupling --json --no-git src/u);
+		assert.match(runArgs, /coupling --json --no-git crates\/member\/src/u);
 		assert.deepEqual(
 			fs.readFileSync(tooling.dockerManifestLog, "utf8").trim().split("\n"),
 			["crates/member/Cargo.toml"],

--- a/cargo-coupling/cargo-coupling.test.js
+++ b/cargo-coupling/cargo-coupling.test.js
@@ -548,7 +548,7 @@ defineCommonCargoManifestTests({
 	tempPrefix: "cargo-coupling-",
 	toolName: "cargo-coupling.sh",
 	setupTooling,
-	assertGroupedResult({ context, result, tooling }) {
+	assertGroupedResult({ result, tooling }) {
 		const runArgs = fs.readFileSync(tooling.dockerRunArgsLog, "utf8");
 
 		assert.equal(result.exit_code, 0);

--- a/cargo-coupling/cargo-coupling.test.js
+++ b/cargo-coupling/cargo-coupling.test.js
@@ -1,0 +1,735 @@
+const test = require("node:test");
+const { execFileSync } = require("node:child_process");
+const { createHash } = require("node:crypto");
+
+const {
+	assert,
+	cleanupTempRepo,
+	defineCommonCargoManifestTests,
+	fs,
+	makeTempRepo,
+	path,
+	writeExecutable,
+	writeFile,
+} = require("../.github/scripts/cargo-linter-test-lib.js");
+
+const installPath = path.join(__dirname, "install.sh");
+const commonPath = path.join(__dirname, "common.sh");
+const runPath = path.join(__dirname, "run.sh");
+
+function createCargoStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "cargo"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1-}" = "--version" ]; then
+  echo "cargo 0.0.0"
+  exit 0
+fi
+if [ "\${1-}" != "metadata" ]; then
+  echo "unexpected cargo command: $*" >&2
+  exit 1
+fi
+shift
+manifest=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --manifest-path|--format-version)
+      if [ "$1" = "--manifest-path" ]; then
+        manifest="$2"
+      fi
+      shift 2
+      ;;
+    --no-deps)
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [ -z "$manifest" ]; then
+  echo "missing --manifest-path" >&2
+  exit 1
+fi
+current_dir=$(dirname "$manifest")
+workspace_dir="$current_dir"
+search_dir="$current_dir"
+while :; do
+  candidate="$search_dir/Cargo.toml"
+  if [ -f "$candidate" ] && grep -Eq '^\\[workspace\\]' "$candidate"; then
+    workspace_dir="$search_dir"
+    break
+  fi
+  if [ "$search_dir" = "." ] || [ "$search_dir" = "/" ]; then
+    break
+  fi
+  search_dir=$(dirname "$search_dir")
+done
+workspace_root=$(cd "$workspace_dir" && pwd)
+node - "$workspace_root" <<'NODE'
+const [workspaceRoot] = process.argv.slice(2);
+process.stdout.write(JSON.stringify({ workspace_root: workspaceRoot }));
+NODE
+`,
+	);
+}
+
+function createDockerStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "docker"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+command="$1"
+shift
+
+case "$command" in
+  image)
+    subcommand="$1"
+    shift
+    if [ "$subcommand" != "inspect" ]; then
+      echo "unsupported docker image subcommand: $subcommand" >&2
+      exit 1
+    fi
+    printf '%s\\n' "$*" >> "$DOCKER_IMAGE_INSPECT_LOG"
+    if [ -n "\${MISSING_IMAGE:-}" ]; then
+      exit 1
+    fi
+    ;;
+  pull)
+    printf '%s\\n' "$*" >> "$DOCKER_PULL_LOG"
+    ;;
+  build)
+    printf '%s\\n' "$*" >> "$DOCKER_BUILD_LOG"
+    ;;
+  run)
+    work_mount_src=""
+    image_ref=""
+    command_args=()
+    option_with_value=""
+    for arg in "$@"; do
+      if [ -n "$option_with_value" ]; then
+        case "$option_with_value" in
+          --mount)
+            case "$arg" in
+              *"dst=/work"*|*"target=/work"*)
+                work_mount_src="\${arg#*src=}"
+                work_mount_src="\${work_mount_src%%,*}"
+                ;;
+            esac
+            ;;
+        esac
+        option_with_value=""
+        continue
+      fi
+      case "$arg" in
+        --mount|--user|--workdir|--tmpfs|--security-opt|--cap-drop|--env|-e)
+          option_with_value="$arg"
+          continue
+          ;;
+        --rm|--read-only|--network=*)
+          continue
+          ;;
+      esac
+      if [ -z "$image_ref" ]; then
+        image_ref="$arg"
+        continue
+      fi
+      command_args+=("$arg")
+    done
+    printf '%s\\n' "$*" >> "$DOCKER_RUN_ARGS_LOG"
+
+    analysis_path="\${command_args[-1]}"
+    if [ -z "$work_mount_src" ]; then
+      echo "missing work mount" >&2
+      exit 1
+    fi
+    analysis_root="$work_mount_src/$analysis_path"
+    if [ -f "$analysis_root" ]; then
+      search_dir=$(dirname "$analysis_root")
+    else
+      search_dir="$analysis_root"
+    fi
+    while :; do
+      candidate="$search_dir/Cargo.toml"
+      if [ -f "$candidate" ]; then
+        manifest_path="$candidate"
+        break
+      fi
+      if [ "$search_dir" = "$work_mount_src" ] || [ "$search_dir" = "/" ]; then
+        echo "missing Cargo.toml" >&2
+        exit 1
+      fi
+      search_dir=$(dirname "$search_dir")
+    done
+
+    manifest_rel=$(python - "$work_mount_src" "$manifest_path" <<'PY'
+import os
+import sys
+print(os.path.relpath(sys.argv[2], sys.argv[1]).replace(os.sep, "/"))
+PY
+)
+    printf '%s\\n' "$manifest_rel" >> "$DOCKER_MANIFEST_LOG"
+    if [ -e "$work_mount_src/.git" ]; then
+      printf 'present\\n' >> "$WORKTREE_GIT_LOG"
+    else
+      printf 'absent\\n' >> "$WORKTREE_GIT_LOG"
+    fi
+
+    if [ -n "\${FAIL_MANIFEST:-}" ] && [ "$manifest_rel" = "$FAIL_MANIFEST" ]; then
+      echo "cargo-coupling failed for $manifest_rel" >&2
+      exit 1
+    fi
+
+    package_name=$(python - "$manifest_path" <<'PY'
+import sys
+name = ""
+for line in open(sys.argv[1], encoding="utf-8"):
+    if line.startswith("name = "):
+        name = line.split("=", 1)[1].strip().strip('"')
+        break
+print(name)
+PY
+)
+    if [ -n "\${COUPLING_RELAXED:-}" ]; then
+      cat <<'JSON'
+{
+  "summary": {
+    "health_grade": "C",
+    "health_score": 0.73,
+    "total_modules": 2,
+    "total_couplings": 1,
+    "internal_couplings": 1,
+    "external_couplings": 0,
+    "critical_issues": 1,
+    "high_issues": 0,
+    "medium_issues": 0
+  },
+  "hotspots": [],
+  "issues": [],
+  "circular_dependencies": [
+    ["crate::a", "crate::b", "crate::a"]
+  ],
+  "modules": []
+}
+JSON
+      exit 0
+    fi
+    if [[ "$package_name" == *fail* ]]; then
+      cat <<'JSON'
+{
+  "summary": {
+    "health_grade": "C",
+    "health_score": 0.62,
+    "total_modules": 2,
+    "total_couplings": 2,
+    "internal_couplings": 2,
+    "external_couplings": 0,
+    "critical_issues": 1,
+    "high_issues": 0,
+    "medium_issues": 1
+  },
+  "hotspots": [],
+  "issues": [
+    {
+      "issue_type": "Global Complexity",
+      "severity": "Critical",
+      "source": "fixture_fail::handler",
+      "target": "fixture_fail::query",
+      "description": "Intrusive coupling across a distant module boundary",
+      "suggestion": "Introduce a trait boundary between handler and query.",
+      "balance_score": 0.24
+    },
+    {
+      "issue_type": "High Afferent Coupling",
+      "severity": "Medium",
+      "source": "fixture_fail::handler",
+      "target": "",
+      "description": "Module attracts many internal dependencies",
+      "suggestion": "Split responsibilities or hide internals behind a smaller API.",
+      "balance_score": 0.49
+    }
+  ],
+  "circular_dependencies": [
+    ["fixture_fail::handler", "fixture_fail::query", "fixture_fail::handler"]
+  ],
+  "modules": [
+    {
+      "name": "fixture_fail::handler",
+      "file_path": "src/lib.rs",
+      "couplings_out": 1,
+      "couplings_in": 1,
+      "balance_score": 0.24,
+      "in_cycle": true
+    },
+    {
+      "name": "fixture_fail::query",
+      "file_path": "src/lib.rs",
+      "couplings_out": 1,
+      "couplings_in": 1,
+      "balance_score": 0.49,
+      "in_cycle": true
+    }
+  ]
+}
+JSON
+      exit 0
+    fi
+    cat <<'JSON'
+{
+  "summary": {
+    "health_grade": "B",
+    "health_score": 0.91,
+    "total_modules": 1,
+    "total_couplings": 1,
+    "internal_couplings": 1,
+    "external_couplings": 0,
+    "critical_issues": 0,
+    "high_issues": 0,
+    "medium_issues": 0
+  },
+  "hotspots": [],
+  "issues": [],
+  "circular_dependencies": [],
+  "modules": [
+    {
+      "name": "fixture_pass::service",
+      "file_path": "src/lib.rs",
+      "couplings_out": 1,
+      "couplings_in": 0,
+      "balance_score": 0.91,
+      "in_cycle": false
+    }
+  ]
+}
+JSON
+    ;;
+  *)
+    echo "unsupported docker command: $command" >&2
+    exit 1
+    ;;
+esac
+`,
+	);
+}
+
+function createCargoCouplingSourceArchive(context) {
+	const sourceRoot = path.join(context.tempDir, "cargo-coupling-source");
+	const archiveRoot = path.join(sourceRoot, "cargo-coupling-src");
+	const archivePath = path.join(
+		context.tempDir,
+		"cargo-coupling-source.tar.gz",
+	);
+
+	writeFile(
+		path.join(archiveRoot, "Cargo.toml"),
+		`[package]
+name = "cargo-coupling"
+version = "0.3.2"
+edition = "2021"
+`,
+	);
+	writeFile(path.join(archiveRoot, "src/main.rs"), "fn main() {}\n");
+	execFileSync(
+		"tar",
+		[
+			"--sort=name",
+			"--mtime=@0",
+			"--owner=0",
+			"--group=0",
+			"--numeric-owner",
+			"-czf",
+			archivePath,
+			"-C",
+			sourceRoot,
+			"cargo-coupling-src",
+		],
+		{ encoding: "utf8" },
+	);
+
+	return {
+		archivePath,
+		archiveSha256: createHash("sha256")
+			.update(fs.readFileSync(archivePath))
+			.digest("hex"),
+	};
+}
+
+function createCurlStub(binDir) {
+	writeExecutable(
+		path.join(binDir, "curl"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+output_path=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      output_path="$2"
+      shift 2
+      ;;
+    -f|-s|-S|-L|-fsSL)
+      shift
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$output_path" ]; then
+  echo "missing curl output path" >&2
+  exit 1
+fi
+
+printf '%s\\n' "$url" >> "$CURL_LOG"
+if [ -z "\${STUB_CARGO_COUPLING_ARCHIVE:-}" ]; then
+  echo "missing STUB_CARGO_COUPLING_ARCHIVE" >&2
+  exit 1
+fi
+cp "$STUB_CARGO_COUPLING_ARCHIVE" "$output_path"
+`,
+	);
+}
+
+function setupTooling(context) {
+	const cargoCouplingSourceArchive = createCargoCouplingSourceArchive(context);
+
+	writeFile(path.join(context.repoDir, ".git/HEAD"), "ref: refs/heads/test\n");
+	createCargoStub(context.binDir);
+	createCurlStub(context.binDir);
+	createDockerStub(context.binDir);
+
+	const tooling = {
+		cargoCouplingSourceArchivePath: cargoCouplingSourceArchive.archivePath,
+		cargoCouplingSourceArchiveSha256: cargoCouplingSourceArchive.archiveSha256,
+		curlLog: path.join(context.tempDir, "curl.log"),
+		dockerBuildLog: path.join(context.tempDir, "docker-build.log"),
+		dockerImageInspectLog: path.join(
+			context.tempDir,
+			"docker-image-inspect.log",
+		),
+		dockerManifestLog: path.join(context.tempDir, "docker-manifests.log"),
+		dockerPullLog: path.join(context.tempDir, "docker-pull.log"),
+		dockerRunArgsLog: path.join(context.tempDir, "docker-run-args.log"),
+		worktreeGitLog: path.join(context.tempDir, "worktree-git.log"),
+	};
+
+	return {
+		...tooling,
+		env: {
+			CARGO_COUPLING_SOURCE_ARCHIVE_SHA256:
+				cargoCouplingSourceArchive.archiveSha256,
+			CURL_LOG: tooling.curlLog,
+			DOCKER_BUILD_LOG: tooling.dockerBuildLog,
+			DOCKER_IMAGE_INSPECT_LOG: tooling.dockerImageInspectLog,
+			DOCKER_MANIFEST_LOG: tooling.dockerManifestLog,
+			DOCKER_PULL_LOG: tooling.dockerPullLog,
+			DOCKER_RUN_ARGS_LOG: tooling.dockerRunArgsLog,
+			STUB_CARGO_COUPLING_ARCHIVE: cargoCouplingSourceArchive.archivePath,
+			WORKTREE_GIT_LOG: tooling.worktreeGitLog,
+		},
+	};
+}
+
+test("cargo-coupling install builds the pinned local container image when missing", () => {
+	const context = makeTempRepo("cargo-coupling-install-");
+	const tooling = setupTooling(context);
+
+	try {
+		execFileSync("bash", [installPath], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: {
+				...process.env,
+				...tooling.env,
+				MISSING_IMAGE: "1",
+				PATH: `${context.binDir}:${process.env.PATH}`,
+				RUNNER_TEMP: context.runnerTemp,
+			},
+		});
+
+		assert.match(
+			fs.readFileSync(tooling.dockerImageInspectLog, "utf8"),
+			/localhost\/linter-service-cargo-coupling:0\.3\.2-[a-f0-9]{12}/,
+		);
+		assert.match(
+			fs.readFileSync(tooling.curlLog, "utf8"),
+			/github\.com\/nwiizo\/cargo-coupling\/archive\/refs\/tags\/v0\.3\.2\.tar\.gz/,
+		);
+		assert.match(
+			fs.readFileSync(tooling.dockerBuildLog, "utf8"),
+			/--tag localhost\/linter-service-cargo-coupling:0\.3\.2-[a-f0-9]{12}/,
+		);
+		assert.match(
+			fs.readFileSync(tooling.dockerBuildLog, "utf8"),
+			/--file .*cargo-coupling-image\/source\/Dockerfile\.full .*cargo-coupling-image\/source/,
+		);
+		assert.equal(fs.existsSync(tooling.dockerPullLog), false);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("cargo-coupling image ref changes when build inputs change", () => {
+	const defaultEnv = {
+		...process.env,
+		CARGO_COUPLING_VERSION: "v0.3.2",
+		CARGO_COUPLING_SOURCE_ARCHIVE_SHA256:
+			"1111111111111111111111111111111111111111111111111111111111111111",
+	};
+	const alternateEnv = {
+		...defaultEnv,
+		CARGO_COUPLING_SOURCE_ARCHIVE_SHA256:
+			"2222222222222222222222222222222222222222222222222222222222222222",
+	};
+	const defaultImageRef = execFileSync(
+		"bash",
+		["-lc", `source "${commonPath}" && cargo_coupling_image_ref`],
+		{
+			cwd: __dirname,
+			encoding: "utf8",
+			env: defaultEnv,
+		},
+	).trim();
+	const alternateImageRef = execFileSync(
+		"bash",
+		["-lc", `source "${commonPath}" && cargo_coupling_image_ref`],
+		{
+			cwd: __dirname,
+			encoding: "utf8",
+			env: alternateEnv,
+		},
+	).trim();
+
+	assert.notEqual(defaultImageRef, alternateImageRef);
+	assert.match(
+		defaultImageRef,
+		/^localhost\/linter-service-cargo-coupling:0\.3\.2-[a-f0-9]{12}$/u,
+	);
+});
+
+test("cargo-coupling install rejects an unexpected source archive checksum", () => {
+	const context = makeTempRepo("cargo-coupling-install-checksum-");
+	const tooling = setupTooling(context);
+
+	try {
+		let error;
+		assert.throws(() => {
+			try {
+				execFileSync("bash", [installPath], {
+					cwd: context.repoDir,
+					encoding: "utf8",
+					env: {
+						...process.env,
+						...tooling.env,
+						CARGO_COUPLING_SOURCE_ARCHIVE_SHA256: "deadbeef",
+						MISSING_IMAGE: "1",
+						PATH: `${context.binDir}:${process.env.PATH}`,
+						RUNNER_TEMP: context.runnerTemp,
+					},
+				});
+			} catch (e) {
+				error = e;
+				throw e;
+			}
+		});
+
+		assert.match(error.stderr, /source archive checksum mismatch/u);
+		assert.equal(fs.existsSync(tooling.dockerBuildLog), false);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+defineCommonCargoManifestTests({
+	runPath,
+	tempPrefix: "cargo-coupling-",
+	toolName: "cargo-coupling.sh",
+	setupTooling,
+	assertGroupedResult({ context, result, tooling }) {
+		const runArgs = fs.readFileSync(tooling.dockerRunArgsLog, "utf8");
+
+		assert.equal(result.exit_code, 0);
+		assert.deepEqual(
+			fs.readFileSync(tooling.dockerManifestLog, "utf8").trim().split("\n"),
+			["Cargo.toml", "crates/member/Cargo.toml"],
+		);
+		assert.match(runArgs, /--network=none/);
+		assert.match(runArgs, /--read-only/);
+		assert.match(runArgs, /--tmpfs \/tmp/);
+		assert.match(runArgs, /--json --no-git src/);
+		assert.match(runArgs, /--json --no-git crates\/member\/src/);
+		assert.deepEqual(
+			fs.readFileSync(tooling.worktreeGitLog, "utf8").trim().split("\n"),
+			["absent", "absent"],
+		);
+		assert.match(result.details, /Quality gate: PASSED/);
+	},
+	assertMissingManifestResult({ pathValue, result, tooling }) {
+		assert.equal(result.exit_code, 1);
+		assert.match(result.details, /No Cargo\.toml found for:/);
+		assert.match(
+			result.details,
+			new RegExp(pathValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+		);
+		assert.equal(fs.existsSync(tooling.dockerRunArgsLog), false);
+	},
+	continueFailureEnv: {
+		FAIL_MANIFEST: "Cargo.toml",
+	},
+	assertContinueAfterFailureResult({ result }) {
+		assert.equal(result.exit_code, 1);
+		assert.match(result.details, /cargo-coupling failed for Cargo\.toml/);
+	},
+});
+
+test("cargo-coupling rejects repository-supplied Cargo config on the shared path", () => {
+	const context = makeTempRepo("cargo-coupling-unsafe-config-");
+	const tooling = setupTooling(context);
+
+	writeFile(
+		path.join(context.repoDir, "Cargo.toml"),
+		`[package]
+name = "root"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(path.join(context.repoDir, "src/lib.rs"), "pub fn root_lib() {}\n");
+	writeFile(
+		path.join(context.repoDir, ".cargo/config.toml"),
+		`[registries.private]
+index = "sparse+https://example.invalid/index/"
+`,
+	);
+
+	try {
+		const output = execFileSync("bash", [runPath, "src/lib.rs"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: {
+				...process.env,
+				...tooling.env,
+				PATH: `${context.binDir}:${process.env.PATH}`,
+				RUNNER_TEMP: context.runnerTemp,
+			},
+		});
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 1);
+		assert.match(
+			result.details,
+			/Repository-supplied `\.cargo\/config\.toml` is not supported/,
+		);
+		assert.equal(fs.existsSync(tooling.dockerRunArgsLog), false);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("cargo-coupling reads repository thresholds from linter-service config", () => {
+	const context = makeTempRepo("cargo-coupling-config-");
+	const tooling = setupTooling(context);
+
+	writeFile(
+		path.join(context.repoDir, "Cargo.toml"),
+		`[package]
+name = "root"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(path.join(context.repoDir, "src/lib.rs"), "pub fn root_lib() {}\n");
+	writeFile(
+		path.join(context.repoDir, ".github/linter-service.yaml"),
+		[
+			"linters:",
+			"  cargo-coupling:",
+			"    min_grade: C",
+			"    max_critical: 1",
+			"    max_circular: 1",
+			"",
+		].join("\n"),
+	);
+
+	try {
+		const output = execFileSync("bash", [runPath, "src/lib.rs"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: {
+				...process.env,
+				...tooling.env,
+				COUPLING_RELAXED: "1",
+				PATH: `${context.binDir}:${process.env.PATH}`,
+				RUNNER_TEMP: context.runnerTemp,
+			},
+		});
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 0);
+		assert.match(
+			result.details,
+			/Thresholds: min_grade=C, max_critical=1, max_circular=1/,
+		);
+		assert.match(result.details, /Quality gate: PASSED/);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("cargo-coupling keeps member crate analysis scoped to the selected package in workspaces", () => {
+	const context = makeTempRepo("cargo-coupling-workspace-member-");
+	const tooling = setupTooling(context);
+
+	writeFile(
+		path.join(context.repoDir, "Cargo.toml"),
+		`[package]
+name = "workspace-root"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+members = ["crates/member"]
+`,
+	);
+	writeFile(path.join(context.repoDir, "src/lib.rs"), "pub fn root_lib() {}\n");
+	writeFile(
+		path.join(context.repoDir, "crates/member/Cargo.toml"),
+		`[package]
+name = "member"
+version = "0.1.0"
+edition = "2021"
+`,
+	);
+	writeFile(
+		path.join(context.repoDir, "crates/member/src/lib.rs"),
+		"pub fn member_lib() {}\n",
+	);
+
+	try {
+		const output = execFileSync("bash", [runPath, "crates/member/src/lib.rs"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: {
+				...process.env,
+				...tooling.env,
+				PATH: `${context.binDir}:${process.env.PATH}`,
+				RUNNER_TEMP: context.runnerTemp,
+			},
+		});
+		const result = JSON.parse(output);
+		const runArgs = fs.readFileSync(tooling.dockerRunArgsLog, "utf8");
+
+		assert.equal(result.exit_code, 0);
+		assert.doesNotMatch(runArgs, /--json --no-git src/u);
+		assert.match(runArgs, /--json --no-git crates\/member\/src/u);
+		assert.deepEqual(
+			fs.readFileSync(tooling.dockerManifestLog, "utf8").trim().split("\n"),
+			["crates/member/Cargo.toml"],
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/cargo-coupling/cargo-coupling.test.js
+++ b/cargo-coupling/cargo-coupling.test.js
@@ -559,6 +559,7 @@ defineCommonCargoManifestTests({
 		assert.match(runArgs, /--network=none/);
 		assert.match(runArgs, /--read-only/);
 		assert.match(runArgs, /--tmpfs \/tmp/);
+		assert.doesNotMatch(runArgs, /dst=\/work,ro/);
 		assert.match(runArgs, /coupling --json --no-git src/);
 		assert.match(runArgs, /coupling --json --no-git crates\/member\/src/);
 		assert.deepEqual(
@@ -723,6 +724,7 @@ edition = "2021"
 		const runArgs = fs.readFileSync(tooling.dockerRunArgsLog, "utf8");
 
 		assert.equal(result.exit_code, 0);
+		assert.doesNotMatch(runArgs, /dst=\/work,ro/u);
 		assert.doesNotMatch(runArgs, /coupling --json --no-git src/u);
 		assert.match(runArgs, /coupling --json --no-git crates\/member\/src/u);
 		assert.deepEqual(

--- a/cargo-coupling/common.sh
+++ b/cargo-coupling/common.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../.github/scripts/linter-library.sh
+source "$script_dir/../.github/scripts/linter-library.sh"
+
+cargo_coupling::sha256_prefix() {
+  local input=${1-}
+  local prefix_length=${2:?}
+  local digest
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    digest=$(printf '%s' "$input" | sha256sum | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    digest=$(printf '%s' "$input" | shasum -a 256 | awk '{print $1}')
+  elif command -v python3 >/dev/null 2>&1; then
+    digest=$(printf '%s' "$input" | python3 -c 'import hashlib,sys; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest())')
+  else
+    echo "sha256sum, shasum, or python3 is required to derive the cargo-coupling image tag" >&2
+    return 1
+  fi
+
+  printf '%s\n' "${digest:0:$prefix_length}"
+}
+
+cargo_coupling::read_install_assignment() {
+  local variable_name=${1:?}
+  local value
+
+  value=$(sed -n "s/^${variable_name}=\"\\([^\"]*\\)\"$/\\1/p" "$script_dir/install.sh")
+  if [ -z "$value" ]; then
+    echo "Failed to read ${variable_name} from $script_dir/install.sh" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$value"
+}
+
+cargo_coupling_source_version() {
+  printf '%s\n' "${CARGO_COUPLING_VERSION:-$(cargo_coupling::read_install_assignment cargo_coupling_version)}"
+}
+
+cargo_coupling_source_archive_sha256() {
+  printf '%s\n' "${CARGO_COUPLING_SOURCE_ARCHIVE_SHA256:-$(cargo_coupling::read_install_assignment cargo_coupling_source_archive_sha256)}"
+}
+
+cargo_coupling_image_tag() {
+  local source_version source_archive_sha256 dockerfile_contents build_hash
+
+  source_version=$(cargo_coupling_source_version)
+  source_archive_sha256=$(cargo_coupling_source_archive_sha256)
+  dockerfile_contents=$(cat "$script_dir/Dockerfile.full")
+  build_hash=$(
+    cargo_coupling::sha256_prefix \
+      "$(printf '%s\n%s\n%s' "$source_version" "$source_archive_sha256" "$dockerfile_contents")" \
+      12
+  )
+
+  printf '%s\n' "${source_version#v}-${build_hash}"
+}
+
+cargo_coupling_image_ref() {
+  local image_tag
+
+  image_tag=$(cargo_coupling_image_tag)
+  printf '%s\n' "${CARGO_COUPLING_IMAGE_REF:-localhost/linter-service-cargo-coupling:${image_tag}}"
+}
+
+cargo_coupling_container_bin() {
+  local docker_bin resolved_bin podman_bin
+
+  podman_bin="${CONTROL_PLANE_PODMAN_BIN:-/usr/bin/podman}"
+  docker_bin=""
+  resolved_bin=""
+
+  if command -v docker >/dev/null 2>&1; then
+    docker_bin=$(command -v docker)
+    resolved_bin="$docker_bin"
+  elif command -v podman >/dev/null 2>&1; then
+    printf '%s\n' "$(command -v podman)"
+    return 0
+  else
+    echo "docker or podman is required to run cargo-coupling in an isolated container" >&2
+    return 1
+  fi
+
+  if command -v readlink >/dev/null 2>&1; then
+    resolved_bin=$(readlink -f "$docker_bin" 2>/dev/null || printf '%s\n' "$docker_bin")
+  fi
+
+  if [ "$(basename "$resolved_bin")" = "control-plane-podman" ] && [ -x "$podman_bin" ]; then
+    printf '%s\n' "$podman_bin"
+    return 0
+  fi
+
+  printf '%s\n' "$docker_bin"
+}
+
+cargo_coupling_require_container_runtime() {
+  if ! command -v docker >/dev/null 2>&1 && ! command -v podman >/dev/null 2>&1; then
+    echo "docker or podman is required to run cargo-coupling in an isolated container" >&2
+    return 1
+  fi
+}
+
+cargo_coupling_analysis_path_for_manifest() {
+  local manifest_path=$1
+  local manifest_dir src_dir
+
+  manifest_dir=$(dirname "$manifest_path")
+  src_dir="$manifest_dir/src"
+
+  if [ "$manifest_dir" = "." ]; then
+    if [ -d src ]; then
+      printf '%s\n' "src"
+    else
+      printf '%s\n' "."
+    fi
+    return 0
+  fi
+
+  if [ -d "$src_dir" ]; then
+    printf '%s\n' "$src_dir"
+    return 0
+  fi
+
+  printf '%s\n' "$manifest_dir"
+}

--- a/cargo-coupling/config_trigger_patterns.sh
+++ b/cargo-coupling/config_trigger_patterns.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cat <<'EOF'
+(?:^|/)\.github/linter-service\.(?:json|ya?ml)$
+(?:^|/)(?:\.coupling\.toml|coupling\.toml|\.cargo/config(?:\.toml)?)$
+EOF

--- a/cargo-coupling/install.sh
+++ b/cargo-coupling/install.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=./common.sh
+source "$script_dir/common.sh"
+
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+cargo_coupling_require_container_runtime
+
+container_bin=$(cargo_coupling_container_bin)
+# renovate: datasource=github-tags depName=nwiizo/cargo-coupling
+cargo_coupling_version="v0.3.2"
+cargo_coupling_source_archive_sha256="0bbfe05d0302fd6752b5e4b512226820e13e52498dc3bc1ce03e172e19cbd556"
+image_ref=$(cargo_coupling_image_ref)
+build_root="$RUNNER_TEMP/cargo-coupling-image"
+archive_path="$build_root/cargo-coupling.tar.gz"
+source_dir="$build_root/source"
+dockerfile_path="$source_dir/Dockerfile.full"
+source_url="https://github.com/nwiizo/cargo-coupling/archive/refs/tags/${cargo_coupling_version}.tar.gz"
+
+if "$container_bin" image inspect "$image_ref" >/dev/null 2>&1; then
+  exit 0
+fi
+
+rm -rf "$build_root"
+mkdir -p "$source_dir"
+
+cleanup_build_root() {
+  rm -rf "$build_root"
+}
+
+verify_source_archive_sha256() {
+  local archive_path=${1:?}
+  local expected_sha256 actual_sha256
+
+  expected_sha256="${CARGO_COUPLING_SOURCE_ARCHIVE_SHA256:-$cargo_coupling_source_archive_sha256}"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual_sha256=$(sha256sum "$archive_path" | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    actual_sha256=$(shasum -a 256 "$archive_path" | awk '{print $1}')
+  else
+    echo "sha256sum or shasum is required to verify cargo-coupling source archive integrity" >&2
+    return 1
+  fi
+
+  if [ "$actual_sha256" != "$expected_sha256" ]; then
+    echo "cargo-coupling source archive checksum mismatch: expected $expected_sha256 but got $actual_sha256" >&2
+    return 1
+  fi
+}
+
+trap cleanup_build_root EXIT
+
+curl -fsSL "$source_url" -o "$archive_path"
+verify_source_archive_sha256 "$archive_path"
+tar -xzf "$archive_path" -C "$source_dir" --strip-components=1
+cp "$script_dir/Dockerfile.full" "$dockerfile_path"
+
+"$container_bin" build \
+  --pull \
+  --file "$dockerfile_path" \
+  --tag "$image_ref" \
+  "$source_dir"

--- a/cargo-coupling/linter-service-config.js
+++ b/cargo-coupling/linter-service-config.js
@@ -1,0 +1,12 @@
+const { normalizeCargoCouplingConfig } = require("./cargo-coupling-config.js");
+
+function normalizeConfig({ currentConfig, entry, label }) {
+	return {
+		...entry,
+		...normalizeCargoCouplingConfig({ currentConfig, label }),
+	};
+}
+
+module.exports = {
+	normalizeConfig,
+};

--- a/cargo-coupling/load-config.js
+++ b/cargo-coupling/load-config.js
@@ -1,0 +1,28 @@
+const path = require("node:path");
+
+const {
+	getLinterConfig,
+	loadLinterServiceConfig,
+} = require("../.github/scripts/linter-service-config.js");
+const { normalizeCargoCouplingConfig } = require("./cargo-coupling-config.js");
+
+function loadCargoCouplingConfig(repositoryPath) {
+	const serviceConfig = loadLinterServiceConfig({ repositoryPath });
+	return normalizeCargoCouplingConfig({
+		currentConfig: getLinterConfig(serviceConfig, "cargo-coupling"),
+	});
+}
+
+if (require.main === module) {
+	const repositoryPath =
+		process.argv[2] && process.argv[2].length > 0
+			? path.resolve(process.argv[2])
+			: process.cwd();
+	process.stdout.write(
+		`${JSON.stringify(loadCargoCouplingConfig(repositoryPath))}\n`,
+	);
+}
+
+module.exports = {
+	loadCargoCouplingConfig,
+};

--- a/cargo-coupling/patterns.sh
+++ b/cargo-coupling/patterns.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cat <<'EOF'
+\.(?:rs)$
+EOF

--- a/cargo-coupling/render-linter-report.js
+++ b/cargo-coupling/render-linter-report.js
@@ -1,0 +1,67 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+function collectProjectTargets({ selectedFiles, sourceRepositoryPath }) {
+	const manifests = [];
+	const seen = new Set();
+
+	for (const selectedFile of selectedFiles) {
+		const manifestPath = findNearestCargoManifest(
+			sourceRepositoryPath,
+			selectedFile,
+		);
+
+		if (manifestPath && !seen.has(manifestPath)) {
+			seen.add(manifestPath);
+			manifests.push(manifestPath);
+		}
+	}
+
+	return manifests;
+}
+
+function findNearestCargoManifest(sourceRepositoryPath, filePath) {
+	const repoRoot = path.resolve(sourceRepositoryPath);
+	let currentDir = path.resolve(repoRoot, path.dirname(filePath));
+
+	if (!isWithinRoot(repoRoot, currentDir)) {
+		return null;
+	}
+
+	while (isWithinRoot(repoRoot, currentDir)) {
+		const candidate = path.join(currentDir, "Cargo.toml");
+
+		if (fs.existsSync(candidate)) {
+			return normalizePath(path.relative(repoRoot, candidate) || "Cargo.toml");
+		}
+
+		if (currentDir === repoRoot) {
+			return null;
+		}
+
+		const parentDir = path.dirname(currentDir);
+		if (parentDir === currentDir) {
+			return null;
+		}
+
+		currentDir = parentDir;
+	}
+
+	return null;
+}
+
+function isWithinRoot(rootPath, candidatePath) {
+	const relative = path.relative(rootPath, candidatePath);
+	return (
+		relative === "" ||
+		(!relative.startsWith("..") && !path.isAbsolute(relative))
+	);
+}
+
+function normalizePath(filePath) {
+	return filePath.replace(/\\/gu, "/");
+}
+
+module.exports = {
+	collectProjectTargets,
+};

--- a/cargo-coupling/render-linter-sarif.js
+++ b/cargo-coupling/render-linter-sarif.js
@@ -1,0 +1,199 @@
+function buildSarifResults({
+	createResult,
+	dedupeResults,
+	linterName,
+	normalizeReportedPath,
+	reportedPathRoots,
+	result,
+	sourceRepositoryPath,
+	targetPaths,
+}) {
+	if (linterName !== "cargo-coupling") {
+		return [];
+	}
+
+	const runs = Array.isArray(result?.cargo_coupling_runs)
+		? result.cargo_coupling_runs
+		: [];
+	const results = [];
+
+	for (const run of runs) {
+		const modulePaths = buildModulePathMap({
+			jsonOutput: run?.json_output,
+			normalizeReportedPath,
+			reportedPathRoots,
+			sourceRepositoryPath,
+			targetPaths,
+		});
+
+		for (const issue of Array.isArray(run?.json_output?.issues)
+			? run.json_output.issues
+			: []) {
+			const source = String(issue?.source || "").trim();
+			const target = String(issue?.target || "").trim();
+			const filePath =
+				modulePaths.get(source) || modulePaths.get(target) || null;
+			results.push(
+				createResult({
+					column: filePath ? 1 : null,
+					filePath,
+					level: mapIssueLevel(issue?.severity),
+					line: filePath ? 1 : null,
+					linterName,
+					message: buildIssueMessage(issue),
+					ruleId: slugifyIssueType(issue?.issue_type),
+				}),
+			);
+		}
+
+		for (const cycle of Array.isArray(run?.json_output?.circular_dependencies)
+			? run.json_output.circular_dependencies
+			: []) {
+			const firstModule = Array.isArray(cycle) ? cycle[0] : null;
+			const filePath =
+				typeof firstModule === "string"
+					? modulePaths.get(firstModule) || null
+					: null;
+			results.push(
+				createResult({
+					column: filePath ? 1 : null,
+					filePath,
+					level: "error",
+					line: filePath ? 1 : null,
+					linterName,
+					message: `Circular dependency: ${cycle.map((entry) => String(entry)).join(" -> ")}`,
+					ruleId: "cargo-coupling/circular-dependency",
+				}),
+			);
+		}
+	}
+
+	return dedupeResults(results);
+}
+
+function buildModulePathMap({
+	jsonOutput,
+	normalizeReportedPath,
+	reportedPathRoots,
+	sourceRepositoryPath,
+	targetPaths,
+}) {
+	const modules = Array.isArray(jsonOutput?.modules) ? jsonOutput.modules : [];
+	return new Map(
+		modules
+			.map((module) => {
+				if (
+					!module ||
+					typeof module.name !== "string" ||
+					typeof module.file_path !== "string"
+				) {
+					return null;
+				}
+
+				const filePath = normalizeReportedPath(
+					sourceRepositoryPath,
+					module.file_path,
+					targetPaths,
+					reportedPathRoots,
+				);
+				return filePath ? [module.name, filePath] : null;
+			})
+			.filter(Boolean),
+	);
+}
+
+function buildIssueMessage(issue) {
+	const source = String(issue?.source || "").trim();
+	const target = String(issue?.target || "").trim();
+	const description =
+		typeof issue?.description === "string" &&
+		issue.description.trim().length > 0
+			? issue.description.trim()
+			: "cargo-coupling reported an issue";
+	const suggestion =
+		typeof issue?.suggestion === "string" && issue.suggestion.trim().length > 0
+			? ` Suggestion: ${issue.suggestion.trim()}`
+			: "";
+	const subject = [source, target].filter(Boolean).join(" -> ");
+	return `${subject.length > 0 ? `${subject}: ` : ""}${description}${suggestion}`;
+}
+
+function buildSarifRules({ result }) {
+	const runs = Array.isArray(result?.cargo_coupling_runs)
+		? result.cargo_coupling_runs
+		: [];
+	const rules = new Map();
+
+	for (const run of runs) {
+		for (const issue of Array.isArray(run?.json_output?.issues)
+			? run.json_output.issues
+			: []) {
+			const id = slugifyIssueType(issue?.issue_type);
+			if (!rules.has(id)) {
+				rules.set(id, {
+					id,
+					name:
+						typeof issue?.issue_type === "string" &&
+						issue.issue_type.trim().length > 0
+							? issue.issue_type.trim()
+							: id,
+					shortDescription: {
+						text:
+							typeof issue?.issue_type === "string" &&
+							issue.issue_type.trim().length > 0
+								? issue.issue_type.trim()
+								: id,
+					},
+				});
+			}
+		}
+
+		if (
+			Array.isArray(run?.json_output?.circular_dependencies) &&
+			run.json_output.circular_dependencies.length > 0
+		) {
+			rules.set("cargo-coupling/circular-dependency", {
+				id: "cargo-coupling/circular-dependency",
+				name: "Circular Dependency",
+				shortDescription: {
+					text: "Circular Dependency",
+				},
+			});
+		}
+	}
+
+	return [...rules.values()];
+}
+
+function mapIssueLevel(severity) {
+	switch (
+		String(severity || "")
+			.trim()
+			.toLowerCase()
+	) {
+		case "critical":
+			return "error";
+		case "high":
+		case "medium":
+			return "warning";
+		case "low":
+			return "note";
+		default:
+			return "warning";
+	}
+}
+
+function slugifyIssueType(value) {
+	return `cargo-coupling/${
+		String(value || "diagnostic")
+			.trim()
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/gu, "-")
+			.replace(/^-+|-+$/gu, "") || "diagnostic"
+	}`;
+}
+
+module.exports = {
+	buildSarifResults,
+	buildSarifRules,
+};

--- a/cargo-coupling/render-linter-sarif.test.js
+++ b/cargo-coupling/render-linter-sarif.test.js
@@ -39,7 +39,7 @@ test("emits SARIF for cargo-coupling issues and cycles", () => {
 						passed: false,
 						score: 0.5,
 					},
-					command: "docker run cargo-coupling --json --no-git src",
+					command: "docker run cargo-coupling coupling --json --no-git src",
 					exit_code: 0,
 					json_output: {
 						circular_dependencies: [["demo::a", "demo::b", "demo::a"]],

--- a/cargo-coupling/render-linter-sarif.test.js
+++ b/cargo-coupling/render-linter-sarif.test.js
@@ -1,0 +1,116 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+	cleanupTempRepo,
+	makeTempRepo,
+	writeFile,
+} = require("../.github/scripts/cargo-linter-test-lib.js");
+const { runFromEnv } = require("../.github/scripts/render-linter-sarif.js");
+
+const configPath = path.join(__dirname, "..", "linters.json");
+
+test("emits SARIF for cargo-coupling issues and cycles", () => {
+	const context = makeTempRepo("render-linter-sarif-cargo-coupling-");
+
+	writeFile(
+		path.join(context.repoDir, "Cargo.toml"),
+		'[package]\nname = "demo"\nversion = "0.1.0"\nedition = "2021"\n',
+	);
+	writeFile(path.join(context.repoDir, "src/lib.rs"), "pub fn demo() {}\n");
+	writeFile(
+		path.join(context.runnerTemp, "selected-files.txt"),
+		"src/lib.rs\n",
+	);
+	writeFile(
+		path.join(context.runnerTemp, "linter-result.json"),
+		JSON.stringify({
+			cargo_coupling_runs: [
+				{
+					analysis_path: "src",
+					check_result: {
+						circular_count: 1,
+						critical_count: 1,
+						failures: ["Grade C is below minimum B"],
+						grade: "C",
+						high_count: 0,
+						medium_count: 0,
+						passed: false,
+						score: 0.5,
+					},
+					command: "docker run cargo-coupling --json --no-git src",
+					exit_code: 0,
+					json_output: {
+						circular_dependencies: [["demo::a", "demo::b", "demo::a"]],
+						hotspots: [],
+						issues: [
+							{
+								description:
+									"Intrusive coupling across a distant module boundary",
+								issue_type: "Global Complexity",
+								severity: "Critical",
+								source: "demo::a",
+								suggestion: "Introduce a trait boundary.",
+								target: "demo::b",
+							},
+						],
+						modules: [
+							{
+								file_path: "src/lib.rs",
+								name: "demo::a",
+							},
+							{
+								file_path: "src/lib.rs",
+								name: "demo::b",
+							},
+						],
+						summary: {
+							critical_issues: 1,
+							health_grade: "C",
+							health_score: 0.5,
+							high_issues: 0,
+							medium_issues: 0,
+							total_couplings: 1,
+							total_modules: 2,
+						},
+					},
+					manifest_path: "Cargo.toml",
+				},
+			],
+			details: "",
+			exit_code: 1,
+		}),
+	);
+
+	try {
+		const report = runFromEnv({
+			INSTALL_TOOL_OUTCOME: "success",
+			LINTER_CONFIG_PATH: configPath,
+			LINTER_NAME: "cargo-coupling",
+			OUTPUT_PATH: path.join(context.runnerTemp, "cargo-coupling.sarif"),
+			RESULT_PATH: path.join(context.runnerTemp, "linter-result.json"),
+			RUNNER_TEMP: context.runnerTemp,
+			RUN_LINTER_OUTCOME: "success",
+			SELECTED_FILES_PATH: path.join(context.runnerTemp, "selected-files.txt"),
+			SELECT_FILES_OUTCOME: "success",
+			SOURCE_REPOSITORY_PATH: context.repoDir,
+		});
+
+		assert.equal(report.produced, true);
+		assert.deepEqual(
+			report.sarif.runs[0].results.map((result) => result.ruleId),
+			[
+				"cargo-coupling/global-complexity",
+				"cargo-coupling/circular-dependency",
+			],
+		);
+		assert.equal(
+			report.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			"src/lib.rs",
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/cargo-coupling/run.sh
+++ b/cargo-coupling/run.sh
@@ -88,7 +88,7 @@ run_cargo_coupling() {
     analysis_path=$(cargo_coupling_analysis_path_for_manifest "$current_manifest")
     stdout_file="$run_dir/stdout.txt"
     stderr_file="$run_dir/stderr.txt"
-    command_line="docker run cargo-coupling --json --no-git $analysis_path"
+    command_line="docker run cargo-coupling coupling --json --no-git $analysis_path"
 
     set +e
     "$container_bin" run \
@@ -103,6 +103,7 @@ run_cargo_coupling() {
       --mount "type=bind,src=$source_root,dst=/work,ro" \
       --env HOME=/tmp \
       "$image_ref" \
+      coupling \
       --json \
       --no-git \
       "$analysis_path" >"$stdout_file" 2>"$stderr_file"

--- a/cargo-coupling/run.sh
+++ b/cargo-coupling/run.sh
@@ -100,7 +100,7 @@ run_cargo_coupling() {
       --tmpfs /tmp \
       --user "$user_id:$group_id" \
       --workdir /work \
-      --mount "type=bind,src=$source_root,dst=/work,ro" \
+      --mount "type=bind,src=$source_root,dst=/work" \
       --env HOME=/tmp \
       "$image_ref" \
       coupling \

--- a/cargo-coupling/run.sh
+++ b/cargo-coupling/run.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=./common.sh
+source "$script_dir/common.sh"
+
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+output_file="$RUNNER_TEMP/linter-output.txt"
+result_json_file="$RUNNER_TEMP/cargo-coupling-result.json"
+config_json_file="$RUNNER_TEMP/cargo-coupling-config.json"
+manifest_list_file="$RUNNER_TEMP/cargo-coupling-manifests.txt"
+run_entries_dir="$RUNNER_TEMP/cargo-coupling-runs"
+manifests=()
+deduped_manifests=()
+relevant_dirs=()
+unsupported_config=""
+
+rm -f "$output_file" "$result_json_file" "$config_json_file" "$manifest_list_file"
+rm -rf "$run_entries_dir"
+
+cargo_coupling_require_container_runtime
+container_bin=$(cargo_coupling_container_bin)
+image_ref=$(cargo_coupling_image_ref)
+
+if ! linter_lib::collect_cargo_manifests "$output_file" "Cargo coupling" manifests "$@"; then
+  linter_lib::emit_json_result 1 "$output_file"
+  exit 0
+fi
+
+mapfile -t relevant_dirs < <(linter_lib::collect_cargo_relevant_dirs "${manifests[@]}")
+if unsupported_config="$(linter_lib::find_unsupported_cargo_config "${relevant_dirs[@]}")"; then
+  cat > "$output_file" <<EOF
+Repository-supplied \`$unsupported_config\` is not supported in this shared linter service because \`cargo metadata\` / \`cargo-coupling\` for untrusted pull requests cannot safely honor repository-controlled Cargo configuration.
+Use the default Cargo registry configuration for the shared \`cargo-coupling\` path.
+EOF
+  linter_lib::emit_json_result 1 "$output_file"
+  exit 0
+fi
+
+workspace_root="$RUNNER_TEMP/cargo-coupling-workspace"
+source_root="$workspace_root/source"
+user_id=$(id -u)
+group_id=$(id -g)
+
+rm -rf "$workspace_root"
+mkdir -p "$workspace_root" "$run_entries_dir"
+linter_lib::copy_worktree_without_git "$source_root"
+
+cleanup_workspace() {
+  rm -rf "$workspace_root"
+}
+
+trap cleanup_workspace EXIT
+
+node "$script_dir/load-config.js" "$PWD" > "$config_json_file"
+
+cargo_coupling_dedupe_manifests() {
+  local -A seen_manifests=()
+  local manifest_path
+
+  for manifest_path in "${manifests[@]}"; do
+    if [ -n "${seen_manifests[$manifest_path]+x}" ]; then
+      continue
+    fi
+
+    seen_manifests["$manifest_path"]=1
+    printf '%s\n' "$manifest_path"
+  done
+}
+
+mapfile -t deduped_manifests < <(cargo_coupling_dedupe_manifests)
+
+run_cargo_coupling() {
+  local failure=0
+  local current_manifest analysis_path run_dir run_exit command_line stdout_file stderr_file
+  local run_index=0
+
+  cd "$source_root"
+  rm -rf "$run_entries_dir"
+  mkdir -p "$run_entries_dir"
+
+  for current_manifest in "${deduped_manifests[@]}"; do
+    run_index=$((run_index + 1))
+    run_dir=$(printf '%s/%04d' "$run_entries_dir" "$run_index")
+    mkdir -p "$run_dir"
+    analysis_path=$(cargo_coupling_analysis_path_for_manifest "$current_manifest")
+    stdout_file="$run_dir/stdout.txt"
+    stderr_file="$run_dir/stderr.txt"
+    command_line="docker run cargo-coupling --json --no-git $analysis_path"
+
+    set +e
+    "$container_bin" run \
+      --rm \
+      --cap-drop ALL \
+      --security-opt no-new-privileges \
+      --network=none \
+      --read-only \
+      --tmpfs /tmp \
+      --user "$user_id:$group_id" \
+      --workdir /work \
+      --mount "type=bind,src=$source_root,dst=/work,ro" \
+      --env HOME=/tmp \
+      "$image_ref" \
+      --json \
+      --no-git \
+      "$analysis_path" >"$stdout_file" 2>"$stderr_file"
+    run_exit=$?
+    set -e
+
+    printf '%s\n' "$analysis_path" > "$run_dir/analysis_path.txt"
+    printf '%s\n' "$command_line" > "$run_dir/command.txt"
+    printf '%s\n' "$current_manifest" > "$run_dir/manifest_path.txt"
+    printf '%s\n' "$run_exit" > "$run_dir/exit_code.txt"
+
+    if [ "$run_exit" -ne 0 ]; then
+      failure=1
+    fi
+  done
+
+  return "$failure"
+}
+
+if run_cargo_coupling; then
+  command_exit_code=0
+else
+  command_exit_code=1
+fi
+
+node "$script_dir/cargo-coupling-result.js" \
+  "$run_entries_dir" \
+  "$config_json_file" \
+  "$command_exit_code" > "$result_json_file"
+cat "$result_json_file"

--- a/cargo-coupling/tests/fail/result.json
+++ b/cargo-coupling/tests/fail/result.json
@@ -1,0 +1,93 @@
+{
+  "checked_projects": [
+    "Cargo.toml"
+  ],
+  "result": {
+    "cargo_coupling_runs": [
+      {
+        "analysis_path": "src",
+        "command": "docker run cargo-coupling --json --no-git src",
+        "check_result": {
+          "circular_count": 1,
+          "critical_count": 1,
+          "failures": [
+            "Grade C is below minimum B",
+            "1 critical issues (max: 0)",
+            "1 circular dependencies (max: 0)"
+          ],
+          "grade": "C",
+          "high_count": 0,
+          "medium_count": 1,
+          "passed": false,
+          "score": 0.62
+        },
+        "exit_code": 0,
+        "json_output": {
+          "circular_dependencies": [
+            [
+              "fixture_fail::handler",
+              "fixture_fail::query",
+              "fixture_fail::handler"
+            ]
+          ],
+          "hotspots": [],
+          "issues": [
+            {
+              "balance_score": 0.24,
+              "description": "Intrusive coupling across a distant module boundary",
+              "issue_type": "Global Complexity",
+              "severity": "Critical",
+              "source": "fixture_fail::handler",
+              "suggestion": "Introduce a trait boundary between handler and query.",
+              "target": "fixture_fail::query"
+            },
+            {
+              "balance_score": 0.49,
+              "description": "Module attracts many internal dependencies",
+              "issue_type": "High Afferent Coupling",
+              "severity": "Medium",
+              "source": "fixture_fail::handler",
+              "suggestion": "Split responsibilities or hide internals behind a smaller API.",
+              "target": ""
+            }
+          ],
+          "modules": [
+            {
+              "balance_score": 0.24,
+              "couplings_in": 1,
+              "couplings_out": 1,
+              "file_path": "src/lib.rs",
+              "in_cycle": true,
+              "name": "fixture_fail::handler"
+            },
+            {
+              "balance_score": 0.49,
+              "couplings_in": 1,
+              "couplings_out": 1,
+              "file_path": "src/lib.rs",
+              "in_cycle": true,
+              "name": "fixture_fail::query"
+            }
+          ],
+          "summary": {
+            "critical_issues": 1,
+            "external_couplings": 0,
+            "health_grade": "C",
+            "health_score": 0.62,
+            "high_issues": 0,
+            "internal_couplings": 2,
+            "medium_issues": 1,
+            "total_couplings": 2,
+            "total_modules": 2
+          }
+        },
+        "manifest_path": "Cargo.toml"
+      }
+    ],
+    "details": "==> docker run cargo-coupling --json --no-git src\nGrade: C | Score: 62% | Quality gate: FAILED\nThresholds: min_grade=B, max_critical=0, max_circular=0\nModules: 2 | Couplings: 2 | Critical: 1 | High: 0 | Medium: 1 | Circular: 1\nBlocking issues:\n - Grade C is below minimum B\n - 1 critical issues (max: 0)\n - 1 circular dependencies (max: 0)\nIssues:\nsrc/lib.rs: fixture_fail::handler -> fixture_fail::query: critical[Global Complexity]: Intrusive coupling across a distant module boundary\n suggestion: Introduce a trait boundary between handler and query.\nsrc/lib.rs: fixture_fail::handler: medium[High Afferent Coupling]: Module attracts many internal dependencies\n suggestion: Split responsibilities or hide internals behind a smaller API.\nCircular dependencies:\n - fixture_fail::handler -> fixture_fail::query -> fixture_fail::handler",
+    "exit_code": 1
+  },
+  "selected_files": [
+    "src/lib.rs"
+  ]
+}

--- a/cargo-coupling/tests/fail/result.json
+++ b/cargo-coupling/tests/fail/result.json
@@ -1,110 +1,99 @@
 {
-  "checked_projects": [
-    "Cargo.toml"
-  ],
-  "result": {
-    "cargo_coupling_runs": [
-      {
-        "analysis_path": "src",
-        "command": "docker run cargo-coupling coupling --json --no-git src",
-        "check_result": {
-          "circular_count": 1,
-          "critical_count": 0,
-          "failures": [
-            "1 circular dependencies (max: 0)"
-          ],
-          "grade": "B",
-          "high_count": 0,
-          "medium_count": 0,
-          "passed": false,
-          "score": 0.75
-        },
-        "exit_code": 0,
-        "json_output": {
-          "circular_dependencies": [
-            [
-              "fixture-fail::handler",
-              "fixture-fail::query"
-            ]
-          ],
-          "hotspots": [
-            {
-              "file_path": null,
-              "in_cycle": true,
-              "issues": [
-                {
-                  "description": "Part of a circular dependency cycle",
-                  "issue_type": "CircularDependency",
-                  "severity": "Critical"
-                }
-              ],
-              "module": "fixture-fail::handler",
-              "score": 40,
-              "suggestion": "Break circular dependency by extracting shared types or inverting with traits"
-            },
-            {
-              "file_path": null,
-              "in_cycle": true,
-              "issues": [
-                {
-                  "description": "Part of a circular dependency cycle",
-                  "issue_type": "CircularDependency",
-                  "severity": "Critical"
-                }
-              ],
-              "module": "fixture-fail::query",
-              "score": 40,
-              "suggestion": "Break circular dependency by extracting shared types or inverting with traits"
-            }
-          ],
-          "issues": [],
-          "modules": [
-            {
-              "balance_score": 1,
-              "couplings_in": 0,
-              "couplings_out": 0,
-              "file_path": "src/handler.rs",
-              "in_cycle": false,
-              "name": "handler"
-            },
-            {
-              "balance_score": 1,
-              "couplings_in": 0,
-              "couplings_out": 0,
-              "file_path": "src/lib.rs",
-              "in_cycle": false,
-              "name": "lib"
-            },
-            {
-              "balance_score": 1,
-              "couplings_in": 0,
-              "couplings_out": 0,
-              "file_path": "src/query.rs",
-              "in_cycle": false,
-              "name": "query"
-            }
-          ],
-          "summary": {
-            "critical_issues": 0,
-            "external_couplings": 0,
-            "health_grade": "B",
-            "health_score": 0.75,
-            "high_issues": 0,
-            "internal_couplings": 2,
-            "medium_issues": 0,
-            "total_couplings": 2,
-            "total_modules": 3
-          }
-        },
-        "manifest_path": "Cargo.toml"
-      }
-    ],
-    "details": "==> docker run cargo-coupling coupling --json --no-git src\nGrade: B | Score: 75% | Quality gate: FAILED\nThresholds: min_grade=B, max_critical=0, max_circular=0\nModules: 3 | Couplings: 2 | Critical: 0 | High: 0 | Medium: 0 | Circular: 1\nBlocking issues:\n - 1 circular dependencies (max: 0)\nCircular dependencies:\n - fixture-fail::handler -> fixture-fail::query\nAnalyzing project at 'src'...\nAnalysis complete: 3 files, 3 modules",
-    "exit_code": 1
-  },
-  "selected_files": [
-    "src/handler.rs",
-    "src/lib.rs",
-    "src/query.rs"
-  ]
+	"checked_projects": ["Cargo.toml"],
+	"result": {
+		"cargo_coupling_runs": [
+			{
+				"analysis_path": "src",
+				"command": "docker run cargo-coupling coupling --json --no-git src",
+				"check_result": {
+					"circular_count": 1,
+					"critical_count": 0,
+					"failures": ["1 circular dependencies (max: 0)"],
+					"grade": "B",
+					"high_count": 0,
+					"medium_count": 0,
+					"passed": false,
+					"score": 0.75
+				},
+				"exit_code": 0,
+				"json_output": {
+					"circular_dependencies": [
+						["fixture-fail::handler", "fixture-fail::query"]
+					],
+					"hotspots": [
+						{
+							"file_path": null,
+							"in_cycle": true,
+							"issues": [
+								{
+									"description": "Part of a circular dependency cycle",
+									"issue_type": "CircularDependency",
+									"severity": "Critical"
+								}
+							],
+							"module": "fixture-fail::handler",
+							"score": 40,
+							"suggestion": "Break circular dependency by extracting shared types or inverting with traits"
+						},
+						{
+							"file_path": null,
+							"in_cycle": true,
+							"issues": [
+								{
+									"description": "Part of a circular dependency cycle",
+									"issue_type": "CircularDependency",
+									"severity": "Critical"
+								}
+							],
+							"module": "fixture-fail::query",
+							"score": 40,
+							"suggestion": "Break circular dependency by extracting shared types or inverting with traits"
+						}
+					],
+					"issues": [],
+					"modules": [
+						{
+							"balance_score": 1,
+							"couplings_in": 0,
+							"couplings_out": 0,
+							"file_path": "src/handler.rs",
+							"in_cycle": false,
+							"name": "handler"
+						},
+						{
+							"balance_score": 1,
+							"couplings_in": 0,
+							"couplings_out": 0,
+							"file_path": "src/lib.rs",
+							"in_cycle": false,
+							"name": "lib"
+						},
+						{
+							"balance_score": 1,
+							"couplings_in": 0,
+							"couplings_out": 0,
+							"file_path": "src/query.rs",
+							"in_cycle": false,
+							"name": "query"
+						}
+					],
+					"summary": {
+						"critical_issues": 0,
+						"external_couplings": 0,
+						"health_grade": "B",
+						"health_score": 0.75,
+						"high_issues": 0,
+						"internal_couplings": 2,
+						"medium_issues": 0,
+						"total_couplings": 2,
+						"total_modules": 3
+					}
+				},
+				"manifest_path": "Cargo.toml"
+			}
+		],
+		"details": "==> docker run cargo-coupling coupling --json --no-git src\nGrade: B | Score: 75% | Quality gate: FAILED\nThresholds: min_grade=B, max_critical=0, max_circular=0\nModules: 3 | Couplings: 2 | Critical: 0 | High: 0 | Medium: 0 | Circular: 1\nBlocking issues:\n - 1 circular dependencies (max: 0)\nCircular dependencies:\n - fixture-fail::handler -> fixture-fail::query\nAnalyzing project at 'src'...\nAnalysis complete: 3 files, 3 modules",
+		"exit_code": 1
+	},
+	"selected_files": ["src/handler.rs", "src/lib.rs", "src/query.rs"]
 }

--- a/cargo-coupling/tests/fail/result.json
+++ b/cargo-coupling/tests/fail/result.json
@@ -6,7 +6,7 @@
     "cargo_coupling_runs": [
       {
         "analysis_path": "src",
-        "command": "docker run cargo-coupling --json --no-git src",
+        "command": "docker run cargo-coupling coupling --json --no-git src",
         "check_result": {
           "circular_count": 1,
           "critical_count": 1,
@@ -84,7 +84,7 @@
         "manifest_path": "Cargo.toml"
       }
     ],
-    "details": "==> docker run cargo-coupling --json --no-git src\nGrade: C | Score: 62% | Quality gate: FAILED\nThresholds: min_grade=B, max_critical=0, max_circular=0\nModules: 2 | Couplings: 2 | Critical: 1 | High: 0 | Medium: 1 | Circular: 1\nBlocking issues:\n - Grade C is below minimum B\n - 1 critical issues (max: 0)\n - 1 circular dependencies (max: 0)\nIssues:\nsrc/lib.rs: fixture_fail::handler -> fixture_fail::query: critical[Global Complexity]: Intrusive coupling across a distant module boundary\n suggestion: Introduce a trait boundary between handler and query.\nsrc/lib.rs: fixture_fail::handler: medium[High Afferent Coupling]: Module attracts many internal dependencies\n suggestion: Split responsibilities or hide internals behind a smaller API.\nCircular dependencies:\n - fixture_fail::handler -> fixture_fail::query -> fixture_fail::handler",
+    "details": "==> docker run cargo-coupling coupling --json --no-git src\nGrade: C | Score: 62% | Quality gate: FAILED\nThresholds: min_grade=B, max_critical=0, max_circular=0\nModules: 2 | Couplings: 2 | Critical: 1 | High: 0 | Medium: 1 | Circular: 1\nBlocking issues:\n - Grade C is below minimum B\n - 1 critical issues (max: 0)\n - 1 circular dependencies (max: 0)\nIssues:\nsrc/lib.rs: fixture_fail::handler -> fixture_fail::query: critical[Global Complexity]: Intrusive coupling across a distant module boundary\n suggestion: Introduce a trait boundary between handler and query.\nsrc/lib.rs: fixture_fail::handler: medium[High Afferent Coupling]: Module attracts many internal dependencies\n suggestion: Split responsibilities or hide internals behind a smaller API.\nCircular dependencies:\n - fixture_fail::handler -> fixture_fail::query -> fixture_fail::handler",
     "exit_code": 1
   },
   "selected_files": [

--- a/cargo-coupling/tests/fail/result.json
+++ b/cargo-coupling/tests/fail/result.json
@@ -9,85 +9,102 @@
         "command": "docker run cargo-coupling coupling --json --no-git src",
         "check_result": {
           "circular_count": 1,
-          "critical_count": 1,
+          "critical_count": 0,
           "failures": [
-            "Grade C is below minimum B",
-            "1 critical issues (max: 0)",
             "1 circular dependencies (max: 0)"
           ],
-          "grade": "C",
+          "grade": "B",
           "high_count": 0,
-          "medium_count": 1,
+          "medium_count": 0,
           "passed": false,
-          "score": 0.62
+          "score": 0.75
         },
         "exit_code": 0,
         "json_output": {
           "circular_dependencies": [
             [
-              "fixture_fail::handler",
-              "fixture_fail::query",
-              "fixture_fail::handler"
+              "fixture-fail::handler",
+              "fixture-fail::query"
             ]
           ],
-          "hotspots": [],
-          "issues": [
+          "hotspots": [
             {
-              "balance_score": 0.24,
-              "description": "Intrusive coupling across a distant module boundary",
-              "issue_type": "Global Complexity",
-              "severity": "Critical",
-              "source": "fixture_fail::handler",
-              "suggestion": "Introduce a trait boundary between handler and query.",
-              "target": "fixture_fail::query"
+              "file_path": null,
+              "in_cycle": true,
+              "issues": [
+                {
+                  "description": "Part of a circular dependency cycle",
+                  "issue_type": "CircularDependency",
+                  "severity": "Critical"
+                }
+              ],
+              "module": "fixture-fail::handler",
+              "score": 40,
+              "suggestion": "Break circular dependency by extracting shared types or inverting with traits"
             },
             {
-              "balance_score": 0.49,
-              "description": "Module attracts many internal dependencies",
-              "issue_type": "High Afferent Coupling",
-              "severity": "Medium",
-              "source": "fixture_fail::handler",
-              "suggestion": "Split responsibilities or hide internals behind a smaller API.",
-              "target": ""
+              "file_path": null,
+              "in_cycle": true,
+              "issues": [
+                {
+                  "description": "Part of a circular dependency cycle",
+                  "issue_type": "CircularDependency",
+                  "severity": "Critical"
+                }
+              ],
+              "module": "fixture-fail::query",
+              "score": 40,
+              "suggestion": "Break circular dependency by extracting shared types or inverting with traits"
             }
           ],
+          "issues": [],
           "modules": [
             {
-              "balance_score": 0.24,
-              "couplings_in": 1,
-              "couplings_out": 1,
-              "file_path": "src/lib.rs",
-              "in_cycle": true,
-              "name": "fixture_fail::handler"
+              "balance_score": 1,
+              "couplings_in": 0,
+              "couplings_out": 0,
+              "file_path": "src/handler.rs",
+              "in_cycle": false,
+              "name": "handler"
             },
             {
-              "balance_score": 0.49,
-              "couplings_in": 1,
-              "couplings_out": 1,
+              "balance_score": 1,
+              "couplings_in": 0,
+              "couplings_out": 0,
               "file_path": "src/lib.rs",
-              "in_cycle": true,
-              "name": "fixture_fail::query"
+              "in_cycle": false,
+              "name": "lib"
+            },
+            {
+              "balance_score": 1,
+              "couplings_in": 0,
+              "couplings_out": 0,
+              "file_path": "src/query.rs",
+              "in_cycle": false,
+              "name": "query"
             }
           ],
           "summary": {
-            "critical_issues": 1,
+            "critical_issues": 0,
             "external_couplings": 0,
-            "health_grade": "C",
-            "health_score": 0.62,
+            "health_grade": "B",
+            "health_score": 0.75,
             "high_issues": 0,
             "internal_couplings": 2,
-            "medium_issues": 1,
+            "medium_issues": 0,
             "total_couplings": 2,
-            "total_modules": 2
+            "total_modules": 3
           }
         },
         "manifest_path": "Cargo.toml"
       }
     ],
-    "details": "==> docker run cargo-coupling coupling --json --no-git src\nGrade: C | Score: 62% | Quality gate: FAILED\nThresholds: min_grade=B, max_critical=0, max_circular=0\nModules: 2 | Couplings: 2 | Critical: 1 | High: 0 | Medium: 1 | Circular: 1\nBlocking issues:\n - Grade C is below minimum B\n - 1 critical issues (max: 0)\n - 1 circular dependencies (max: 0)\nIssues:\nsrc/lib.rs: fixture_fail::handler -> fixture_fail::query: critical[Global Complexity]: Intrusive coupling across a distant module boundary\n suggestion: Introduce a trait boundary between handler and query.\nsrc/lib.rs: fixture_fail::handler: medium[High Afferent Coupling]: Module attracts many internal dependencies\n suggestion: Split responsibilities or hide internals behind a smaller API.\nCircular dependencies:\n - fixture_fail::handler -> fixture_fail::query -> fixture_fail::handler",
+    "details": "==> docker run cargo-coupling coupling --json --no-git src\nGrade: B | Score: 75% | Quality gate: FAILED\nThresholds: min_grade=B, max_critical=0, max_circular=0\nModules: 3 | Couplings: 2 | Critical: 0 | High: 0 | Medium: 0 | Circular: 1\nBlocking issues:\n - 1 circular dependencies (max: 0)\nCircular dependencies:\n - fixture-fail::handler -> fixture-fail::query\nAnalyzing project at 'src'...\nAnalysis complete: 3 files, 3 modules",
     "exit_code": 1
   },
   "selected_files": [
-    "src/lib.rs"
+    "src/handler.rs",
+    "src/lib.rs",
+    "src/query.rs"
   ]
 }

--- a/cargo-coupling/tests/fail/sarif.json
+++ b/cargo-coupling/tests/fail/sarif.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "runs": [
+    {
+      "automationDetails": {
+        "id": "linter-service/cargo-coupling"
+      },
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/lib.rs"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Circular dependency: fixture_fail::handler -> fixture_fail::query -> fixture_fail::handler"
+          },
+          "properties": {
+            "linter_name": "cargo-coupling"
+          },
+          "ruleId": "cargo-coupling/circular-dependency"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/lib.rs"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "fixture_fail::handler -> fixture_fail::query: Intrusive coupling across a distant module boundary Suggestion: Introduce a trait boundary between handler and query."
+          },
+          "properties": {
+            "linter_name": "cargo-coupling"
+          },
+          "ruleId": "cargo-coupling/global-complexity"
+        },
+        {
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/lib.rs"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "fixture_fail::handler: Module attracts many internal dependencies Suggestion: Split responsibilities or hide internals behind a smaller API."
+          },
+          "properties": {
+            "linter_name": "cargo-coupling"
+          },
+          "ruleId": "cargo-coupling/high-afferent-coupling"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/chalharu/linter-service",
+          "name": "linter-service/cargo-coupling",
+          "rules": [
+            {
+              "id": "cargo-coupling/circular-dependency",
+              "name": "Circular Dependency",
+              "shortDescription": {
+                "text": "Circular Dependency"
+              }
+            },
+            {
+              "id": "cargo-coupling/global-complexity",
+              "name": "Global Complexity",
+              "shortDescription": {
+                "text": "Global Complexity"
+              }
+            },
+            {
+              "id": "cargo-coupling/high-afferent-coupling",
+              "name": "High Afferent Coupling",
+              "shortDescription": {
+                "text": "High Afferent Coupling"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/cargo-coupling/tests/fail/sarif.json
+++ b/cargo-coupling/tests/fail/sarif.json
@@ -5,105 +5,32 @@
       "automationDetails": {
         "id": "linter-service/cargo-coupling"
       },
-      "results": [
-        {
-          "level": "error",
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "src/lib.rs"
-                },
-                "region": {
-                  "startColumn": 1,
-                  "startLine": 1
-                }
-              }
-            }
-          ],
-          "message": {
-            "text": "Circular dependency: fixture_fail::handler -> fixture_fail::query -> fixture_fail::handler"
-          },
-          "properties": {
-            "linter_name": "cargo-coupling"
-          },
-          "ruleId": "cargo-coupling/circular-dependency"
-        },
-        {
-          "level": "error",
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "src/lib.rs"
-                },
-                "region": {
-                  "startColumn": 1,
-                  "startLine": 1
-                }
-              }
-            }
-          ],
-          "message": {
-            "text": "fixture_fail::handler -> fixture_fail::query: Intrusive coupling across a distant module boundary Suggestion: Introduce a trait boundary between handler and query."
-          },
-          "properties": {
-            "linter_name": "cargo-coupling"
-          },
-          "ruleId": "cargo-coupling/global-complexity"
-        },
-        {
-          "level": "warning",
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "src/lib.rs"
-                },
-                "region": {
-                  "startColumn": 1,
-                  "startLine": 1
-                }
-              }
-            }
-          ],
-          "message": {
-            "text": "fixture_fail::handler: Module attracts many internal dependencies Suggestion: Split responsibilities or hide internals behind a smaller API."
-          },
-          "properties": {
-            "linter_name": "cargo-coupling"
-          },
-          "ruleId": "cargo-coupling/high-afferent-coupling"
-        }
-      ],
-      "tool": {
-        "driver": {
-          "informationUri": "https://github.com/chalharu/linter-service",
-          "name": "linter-service/cargo-coupling",
-          "rules": [
-            {
-              "id": "cargo-coupling/circular-dependency",
-              "name": "Circular Dependency",
-              "shortDescription": {
-                "text": "Circular Dependency"
-              }
+        "results": [
+          {
+            "level": "error",
+            "message": {
+              "text": "Circular dependency: fixture-fail::handler -> fixture-fail::query"
             },
-            {
-              "id": "cargo-coupling/global-complexity",
-              "name": "Global Complexity",
-              "shortDescription": {
-                "text": "Global Complexity"
-              }
+            "properties": {
+              "linter_name": "cargo-coupling"
             },
-            {
-              "id": "cargo-coupling/high-afferent-coupling",
-              "name": "High Afferent Coupling",
-              "shortDescription": {
-                "text": "High Afferent Coupling"
+            "ruleId": "cargo-coupling/circular-dependency"
+          }
+        ],
+        "tool": {
+          "driver": {
+            "informationUri": "https://github.com/chalharu/linter-service",
+            "name": "linter-service/cargo-coupling",
+            "rules": [
+              {
+                "id": "cargo-coupling/circular-dependency",
+                "name": "Circular Dependency",
+                "shortDescription": {
+                  "text": "Circular Dependency"
+                }
               }
-            }
-          ]
-        }
+            ]
+          }
       }
     }
   ],

--- a/cargo-coupling/tests/fail/target/Cargo.toml
+++ b/cargo-coupling/tests/fail/target/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "fixture-fail"
+version = "0.1.0"
+edition = "2021"
+

--- a/cargo-coupling/tests/fail/target/src/handler.rs
+++ b/cargo-coupling/tests/fail/target/src/handler.rs
@@ -1,0 +1,13 @@
+use crate::query::Query;
+
+pub struct Handler;
+
+impl Handler {
+    pub fn run(&self, query: &Query) -> bool {
+        self.validate(query)
+    }
+
+    fn validate(&self, _query: &Query) -> bool {
+        true
+    }
+}

--- a/cargo-coupling/tests/fail/target/src/lib.rs
+++ b/cargo-coupling/tests/fail/target/src/lib.rs
@@ -1,0 +1,13 @@
+pub struct Query;
+
+pub struct Handler;
+
+impl Handler {
+    pub fn run(&self, query: &Query) -> bool {
+        self.validate(query)
+    }
+
+    fn validate(&self, _query: &Query) -> bool {
+        true
+    }
+}

--- a/cargo-coupling/tests/fail/target/src/lib.rs
+++ b/cargo-coupling/tests/fail/target/src/lib.rs
@@ -1,13 +1,2 @@
-pub struct Query;
-
-pub struct Handler;
-
-impl Handler {
-    pub fn run(&self, query: &Query) -> bool {
-        self.validate(query)
-    }
-
-    fn validate(&self, _query: &Query) -> bool {
-        true
-    }
-}
+pub mod handler;
+pub mod query;

--- a/cargo-coupling/tests/fail/target/src/query.rs
+++ b/cargo-coupling/tests/fail/target/src/query.rs
@@ -1,0 +1,9 @@
+use crate::handler::Handler;
+
+pub struct Query;
+
+impl Query {
+    pub fn process(&self, handler: &Handler) -> bool {
+        handler.run(self)
+    }
+}

--- a/cargo-coupling/tests/pass/result.json
+++ b/cargo-coupling/tests/pass/result.json
@@ -1,0 +1,56 @@
+{
+  "checked_projects": [
+    "Cargo.toml"
+  ],
+  "result": {
+    "cargo_coupling_runs": [
+      {
+        "analysis_path": "src",
+        "command": "docker run cargo-coupling --json --no-git src",
+        "check_result": {
+          "circular_count": 0,
+          "critical_count": 0,
+          "failures": [],
+          "grade": "B",
+          "high_count": 0,
+          "medium_count": 0,
+          "passed": true,
+          "score": 0.91
+        },
+        "exit_code": 0,
+        "json_output": {
+          "circular_dependencies": [],
+          "hotspots": [],
+          "issues": [],
+          "modules": [
+            {
+              "balance_score": 0.91,
+              "couplings_in": 0,
+              "couplings_out": 1,
+              "file_path": "src/lib.rs",
+              "in_cycle": false,
+              "name": "fixture_pass::service"
+            }
+          ],
+          "summary": {
+            "critical_issues": 0,
+            "external_couplings": 0,
+            "health_grade": "B",
+            "health_score": 0.91,
+            "high_issues": 0,
+            "internal_couplings": 1,
+            "medium_issues": 0,
+            "total_couplings": 1,
+            "total_modules": 1
+          }
+        },
+        "manifest_path": "Cargo.toml"
+      }
+    ],
+    "details": "==> docker run cargo-coupling --json --no-git src\nGrade: B | Score: 91% | Quality gate: PASSED\nThresholds: min_grade=B, max_critical=0, max_circular=0\nModules: 1 | Couplings: 1 | Critical: 0 | High: 0 | Medium: 0 | Circular: 0",
+    "exit_code": 0
+  },
+  "selected_files": [
+    "src/lib.rs"
+  ]
+}

--- a/cargo-coupling/tests/pass/result.json
+++ b/cargo-coupling/tests/pass/result.json
@@ -1,56 +1,52 @@
 {
-  "checked_projects": [
-    "Cargo.toml"
-  ],
-  "result": {
-    "cargo_coupling_runs": [
-      {
-        "analysis_path": "src",
-        "command": "docker run cargo-coupling coupling --json --no-git src",
-        "check_result": {
-          "circular_count": 0,
-          "critical_count": 0,
-          "failures": [],
-          "grade": "B",
-          "high_count": 0,
-          "medium_count": 0,
-          "passed": true,
-          "score": 1
-        },
-        "exit_code": 0,
-        "json_output": {
-          "circular_dependencies": [],
-          "hotspots": [],
-          "issues": [],
-          "modules": [
-            {
-              "balance_score": 1,
-              "couplings_in": 0,
-              "couplings_out": 0,
-              "file_path": "src/lib.rs",
-              "in_cycle": false,
-              "name": "lib"
-            }
-          ],
-          "summary": {
-            "critical_issues": 0,
-            "external_couplings": 1,
-            "health_grade": "B",
-            "health_score": 1,
-            "high_issues": 0,
-            "internal_couplings": 0,
-            "medium_issues": 0,
-            "total_couplings": 1,
-            "total_modules": 1
-          }
-        },
-        "manifest_path": "Cargo.toml"
-      }
-    ],
-    "details": "==> docker run cargo-coupling coupling --json --no-git src\nGrade: B | Score: 100% | Quality gate: PASSED\nThresholds: min_grade=B, max_critical=0, max_circular=0\nModules: 1 | Couplings: 1 | Critical: 0 | High: 0 | Medium: 0 | Circular: 0\nAnalyzing project at 'src'...\nAnalysis complete: 1 files, 1 modules",
-    "exit_code": 0
-  },
-  "selected_files": [
-    "src/lib.rs"
-  ]
+	"checked_projects": ["Cargo.toml"],
+	"result": {
+		"cargo_coupling_runs": [
+			{
+				"analysis_path": "src",
+				"command": "docker run cargo-coupling coupling --json --no-git src",
+				"check_result": {
+					"circular_count": 0,
+					"critical_count": 0,
+					"failures": [],
+					"grade": "B",
+					"high_count": 0,
+					"medium_count": 0,
+					"passed": true,
+					"score": 1
+				},
+				"exit_code": 0,
+				"json_output": {
+					"circular_dependencies": [],
+					"hotspots": [],
+					"issues": [],
+					"modules": [
+						{
+							"balance_score": 1,
+							"couplings_in": 0,
+							"couplings_out": 0,
+							"file_path": "src/lib.rs",
+							"in_cycle": false,
+							"name": "lib"
+						}
+					],
+					"summary": {
+						"critical_issues": 0,
+						"external_couplings": 1,
+						"health_grade": "B",
+						"health_score": 1,
+						"high_issues": 0,
+						"internal_couplings": 0,
+						"medium_issues": 0,
+						"total_couplings": 1,
+						"total_modules": 1
+					}
+				},
+				"manifest_path": "Cargo.toml"
+			}
+		],
+		"details": "==> docker run cargo-coupling coupling --json --no-git src\nGrade: B | Score: 100% | Quality gate: PASSED\nThresholds: min_grade=B, max_critical=0, max_circular=0\nModules: 1 | Couplings: 1 | Critical: 0 | High: 0 | Medium: 0 | Circular: 0\nAnalyzing project at 'src'...\nAnalysis complete: 1 files, 1 modules",
+		"exit_code": 0
+	},
+	"selected_files": ["src/lib.rs"]
 }

--- a/cargo-coupling/tests/pass/result.json
+++ b/cargo-coupling/tests/pass/result.json
@@ -6,7 +6,7 @@
     "cargo_coupling_runs": [
       {
         "analysis_path": "src",
-        "command": "docker run cargo-coupling --json --no-git src",
+        "command": "docker run cargo-coupling coupling --json --no-git src",
         "check_result": {
           "circular_count": 0,
           "critical_count": 0,
@@ -47,7 +47,7 @@
         "manifest_path": "Cargo.toml"
       }
     ],
-    "details": "==> docker run cargo-coupling --json --no-git src\nGrade: B | Score: 91% | Quality gate: PASSED\nThresholds: min_grade=B, max_critical=0, max_circular=0\nModules: 1 | Couplings: 1 | Critical: 0 | High: 0 | Medium: 0 | Circular: 0",
+    "details": "==> docker run cargo-coupling coupling --json --no-git src\nGrade: B | Score: 91% | Quality gate: PASSED\nThresholds: min_grade=B, max_critical=0, max_circular=0\nModules: 1 | Couplings: 1 | Critical: 0 | High: 0 | Medium: 0 | Circular: 0",
     "exit_code": 0
   },
   "selected_files": [

--- a/cargo-coupling/tests/pass/result.json
+++ b/cargo-coupling/tests/pass/result.json
@@ -15,7 +15,7 @@
           "high_count": 0,
           "medium_count": 0,
           "passed": true,
-          "score": 0.91
+          "score": 1
         },
         "exit_code": 0,
         "json_output": {
@@ -24,21 +24,21 @@
           "issues": [],
           "modules": [
             {
-              "balance_score": 0.91,
+              "balance_score": 1,
               "couplings_in": 0,
-              "couplings_out": 1,
+              "couplings_out": 0,
               "file_path": "src/lib.rs",
               "in_cycle": false,
-              "name": "fixture_pass::service"
+              "name": "lib"
             }
           ],
           "summary": {
             "critical_issues": 0,
-            "external_couplings": 0,
+            "external_couplings": 1,
             "health_grade": "B",
-            "health_score": 0.91,
+            "health_score": 1,
             "high_issues": 0,
-            "internal_couplings": 1,
+            "internal_couplings": 0,
             "medium_issues": 0,
             "total_couplings": 1,
             "total_modules": 1
@@ -47,7 +47,7 @@
         "manifest_path": "Cargo.toml"
       }
     ],
-    "details": "==> docker run cargo-coupling coupling --json --no-git src\nGrade: B | Score: 91% | Quality gate: PASSED\nThresholds: min_grade=B, max_critical=0, max_circular=0\nModules: 1 | Couplings: 1 | Critical: 0 | High: 0 | Medium: 0 | Circular: 0",
+    "details": "==> docker run cargo-coupling coupling --json --no-git src\nGrade: B | Score: 100% | Quality gate: PASSED\nThresholds: min_grade=B, max_critical=0, max_circular=0\nModules: 1 | Couplings: 1 | Critical: 0 | High: 0 | Medium: 0 | Circular: 0\nAnalyzing project at 'src'...\nAnalysis complete: 1 files, 1 modules",
     "exit_code": 0
   },
   "selected_files": [

--- a/cargo-coupling/tests/pass/sarif.json
+++ b/cargo-coupling/tests/pass/sarif.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "runs": [
+    {
+      "automationDetails": {
+        "id": "linter-service/cargo-coupling"
+      },
+      "results": [],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/chalharu/linter-service",
+          "name": "linter-service/cargo-coupling",
+          "rules": []
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/cargo-coupling/tests/pass/target/Cargo.toml
+++ b/cargo-coupling/tests/pass/target/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "fixture-pass"
+version = "0.1.0"
+edition = "2021"
+

--- a/cargo-coupling/tests/pass/target/src/lib.rs
+++ b/cargo-coupling/tests/pass/target/src/lib.rs
@@ -1,0 +1,17 @@
+pub trait Store {
+    fn save(&self, value: &str);
+}
+
+pub struct Service<T: Store> {
+    store: T,
+}
+
+impl<T: Store> Service<T> {
+    pub fn new(store: T) -> Self {
+        Self { store }
+    }
+
+    pub fn save(&self, value: &str) {
+        self.store.save(value);
+    }
+}

--- a/linters.json
+++ b/linters.json
@@ -94,6 +94,13 @@
         "target_kind": "cargo-projects"
       }
     },
+    "cargo-coupling": {
+      "isolated": true,
+      "sarif": {
+        "enabled": true,
+        "target_kind": "cargo-projects"
+      }
+    },
     "taplo": {
       "sarif": {
         "enabled": true

--- a/linters.json
+++ b/linters.json
@@ -1,130 +1,128 @@
 {
-  "linters": {
-    "actionlint": {
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "ghalint": {
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "hadolint": {
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "helmlint": {
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "lizard": {
-      "default_disabled": true,
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "trivy": {
-      "sarif": {
-        "enabled": true,
-        "default_level": "warning"
-      }
-    },
-    "dotenv-linter": {
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "spectral": {
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "yamllint": {
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "yamlfmt": {
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "markdownlint-cli2": {
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "renovate": {
-      "isolated": true,
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "textlint": {
-      "isolated": true,
-      "required_root_files": [
-        ".textlintrc"
-      ],
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "ruff": {
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "rustfmt": {
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "cargo-clippy": {
-      "isolated": true,
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "cargo-deny": {
-      "sarif": {
-        "enabled": true,
-        "target_kind": "cargo-projects"
-      }
-    },
-    "cargo-coupling": {
-      "isolated": true,
-      "sarif": {
-        "enabled": true,
-        "target_kind": "cargo-projects"
-      }
-    },
-    "taplo": {
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "biome": {
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "editorconfig-checker": {
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "shellcheck": {
-      "sarif": {
-        "enabled": true
-      }
-    },
-    "zizmor": {
-      "sarif": {
-        "enabled": true
-      }
-    }
-  }
+	"linters": {
+		"actionlint": {
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"ghalint": {
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"hadolint": {
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"helmlint": {
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"lizard": {
+			"default_disabled": true,
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"trivy": {
+			"sarif": {
+				"enabled": true,
+				"default_level": "warning"
+			}
+		},
+		"dotenv-linter": {
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"spectral": {
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"yamllint": {
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"yamlfmt": {
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"markdownlint-cli2": {
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"renovate": {
+			"isolated": true,
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"textlint": {
+			"isolated": true,
+			"required_root_files": [".textlintrc"],
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"ruff": {
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"rustfmt": {
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"cargo-clippy": {
+			"isolated": true,
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"cargo-deny": {
+			"sarif": {
+				"enabled": true,
+				"target_kind": "cargo-projects"
+			}
+		},
+		"cargo-coupling": {
+			"isolated": true,
+			"sarif": {
+				"enabled": true,
+				"target_kind": "cargo-projects"
+			}
+		},
+		"taplo": {
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"biome": {
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"editorconfig-checker": {
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"shellcheck": {
+			"sarif": {
+				"enabled": true
+			}
+		},
+		"zizmor": {
+			"sarif": {
+				"enabled": true
+			}
+		}
+	}
 }

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,8 @@
       "description": "Update pinned linter installer versions and Renovate base image pins",
       "managerFilePatterns": [
         "/(^|/)[^/]+/install\\.sh$/",
-        "/(^|/)renovate/Dockerfile$/"
+        "/(^|/)renovate/Dockerfile$/",
+        "/(^|/)cargo-coupling/Dockerfile\\.full$/"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)(?: versioning=(?<versioning>[^\\s]+))?\\s+[A-Za-z0-9_]+_version=\"(?<currentValue>[^\"]+)\"",

--- a/renovate.json
+++ b/renovate.json
@@ -1,72 +1,72 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    "helpers:pinGitHubActionDigests",
-    ":disableRateLimiting"
-  ],
-  "enabledManagers": ["github-actions", "npm", "custom.regex"],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Update pinned linter installer versions and Renovate base image pins",
-      "managerFilePatterns": [
-        "/(^|/)[^/]+/install\\.sh$/",
-        "/(^|/)renovate/Dockerfile$/",
-        "/(^|/)cargo-coupling/Dockerfile\\.full$/"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)(?: versioning=(?<versioning>[^\\s]+))?\\s+[A-Za-z0-9_]+_version=\"(?<currentValue>[^\"]+)\"",
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)(?: versioning=(?<versioning>[^\\s]+))?\\s+ARG [A-Z0-9_]+=(?<currentValue>[^\\s]+)"
-      ]
-    },
-    {
-      "customType": "regex",
-      "description": "Update textlint preset package pins in YAML config",
-      "managerFilePatterns": ["/(^|/)\\.github/linter-service\\.ya?ml$/"],
-      "datasourceTemplate": "npm",
-      "matchStrings": [
-        "(?m)^\\s*-\\s*\"?(?<depName>(?:@[^/\\s\"#]+/)?textlint-rule-preset-[^@\\s\"#]+)@(?<currentValue>[^\"\\s#]+)\"?\\s*$"
-      ]
-    }
-  ],
-  "labels": ["dependencies", "renovate", "renovate-gate-wait-3d"],
-  "dependencyDashboard": true,
-  "lockFileMaintenance": {
-    "enabled": true
-  },
-  "prCreation": "immediate",
-  "rebaseWhen": "behind-base-branch",
-  "timezone": "Asia/Tokyo",
-  "automergeStrategy": "auto",
-  "pruneStaleBranches": false,
-  "separateMajorMinor": true,
-  "separateMinorPatch": true,
-  "separateMultipleMajor": true,
-  "separateMultipleMinor": true,
-  "automerge": true,
-  "platformAutomerge": false,
-  "vulnerabilityAlerts": {
-    "enabled": true,
-    "labels": ["dependencies", "renovate", "security"]
-  },
-  "packageRules": [
-    {
-      "description": "Give each target version or digest its own Renovate branch",
-      "matchUpdateTypes": [
-        "digest",
-        "major",
-        "minor",
-        "patch",
-        "pin",
-        "pinDigest"
-      ],
-      "branchTopic": "{{{depNameSanitized}}}{{#if newVersion}}__v{{{newVersion}}}{{/if}}{{#if newDigestShort}}__d{{{newDigestShort}}}{{/if}}"
-    },
-    {
-      "description": "Hold pinned linter installer updates for three days",
-      "matchManagers": ["custom.regex"],
-      "minimumReleaseAge": "3 days"
-    }
-  ]
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"config:recommended",
+		"helpers:pinGitHubActionDigests",
+		":disableRateLimiting"
+	],
+	"enabledManagers": ["github-actions", "npm", "custom.regex"],
+	"customManagers": [
+		{
+			"customType": "regex",
+			"description": "Update pinned linter installer versions and Renovate base image pins",
+			"managerFilePatterns": [
+				"/(^|/)[^/]+/install\\.sh$/",
+				"/(^|/)renovate/Dockerfile$/",
+				"/(^|/)cargo-coupling/Dockerfile\\.full$/"
+			],
+			"matchStrings": [
+				"# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)(?: versioning=(?<versioning>[^\\s]+))?\\s+[A-Za-z0-9_]+_version=\"(?<currentValue>[^\"]+)\"",
+				"# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)(?: versioning=(?<versioning>[^\\s]+))?\\s+ARG [A-Z0-9_]+=(?<currentValue>[^\\s]+)"
+			]
+		},
+		{
+			"customType": "regex",
+			"description": "Update textlint preset package pins in YAML config",
+			"managerFilePatterns": ["/(^|/)\\.github/linter-service\\.ya?ml$/"],
+			"datasourceTemplate": "npm",
+			"matchStrings": [
+				"(?m)^\\s*-\\s*\"?(?<depName>(?:@[^/\\s\"#]+/)?textlint-rule-preset-[^@\\s\"#]+)@(?<currentValue>[^\"\\s#]+)\"?\\s*$"
+			]
+		}
+	],
+	"labels": ["dependencies", "renovate", "renovate-gate-wait-3d"],
+	"dependencyDashboard": true,
+	"lockFileMaintenance": {
+		"enabled": true
+	},
+	"prCreation": "immediate",
+	"rebaseWhen": "behind-base-branch",
+	"timezone": "Asia/Tokyo",
+	"automergeStrategy": "auto",
+	"pruneStaleBranches": false,
+	"separateMajorMinor": true,
+	"separateMinorPatch": true,
+	"separateMultipleMajor": true,
+	"separateMultipleMinor": true,
+	"automerge": true,
+	"platformAutomerge": false,
+	"vulnerabilityAlerts": {
+		"enabled": true,
+		"labels": ["dependencies", "renovate", "security"]
+	},
+	"packageRules": [
+		{
+			"description": "Give each target version or digest its own Renovate branch",
+			"matchUpdateTypes": [
+				"digest",
+				"major",
+				"minor",
+				"patch",
+				"pin",
+				"pinDigest"
+			],
+			"branchTopic": "{{{depNameSanitized}}}{{#if newVersion}}__v{{{newVersion}}}{{/if}}{{#if newDigestShort}}__d{{{newDigestShort}}}{{/if}}"
+		},
+		{
+			"description": "Hold pinned linter installer updates for three days",
+			"matchManagers": ["custom.regex"],
+			"minimumReleaseAge": "3 days"
+		}
+	]
 }


### PR DESCRIPTION
## Summary
- add `cargo-coupling` as a new shared linter for Rust cargo projects
- build the linter container locally from a checksum-verified upstream source tarball and a pinned `Dockerfile.full`
- support default and repo-overridable quality gate thresholds, JSON/SARIF rendering, and isolated execution

---

## Testing
- `/usr/local/bin/node --test cargo-coupling/cargo-coupling.test.js cargo-coupling/cargo-coupling-result.test.js cargo-coupling/render-linter-sarif.test.js .github/scripts/linter-service-config.test.js .github/scripts/validate-linter-service-config.test.js .github/scripts/validate-linters-config.test.js .github/scripts/select-lint-targets.test.js .github/scripts/installer-version-pins.test.js`
- `.github/scripts/run-fixture-tests.js cargo-coupling` (with temporary stub docker/curl tooling because a real container runtime was unavailable)
- `git diff --check`
