### PR TITLE
fix: emit SARIF-backed zizmor results

### DIFF
--- a/.github/scripts/linter-library.sh
+++ b/.github/scripts/linter-library.sh
@@ -316,6 +316,50 @@ linter_lib::emit_json_result_with_sarif() {
   linter_lib::emit_json_result_with_json_file "$exit_code" sarif "$sarif_file"
 }
 
+linter_lib::emit_json_result_with_sarif_findings() {
+  local sarif_file=$1
+  local python_bin
+
+  if [ ! -f "$sarif_file" ]; then
+    printf 'JSON file not found: %s\n' "$sarif_file" >&2
+    return 1
+  fi
+
+  if python_bin="$(linter_lib::python_cmd 2>/dev/null)"; then
+    "$python_bin" - "$sarif_file" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+sarif_path = Path(sys.argv[1])
+payload = json.loads(sarif_path.read_text(encoding="utf-8"))
+has_results = any(len(run.get("results", [])) > 0 for run in payload.get("runs", []))
+print(json.dumps({"exit_code": 1 if has_results else 0, "sarif": payload}))
+PY
+    return 0
+  fi
+
+  if command -v node >/dev/null 2>&1; then
+    node - "$sarif_file" <<'NODE'
+const fs = require("node:fs");
+
+const sarifPath = process.argv[2];
+const payload = JSON.parse(fs.readFileSync(sarifPath, "utf8"));
+const hasResults = (payload?.runs ?? []).some((run) => (run?.results?.length ?? 0) > 0);
+process.stdout.write(
+  JSON.stringify({
+    exit_code: hasResults ? 1 : 0,
+    sarif: payload,
+  }),
+);
+NODE
+    return 0
+  fi
+
+  echo "python3, python, or node is required" >&2
+  return 1
+}
+
 linter_lib::run_and_emit_json() {
   local output_file=$1
   shift

--- a/.github/scripts/linter-library.test.js
+++ b/.github/scripts/linter-library.test.js
@@ -136,3 +136,187 @@ linter_lib::emit_json_result_with_json_file 1 sarif "${payloadPath}"
 		fs.rmSync(tempDir, { force: true, recursive: true });
 	}
 });
+
+test("linter-library.sh derives findings exit_code from SARIF via Node", () => {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "linter-library-"));
+	const sarifPath = path.join(tempDir, "result.sarif");
+	const runnerScript = path.join(tempDir, "runner.sh");
+
+	fs.writeFileSync(
+		sarifPath,
+		JSON.stringify({
+			runs: [
+				{
+					results: [{ message: { text: "native failure" }, ruleId: "parse" }],
+				},
+			],
+			version: "2.1.0",
+		}),
+		"utf8",
+	);
+	fs.writeFileSync(
+		runnerScript,
+		`#!/usr/bin/env bash
+set -euo pipefail
+source "${path.join(process.cwd(), ".github/scripts/linter-library.sh")}"
+PATH="$(dirname "$(command -v node)")"
+linter_lib::emit_json_result_with_sarif_findings "${sarifPath}"
+`,
+		"utf8",
+	);
+	fs.chmodSync(runnerScript, 0o755);
+
+	try {
+		const output = execFileSync("bash", [runnerScript], {
+			encoding: "utf8",
+		});
+
+		assert.deepEqual(JSON.parse(output), {
+			exit_code: 1,
+			sarif: {
+				runs: [
+					{
+						results: [{ message: { text: "native failure" }, ruleId: "parse" }],
+					},
+				],
+				version: "2.1.0",
+			},
+		});
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("linter-library.sh derives empty-findings exit_code from SARIF via Node", () => {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "linter-library-"));
+	const sarifPath = path.join(tempDir, "result.sarif");
+	const runnerScript = path.join(tempDir, "runner.sh");
+
+	fs.writeFileSync(
+		sarifPath,
+		JSON.stringify({
+			runs: [{ results: [] }],
+			version: "2.1.0",
+		}),
+		"utf8",
+	);
+	fs.writeFileSync(
+		runnerScript,
+		`#!/usr/bin/env bash
+set -euo pipefail
+source "${path.join(process.cwd(), ".github/scripts/linter-library.sh")}"
+PATH="$(dirname "$(command -v node)")"
+linter_lib::emit_json_result_with_sarif_findings "${sarifPath}"
+`,
+		"utf8",
+	);
+	fs.chmodSync(runnerScript, 0o755);
+
+	try {
+		const output = execFileSync("bash", [runnerScript], {
+			encoding: "utf8",
+		});
+
+		assert.deepEqual(JSON.parse(output), {
+			exit_code: 0,
+			sarif: {
+				runs: [{ results: [] }],
+				version: "2.1.0",
+			},
+		});
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("linter-library.sh derives findings exit_code from SARIF via Python", () => {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "linter-library-"));
+	const sarifPath = path.join(tempDir, "result.sarif");
+	const runnerScript = path.join(tempDir, "runner.sh");
+
+	fs.writeFileSync(
+		sarifPath,
+		JSON.stringify({
+			runs: [
+				{
+					results: [{ message: { text: "native failure" }, ruleId: "parse" }],
+				},
+			],
+			version: "2.1.0",
+		}),
+		"utf8",
+	);
+	fs.writeFileSync(
+		runnerScript,
+		`#!/usr/bin/env bash
+set -euo pipefail
+source "${path.join(process.cwd(), ".github/scripts/linter-library.sh")}"
+PATH="$(dirname "$(command -v python3)")"
+linter_lib::emit_json_result_with_sarif_findings "${sarifPath}"
+`,
+		"utf8",
+	);
+	fs.chmodSync(runnerScript, 0o755);
+
+	try {
+		const output = execFileSync("bash", [runnerScript], {
+			encoding: "utf8",
+		});
+
+		assert.deepEqual(JSON.parse(output), {
+			exit_code: 1,
+			sarif: {
+				runs: [
+					{
+						results: [{ message: { text: "native failure" }, ruleId: "parse" }],
+					},
+				],
+				version: "2.1.0",
+			},
+		});
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("linter-library.sh derives empty-findings exit_code from SARIF via Python", () => {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "linter-library-"));
+	const sarifPath = path.join(tempDir, "result.sarif");
+	const runnerScript = path.join(tempDir, "runner.sh");
+
+	fs.writeFileSync(
+		sarifPath,
+		JSON.stringify({
+			runs: [{ results: [] }],
+			version: "2.1.0",
+		}),
+		"utf8",
+	);
+	fs.writeFileSync(
+		runnerScript,
+		`#!/usr/bin/env bash
+set -euo pipefail
+source "${path.join(process.cwd(), ".github/scripts/linter-library.sh")}"
+PATH="$(dirname "$(command -v python3)")"
+linter_lib::emit_json_result_with_sarif_findings "${sarifPath}"
+`,
+		"utf8",
+	);
+	fs.chmodSync(runnerScript, 0o755);
+
+	try {
+		const output = execFileSync("bash", [runnerScript], {
+			encoding: "utf8",
+		});
+
+		assert.deepEqual(JSON.parse(output), {
+			exit_code: 0,
+			sarif: {
+				runs: [{ results: [] }],
+				version: "2.1.0",
+			},
+		});
+	} finally {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+});

--- a/zizmor/render-linter-sarif.test.js
+++ b/zizmor/render-linter-sarif.test.js
@@ -10,9 +10,60 @@ const {
 const { runFromEnv } = require("../.github/scripts/render-linter-sarif.js");
 
 const configPath = path.join(__dirname, "..", "linters.json");
-const details = ".github/workflows/ci.yml:14:5: unpinned action reference";
 
-test("emits SARIF for zizmor diagnostics", () => {
+// Native SARIF as emitted by `zizmor --format=sarif`
+const nativeSarif = {
+	$schema:
+		"https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json",
+	version: "2.1.0",
+	runs: [
+		{
+			tool: {
+				driver: {
+					name: "zizmor",
+					version: "1.24.1",
+					informationUri: "https://docs.zizmor.sh",
+					rules: [
+						{
+							id: "zizmor/unpinned-uses",
+							name: "unpinned-uses",
+							helpUri: "https://docs.zizmor.sh/audits/#unpinned-uses",
+							help: {
+								text: "unpinned action reference",
+								markdown:
+									"`unpinned-uses`: unpinned action reference\n\nDocs: <https://docs.zizmor.sh/audits/#unpinned-uses>",
+							},
+						},
+					],
+				},
+			},
+			results: [
+				{
+					ruleId: "zizmor/unpinned-uses",
+					level: "error",
+					message: { text: "unpinned action reference" },
+					locations: [
+						{
+							physicalLocation: {
+								artifactLocation: {
+									uri: ".github/workflows/ci.yml",
+								},
+								region: {
+									startLine: 14,
+									startColumn: 5,
+									endLine: 14,
+									endColumn: 30,
+								},
+							},
+						},
+					],
+				},
+			],
+		},
+	],
+};
+
+test("prefers embedded zizmor SARIF when available", () => {
 	const context = makeTempRepo("render-linter-sarif-zizmor-");
 
 	writeFile(
@@ -26,8 +77,8 @@ test("emits SARIF for zizmor diagnostics", () => {
 	writeFile(
 		path.join(context.runnerTemp, "linter-result.json"),
 		JSON.stringify({
-			details,
 			exit_code: 1,
+			sarif: nativeSarif,
 		}),
 	);
 
@@ -46,7 +97,11 @@ test("emits SARIF for zizmor diagnostics", () => {
 		});
 
 		assert.equal(report.produced, true);
-		assert.ok(report.sarif.runs[0].results.length >= 1);
+		assert.equal(report.sarif.runs[0].results.length, 1);
+		assert.equal(
+			report.sarif.runs[0].results[0].ruleId,
+			"zizmor/unpinned-uses",
+		);
 		assert.equal(
 			report.sarif.runs[0].results[0].locations[0].physicalLocation
 				.artifactLocation.uri,
@@ -61,6 +116,11 @@ test("emits SARIF for zizmor diagnostics", () => {
 			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
 				.startColumn,
 			5,
+		);
+		// Rules are sourced from native SARIF
+		assert.equal(
+			report.sarif.runs[0].tool.driver.rules[0].id,
+			"zizmor/unpinned-uses",
 		);
 	} finally {
 		cleanupTempRepo(context.tempDir);

--- a/zizmor/run.sh
+++ b/zizmor/run.sh
@@ -7,5 +7,49 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "$script_dir/common.sh"
 
 : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
-output_file="$RUNNER_TEMP/linter-output.txt"
-linter_lib::run_and_emit_json "$output_file" zizmor --offline --color=never --format=plain "$@"
+native_sarif_file="$RUNNER_TEMP/zizmor-native.sarif"
+stderr_file="$RUNNER_TEMP/zizmor-stderr.log"
+rm -f "$native_sarif_file" "$stderr_file"
+
+set +e
+zizmor --offline --color=never --format=sarif "$@" >"$native_sarif_file" 2>"$stderr_file"
+set -e
+
+if [ ! -s "$native_sarif_file" ]; then
+  echo "zizmor native SARIF output was empty or missing" >&2
+  if [ -s "$stderr_file" ]; then
+    cat "$stderr_file" >&2
+  fi
+  exit 1
+fi
+
+if [ -s "$stderr_file" ]; then
+  cat "$stderr_file" >&2
+fi
+rm -f "$stderr_file"
+
+# In SARIF mode, findings are communicated in the SARIF payload rather than
+# through zizmor's findings-specific exit codes, so normalize to 0/1 here.
+exit_code=0
+if python_bin="$(linter_lib::python_cmd 2>/dev/null)"; then
+  exit_code=$("$python_bin" - "$native_sarif_file" <<'PY'
+import json, sys
+sarif = json.loads(open(sys.argv[1]).read())
+has_results = any(len(run.get("results", [])) > 0 for run in sarif.get("runs", []))
+print("1" if has_results else "0")
+PY
+  )
+elif command -v node >/dev/null 2>&1; then
+  exit_code=$(node - "$native_sarif_file" <<'NODE'
+const fs = require("node:fs");
+const sarif = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const hasResults = (sarif?.runs ?? []).some((r) => (r?.results?.length ?? 0) > 0);
+process.stdout.write(hasResults ? "1" : "0");
+NODE
+  )
+else
+  echo "python3, python, or node is required" >&2
+  exit 1
+fi
+
+linter_lib::emit_json_result_with_sarif "$exit_code" "$native_sarif_file"

--- a/zizmor/run.sh
+++ b/zizmor/run.sh
@@ -28,28 +28,4 @@ if [ -s "$stderr_file" ]; then
 fi
 rm -f "$stderr_file"
 
-# In SARIF mode, findings are communicated in the SARIF payload rather than
-# through zizmor's findings-specific exit codes, so normalize to 0/1 here.
-exit_code=0
-if python_bin="$(linter_lib::python_cmd 2>/dev/null)"; then
-  exit_code=$("$python_bin" - "$native_sarif_file" <<'PY'
-import json, sys
-sarif = json.loads(open(sys.argv[1]).read())
-has_results = any(len(run.get("results", [])) > 0 for run in sarif.get("runs", []))
-print("1" if has_results else "0")
-PY
-  )
-elif command -v node >/dev/null 2>&1; then
-  exit_code=$(node - "$native_sarif_file" <<'NODE'
-const fs = require("node:fs");
-const sarif = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
-const hasResults = (sarif?.runs ?? []).some((r) => (r?.results?.length ?? 0) > 0);
-process.stdout.write(hasResults ? "1" : "0");
-NODE
-  )
-else
-  echo "python3, python, or node is required" >&2
-  exit 1
-fi
-
-linter_lib::emit_json_result_with_sarif "$exit_code" "$native_sarif_file"
+linter_lib::emit_json_result_with_sarif_findings "$native_sarif_file"

--- a/zizmor/tests/fail/result.json
+++ b/zizmor/tests/fail/result.json
@@ -1,8 +1,535 @@
 {
   "checked_projects": [],
   "result": {
-    "details": "INFO zizmor: 🌈 zizmor v1.24.1\n INFO audit: zizmor: 🌈 completed .github/workflows/workflow.yml\nwarning[artipacked]: credential persistence through GitHub Actions artifacts\n --> .github/workflows/workflow.yml:7:9\n  |\n7 |       - uses: actions/checkout@v4\n  |         ^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false\n  |\n  = note: audit confidence → Low\n  = note: this finding has an auto-fix\n  = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked\n\nwarning[excessive-permissions]: overly broad permissions\n --> .github/workflows/workflow.yml:4:3\n  |\n4 | /   test:\n5 | |     runs-on: ubuntu-latest\n6 | |     steps:\n7 | |       - uses: actions/checkout@v4\n  | |                                  ^\n  | |                                  |\n  | |__________________________________this job\n  |                                    default permissions used due to no permissions: block\n  |\n  = note: audit confidence → Medium\n  = help: audit documentation → https://docs.zizmor.sh/audits/#excessive-permissions\n\nerror[unpinned-uses]: unpinned action reference\n --> .github/workflows/workflow.yml:7:15\n  |\n7 |       - uses: actions/checkout@v4\n  |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)\n  |\n  = note: audit confidence → High\n  = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses\n\n6 findings (3 suppressed, 1 fixable): 0 informational, 0 low, 2 medium, 1 high",
-    "exit_code": 14
+    "exit_code": 1,
+    "sarif": {
+      "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json",
+      "runs": [
+        {
+          "invocations": [
+            {
+              "executionSuccessful": true
+            }
+          ],
+          "results": [
+            {
+              "codeFlows": [
+                {
+                  "threadFlows": [
+                    {
+                      "locations": [
+                        {
+                          "importance": "essential",
+                          "location": {
+                            "logicalLocations": [
+                              {
+                                "properties": {
+                                  "symbolic": {
+                                    "annotation": "does not set persist-credentials: false",
+                                    "feature_kind": "Normal",
+                                    "key": {
+                                      "Local": {
+                                        "given_path": ".github/workflows/workflow.yml",
+                                        "prefix": null
+                                      }
+                                    },
+                                    "kind": "Primary",
+                                    "route": {
+                                      "route": [
+                                        {
+                                          "Key": "jobs"
+                                        },
+                                        {
+                                          "Key": "test"
+                                        },
+                                        {
+                                          "Key": "steps"
+                                        },
+                                        {
+                                          "Index": 0
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            ],
+                            "message": {
+                              "text": "does not set persist-credentials: false"
+                            },
+                            "physicalLocation": {
+                              "artifactLocation": {
+                                "uri": ".github/workflows/workflow.yml"
+                              },
+                              "region": {
+                                "endColumn": 1,
+                                "endLine": 8,
+                                "snippet": {
+                                  "text": "uses: actions/checkout@v4\n"
+                                },
+                                "sourceLanguage": "yaml",
+                                "startColumn": 9,
+                                "startLine": 7
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "kind": "fail",
+              "level": "warning",
+              "locations": [
+                {
+                  "logicalLocations": [
+                    {
+                      "properties": {
+                        "symbolic": {
+                          "annotation": "does not set persist-credentials: false",
+                          "feature_kind": "Normal",
+                          "key": {
+                            "Local": {
+                              "given_path": ".github/workflows/workflow.yml",
+                              "prefix": null
+                            }
+                          },
+                          "kind": "Primary",
+                          "route": {
+                            "route": [
+                              {
+                                "Key": "jobs"
+                              },
+                              {
+                                "Key": "test"
+                              },
+                              {
+                                "Key": "steps"
+                              },
+                              {
+                                "Index": 0
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "message": {
+                    "text": "does not set persist-credentials: false"
+                  },
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": ".github/workflows/workflow.yml"
+                    },
+                    "region": {
+                      "endColumn": 1,
+                      "endLine": 8,
+                      "snippet": {
+                        "text": "uses: actions/checkout@v4\n"
+                      },
+                      "sourceLanguage": "yaml",
+                      "startColumn": 9,
+                      "startLine": 7
+                    }
+                  }
+                }
+              ],
+              "message": {
+                "text": "credential persistence through GitHub Actions artifacts"
+              },
+              "properties": {
+                "zizmor/confidence": "Low",
+                "zizmor/persona": "Regular",
+                "zizmor/severity": "Medium"
+              },
+              "ruleId": "zizmor/artipacked"
+            },
+            {
+              "codeFlows": [
+                {
+                  "threadFlows": [
+                    {
+                      "locations": [
+                        {
+                          "importance": "important",
+                          "location": {
+                            "logicalLocations": [
+                              {
+                                "properties": {
+                                  "symbolic": {
+                                    "annotation": "this job",
+                                    "feature_kind": "Normal",
+                                    "key": {
+                                      "Local": {
+                                        "given_path": ".github/workflows/workflow.yml",
+                                        "prefix": null
+                                      }
+                                    },
+                                    "kind": "Related",
+                                    "route": {
+                                      "route": [
+                                        {
+                                          "Key": "jobs"
+                                        },
+                                        {
+                                          "Key": "test"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            ],
+                            "message": {
+                              "text": "this job"
+                            },
+                            "physicalLocation": {
+                              "artifactLocation": {
+                                "uri": ".github/workflows/workflow.yml"
+                              },
+                              "region": {
+                                "endColumn": 1,
+                                "endLine": 8,
+                                "snippet": {
+                                  "text": "  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n"
+                                },
+                                "sourceLanguage": "yaml",
+                                "startColumn": 3,
+                                "startLine": 4
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "importance": "essential",
+                          "location": {
+                            "logicalLocations": [
+                              {
+                                "properties": {
+                                  "symbolic": {
+                                    "annotation": "default permissions used due to no permissions: block",
+                                    "feature_kind": "Normal",
+                                    "key": {
+                                      "Local": {
+                                        "given_path": ".github/workflows/workflow.yml",
+                                        "prefix": null
+                                      }
+                                    },
+                                    "kind": "Primary",
+                                    "route": {
+                                      "route": [
+                                        {
+                                          "Key": "jobs"
+                                        },
+                                        {
+                                          "Key": "test"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            ],
+                            "message": {
+                              "text": "default permissions used due to no permissions: block"
+                            },
+                            "physicalLocation": {
+                              "artifactLocation": {
+                                "uri": ".github/workflows/workflow.yml"
+                              },
+                              "region": {
+                                "endColumn": 1,
+                                "endLine": 8,
+                                "snippet": {
+                                  "text": "  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n"
+                                },
+                                "sourceLanguage": "yaml",
+                                "startColumn": 3,
+                                "startLine": 4
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "kind": "fail",
+              "level": "warning",
+              "locations": [
+                {
+                  "logicalLocations": [
+                    {
+                      "properties": {
+                        "symbolic": {
+                          "annotation": "default permissions used due to no permissions: block",
+                          "feature_kind": "Normal",
+                          "key": {
+                            "Local": {
+                              "given_path": ".github/workflows/workflow.yml",
+                              "prefix": null
+                            }
+                          },
+                          "kind": "Primary",
+                          "route": {
+                            "route": [
+                              {
+                                "Key": "jobs"
+                              },
+                              {
+                                "Key": "test"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "message": {
+                    "text": "default permissions used due to no permissions: block"
+                  },
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": ".github/workflows/workflow.yml"
+                    },
+                    "region": {
+                      "endColumn": 1,
+                      "endLine": 8,
+                      "snippet": {
+                        "text": "  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n"
+                      },
+                      "sourceLanguage": "yaml",
+                      "startColumn": 3,
+                      "startLine": 4
+                    }
+                  }
+                }
+              ],
+              "message": {
+                "text": "overly broad permissions"
+              },
+              "properties": {
+                "zizmor/confidence": "Medium",
+                "zizmor/persona": "Regular",
+                "zizmor/severity": "Medium"
+              },
+              "ruleId": "zizmor/excessive-permissions"
+            },
+            {
+              "codeFlows": [
+                {
+                  "threadFlows": [
+                    {
+                      "locations": [
+                        {
+                          "importance": "essential",
+                          "location": {
+                            "logicalLocations": [
+                              {
+                                "properties": {
+                                  "symbolic": {
+                                    "annotation": "action is not pinned to a hash (required by blanket policy)",
+                                    "feature_kind": {
+                                      "Subfeature": {
+                                        "after": 0,
+                                        "fragment": {
+                                          "Raw": "actions/checkout@v4"
+                                        }
+                                      }
+                                    },
+                                    "key": {
+                                      "Local": {
+                                        "given_path": ".github/workflows/workflow.yml",
+                                        "prefix": null
+                                      }
+                                    },
+                                    "kind": "Primary",
+                                    "route": {
+                                      "route": [
+                                        {
+                                          "Key": "jobs"
+                                        },
+                                        {
+                                          "Key": "test"
+                                        },
+                                        {
+                                          "Key": "steps"
+                                        },
+                                        {
+                                          "Index": 0
+                                        },
+                                        {
+                                          "Key": "uses"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            ],
+                            "message": {
+                              "text": "action is not pinned to a hash (required by blanket policy)"
+                            },
+                            "physicalLocation": {
+                              "artifactLocation": {
+                                "uri": ".github/workflows/workflow.yml"
+                              },
+                              "region": {
+                                "endColumn": 34,
+                                "endLine": 7,
+                                "snippet": {
+                                  "text": "actions/checkout@v4"
+                                },
+                                "sourceLanguage": "yaml",
+                                "startColumn": 15,
+                                "startLine": 7
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "kind": "fail",
+              "level": "error",
+              "locations": [
+                {
+                  "logicalLocations": [
+                    {
+                      "properties": {
+                        "symbolic": {
+                          "annotation": "action is not pinned to a hash (required by blanket policy)",
+                          "feature_kind": {
+                            "Subfeature": {
+                              "after": 0,
+                              "fragment": {
+                                "Raw": "actions/checkout@v4"
+                              }
+                            }
+                          },
+                          "key": {
+                            "Local": {
+                              "given_path": ".github/workflows/workflow.yml",
+                              "prefix": null
+                            }
+                          },
+                          "kind": "Primary",
+                          "route": {
+                            "route": [
+                              {
+                                "Key": "jobs"
+                              },
+                              {
+                                "Key": "test"
+                              },
+                              {
+                                "Key": "steps"
+                              },
+                              {
+                                "Index": 0
+                              },
+                              {
+                                "Key": "uses"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "message": {
+                    "text": "action is not pinned to a hash (required by blanket policy)"
+                  },
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": ".github/workflows/workflow.yml"
+                    },
+                    "region": {
+                      "endColumn": 34,
+                      "endLine": 7,
+                      "snippet": {
+                        "text": "actions/checkout@v4"
+                      },
+                      "sourceLanguage": "yaml",
+                      "startColumn": 15,
+                      "startLine": 7
+                    }
+                  }
+                }
+              ],
+              "message": {
+                "text": "unpinned action reference"
+              },
+              "properties": {
+                "zizmor/confidence": "High",
+                "zizmor/persona": "Regular",
+                "zizmor/severity": "High"
+              },
+              "ruleId": "zizmor/unpinned-uses"
+            }
+          ],
+          "tool": {
+            "driver": {
+              "downloadUri": "https://github.com/zizmorcore/zizmor",
+              "informationUri": "https://docs.zizmor.sh",
+              "name": "zizmor",
+              "rules": [
+                {
+                  "help": {
+                    "markdown": "`artipacked`: credential persistence through GitHub Actions artifacts\n\nDocs: <https://docs.zizmor.sh/audits/#artipacked>",
+                    "text": "credential persistence through GitHub Actions artifacts"
+                  },
+                  "helpUri": "https://docs.zizmor.sh/audits/#artipacked",
+                  "id": "zizmor/artipacked",
+                  "name": "artipacked",
+                  "properties": {
+                    "tags": [
+                      "security"
+                    ]
+                  }
+                },
+                {
+                  "help": {
+                    "markdown": "`excessive-permissions`: overly broad permissions\n\nDocs: <https://docs.zizmor.sh/audits/#excessive-permissions>",
+                    "text": "overly broad permissions"
+                  },
+                  "helpUri": "https://docs.zizmor.sh/audits/#excessive-permissions",
+                  "id": "zizmor/excessive-permissions",
+                  "name": "excessive-permissions",
+                  "properties": {
+                    "tags": [
+                      "security"
+                    ]
+                  }
+                },
+                {
+                  "help": {
+                    "markdown": "`unpinned-uses`: unpinned action reference\n\nDocs: <https://docs.zizmor.sh/audits/#unpinned-uses>",
+                    "text": "unpinned action reference"
+                  },
+                  "helpUri": "https://docs.zizmor.sh/audits/#unpinned-uses",
+                  "id": "zizmor/unpinned-uses",
+                  "name": "unpinned-uses",
+                  "properties": {
+                    "tags": [
+                      "security"
+                    ]
+                  }
+                }
+              ],
+              "semanticVersion": "1.24.1",
+              "version": "1.24.1"
+            }
+          }
+        }
+      ],
+      "version": "2.1.0"
+    }
   },
   "selected_files": [
     ".github/workflows/workflow.yml"

--- a/zizmor/tests/fail/sarif.json
+++ b/zizmor/tests/fail/sarif.json
@@ -7,14 +7,123 @@
       },
       "results": [
         {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "importance": "essential",
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "properties": {
+                              "symbolic": {
+                                "annotation": "does not set persist-credentials: false",
+                                "feature_kind": "Normal",
+                                "key": {
+                                  "Local": {
+                                    "given_path": ".github/workflows/workflow.yml",
+                                    "prefix": null
+                                  }
+                                },
+                                "kind": "Primary",
+                                "route": {
+                                  "route": [
+                                    {
+                                      "Key": "jobs"
+                                    },
+                                    {
+                                      "Key": "test"
+                                    },
+                                    {
+                                      "Key": "steps"
+                                    },
+                                    {
+                                      "Index": 0
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "message": {
+                          "text": "does not set persist-credentials: false"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": ".github/workflows/workflow.yml"
+                          },
+                          "region": {
+                            "endColumn": 1,
+                            "endLine": 8,
+                            "snippet": {
+                              "text": "uses: actions/checkout@v4\n"
+                            },
+                            "sourceLanguage": "yaml",
+                            "startColumn": 9,
+                            "startLine": 7
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "kind": "fail",
           "level": "warning",
           "locations": [
             {
+              "logicalLocations": [
+                {
+                  "properties": {
+                    "symbolic": {
+                      "annotation": "does not set persist-credentials: false",
+                      "feature_kind": "Normal",
+                      "key": {
+                        "Local": {
+                          "given_path": ".github/workflows/workflow.yml",
+                          "prefix": null
+                        }
+                      },
+                      "kind": "Primary",
+                      "route": {
+                        "route": [
+                          {
+                            "Key": "jobs"
+                          },
+                          {
+                            "Key": "test"
+                          },
+                          {
+                            "Key": "steps"
+                          },
+                          {
+                            "Index": 0
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              ],
+              "message": {
+                "text": "does not set persist-credentials: false"
+              },
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": ".github/workflows/workflow.yml"
                 },
                 "region": {
+                  "endColumn": 1,
+                  "endLine": 8,
+                  "snippet": {
+                    "text": "uses: actions/checkout@v4\n"
+                  },
+                  "sourceLanguage": "yaml",
                   "startColumn": 9,
                   "startLine": 7
                 }
@@ -25,19 +134,169 @@
             "text": "credential persistence through GitHub Actions artifacts"
           },
           "properties": {
-            "linter_name": "zizmor"
+            "linter_name": "zizmor",
+            "zizmor/confidence": "Low",
+            "zizmor/persona": "Regular",
+            "zizmor/severity": "Medium"
           },
-          "ruleId": "artipacked"
+          "ruleId": "zizmor/artipacked"
         },
         {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "importance": "important",
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "properties": {
+                              "symbolic": {
+                                "annotation": "this job",
+                                "feature_kind": "Normal",
+                                "key": {
+                                  "Local": {
+                                    "given_path": ".github/workflows/workflow.yml",
+                                    "prefix": null
+                                  }
+                                },
+                                "kind": "Related",
+                                "route": {
+                                  "route": [
+                                    {
+                                      "Key": "jobs"
+                                    },
+                                    {
+                                      "Key": "test"
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "message": {
+                          "text": "this job"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": ".github/workflows/workflow.yml"
+                          },
+                          "region": {
+                            "endColumn": 1,
+                            "endLine": 8,
+                            "snippet": {
+                              "text": "  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n"
+                            },
+                            "sourceLanguage": "yaml",
+                            "startColumn": 3,
+                            "startLine": 4
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "importance": "essential",
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "properties": {
+                              "symbolic": {
+                                "annotation": "default permissions used due to no permissions: block",
+                                "feature_kind": "Normal",
+                                "key": {
+                                  "Local": {
+                                    "given_path": ".github/workflows/workflow.yml",
+                                    "prefix": null
+                                  }
+                                },
+                                "kind": "Primary",
+                                "route": {
+                                  "route": [
+                                    {
+                                      "Key": "jobs"
+                                    },
+                                    {
+                                      "Key": "test"
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "message": {
+                          "text": "default permissions used due to no permissions: block"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": ".github/workflows/workflow.yml"
+                          },
+                          "region": {
+                            "endColumn": 1,
+                            "endLine": 8,
+                            "snippet": {
+                              "text": "  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n"
+                            },
+                            "sourceLanguage": "yaml",
+                            "startColumn": 3,
+                            "startLine": 4
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "kind": "fail",
           "level": "warning",
           "locations": [
             {
+              "logicalLocations": [
+                {
+                  "properties": {
+                    "symbolic": {
+                      "annotation": "default permissions used due to no permissions: block",
+                      "feature_kind": "Normal",
+                      "key": {
+                        "Local": {
+                          "given_path": ".github/workflows/workflow.yml",
+                          "prefix": null
+                        }
+                      },
+                      "kind": "Primary",
+                      "route": {
+                        "route": [
+                          {
+                            "Key": "jobs"
+                          },
+                          {
+                            "Key": "test"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              ],
+              "message": {
+                "text": "default permissions used due to no permissions: block"
+              },
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": ".github/workflows/workflow.yml"
                 },
                 "region": {
+                  "endColumn": 1,
+                  "endLine": 8,
+                  "snippet": {
+                    "text": "  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n"
+                  },
+                  "sourceLanguage": "yaml",
                   "startColumn": 3,
                   "startLine": 4
                 }
@@ -48,19 +307,151 @@
             "text": "overly broad permissions"
           },
           "properties": {
-            "linter_name": "zizmor"
+            "linter_name": "zizmor",
+            "zizmor/confidence": "Medium",
+            "zizmor/persona": "Regular",
+            "zizmor/severity": "Medium"
           },
-          "ruleId": "excessive-permissions"
+          "ruleId": "zizmor/excessive-permissions"
         },
         {
-          "level": "warning",
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "importance": "essential",
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "properties": {
+                              "symbolic": {
+                                "annotation": "action is not pinned to a hash (required by blanket policy)",
+                                "feature_kind": {
+                                  "Subfeature": {
+                                    "after": 0,
+                                    "fragment": {
+                                      "Raw": "actions/checkout@v4"
+                                    }
+                                  }
+                                },
+                                "key": {
+                                  "Local": {
+                                    "given_path": ".github/workflows/workflow.yml",
+                                    "prefix": null
+                                  }
+                                },
+                                "kind": "Primary",
+                                "route": {
+                                  "route": [
+                                    {
+                                      "Key": "jobs"
+                                    },
+                                    {
+                                      "Key": "test"
+                                    },
+                                    {
+                                      "Key": "steps"
+                                    },
+                                    {
+                                      "Index": 0
+                                    },
+                                    {
+                                      "Key": "uses"
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "message": {
+                          "text": "action is not pinned to a hash (required by blanket policy)"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": ".github/workflows/workflow.yml"
+                          },
+                          "region": {
+                            "endColumn": 34,
+                            "endLine": 7,
+                            "snippet": {
+                              "text": "actions/checkout@v4"
+                            },
+                            "sourceLanguage": "yaml",
+                            "startColumn": 15,
+                            "startLine": 7
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "kind": "fail",
+          "level": "error",
           "locations": [
             {
+              "logicalLocations": [
+                {
+                  "properties": {
+                    "symbolic": {
+                      "annotation": "action is not pinned to a hash (required by blanket policy)",
+                      "feature_kind": {
+                        "Subfeature": {
+                          "after": 0,
+                          "fragment": {
+                            "Raw": "actions/checkout@v4"
+                          }
+                        }
+                      },
+                      "key": {
+                        "Local": {
+                          "given_path": ".github/workflows/workflow.yml",
+                          "prefix": null
+                        }
+                      },
+                      "kind": "Primary",
+                      "route": {
+                        "route": [
+                          {
+                            "Key": "jobs"
+                          },
+                          {
+                            "Key": "test"
+                          },
+                          {
+                            "Key": "steps"
+                          },
+                          {
+                            "Index": 0
+                          },
+                          {
+                            "Key": "uses"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              ],
+              "message": {
+                "text": "action is not pinned to a hash (required by blanket policy)"
+              },
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": ".github/workflows/workflow.yml"
                 },
                 "region": {
+                  "endColumn": 34,
+                  "endLine": 7,
+                  "snippet": {
+                    "text": "actions/checkout@v4"
+                  },
+                  "sourceLanguage": "yaml",
                   "startColumn": 15,
                   "startLine": 7
                 }
@@ -71,9 +462,12 @@
             "text": "unpinned action reference"
           },
           "properties": {
-            "linter_name": "zizmor"
+            "linter_name": "zizmor",
+            "zizmor/confidence": "High",
+            "zizmor/persona": "Regular",
+            "zizmor/severity": "High"
           },
-          "ruleId": "unpinned-uses"
+          "ruleId": "zizmor/unpinned-uses"
         }
       ],
       "tool": {
@@ -82,24 +476,45 @@
           "name": "linter-service/zizmor",
           "rules": [
             {
-              "id": "artipacked",
+              "help": {
+                "markdown": "`artipacked`: credential persistence through GitHub Actions artifacts\n\nDocs: <https://docs.zizmor.sh/audits/#artipacked>",
+                "text": "credential persistence through GitHub Actions artifacts"
+              },
+              "helpUri": "https://docs.zizmor.sh/audits/#artipacked",
+              "id": "zizmor/artipacked",
               "name": "artipacked",
-              "shortDescription": {
-                "text": "artipacked"
+              "properties": {
+                "tags": [
+                  "security"
+                ]
               }
             },
             {
-              "id": "excessive-permissions",
+              "help": {
+                "markdown": "`excessive-permissions`: overly broad permissions\n\nDocs: <https://docs.zizmor.sh/audits/#excessive-permissions>",
+                "text": "overly broad permissions"
+              },
+              "helpUri": "https://docs.zizmor.sh/audits/#excessive-permissions",
+              "id": "zizmor/excessive-permissions",
               "name": "excessive-permissions",
-              "shortDescription": {
-                "text": "excessive-permissions"
+              "properties": {
+                "tags": [
+                  "security"
+                ]
               }
             },
             {
-              "id": "unpinned-uses",
+              "help": {
+                "markdown": "`unpinned-uses`: unpinned action reference\n\nDocs: <https://docs.zizmor.sh/audits/#unpinned-uses>",
+                "text": "unpinned action reference"
+              },
+              "helpUri": "https://docs.zizmor.sh/audits/#unpinned-uses",
+              "id": "zizmor/unpinned-uses",
               "name": "unpinned-uses",
-              "shortDescription": {
-                "text": "unpinned-uses"
+              "properties": {
+                "tags": [
+                  "security"
+                ]
               }
             }
           ]

--- a/zizmor/tests/pass/result.json
+++ b/zizmor/tests/pass/result.json
@@ -1,8 +1,181 @@
 {
   "checked_projects": [],
   "result": {
-    "details": "INFO zizmor: 🌈 zizmor v1.24.1\n INFO audit: zizmor: 🌈 completed .github/workflows/workflow.yml\nwarning[artipacked]: credential persistence through GitHub Actions artifacts\n --> .github/workflows/workflow.yml:9:9\n  |\n9 |       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd\n  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false\n  |\n  = note: audit confidence → Low\n  = note: this finding has an auto-fix\n  = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked\n\n3 findings (2 suppressed, 1 fixable): 0 informational, 0 low, 1 medium, 0 high",
-    "exit_code": 13
+    "exit_code": 1,
+    "sarif": {
+      "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json",
+      "runs": [
+        {
+          "invocations": [
+            {
+              "executionSuccessful": true
+            }
+          ],
+          "results": [
+            {
+              "codeFlows": [
+                {
+                  "threadFlows": [
+                    {
+                      "locations": [
+                        {
+                          "importance": "essential",
+                          "location": {
+                            "logicalLocations": [
+                              {
+                                "properties": {
+                                  "symbolic": {
+                                    "annotation": "does not set persist-credentials: false",
+                                    "feature_kind": "Normal",
+                                    "key": {
+                                      "Local": {
+                                        "given_path": ".github/workflows/workflow.yml",
+                                        "prefix": null
+                                      }
+                                    },
+                                    "kind": "Primary",
+                                    "route": {
+                                      "route": [
+                                        {
+                                          "Key": "jobs"
+                                        },
+                                        {
+                                          "Key": "test"
+                                        },
+                                        {
+                                          "Key": "steps"
+                                        },
+                                        {
+                                          "Index": 0
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            ],
+                            "message": {
+                              "text": "does not set persist-credentials: false"
+                            },
+                            "physicalLocation": {
+                              "artifactLocation": {
+                                "uri": ".github/workflows/workflow.yml"
+                              },
+                              "region": {
+                                "endColumn": 1,
+                                "endLine": 10,
+                                "snippet": {
+                                  "text": "uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd\n"
+                                },
+                                "sourceLanguage": "yaml",
+                                "startColumn": 9,
+                                "startLine": 9
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "kind": "fail",
+              "level": "warning",
+              "locations": [
+                {
+                  "logicalLocations": [
+                    {
+                      "properties": {
+                        "symbolic": {
+                          "annotation": "does not set persist-credentials: false",
+                          "feature_kind": "Normal",
+                          "key": {
+                            "Local": {
+                              "given_path": ".github/workflows/workflow.yml",
+                              "prefix": null
+                            }
+                          },
+                          "kind": "Primary",
+                          "route": {
+                            "route": [
+                              {
+                                "Key": "jobs"
+                              },
+                              {
+                                "Key": "test"
+                              },
+                              {
+                                "Key": "steps"
+                              },
+                              {
+                                "Index": 0
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "message": {
+                    "text": "does not set persist-credentials: false"
+                  },
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": ".github/workflows/workflow.yml"
+                    },
+                    "region": {
+                      "endColumn": 1,
+                      "endLine": 10,
+                      "snippet": {
+                        "text": "uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd\n"
+                      },
+                      "sourceLanguage": "yaml",
+                      "startColumn": 9,
+                      "startLine": 9
+                    }
+                  }
+                }
+              ],
+              "message": {
+                "text": "credential persistence through GitHub Actions artifacts"
+              },
+              "properties": {
+                "zizmor/confidence": "Low",
+                "zizmor/persona": "Regular",
+                "zizmor/severity": "Medium"
+              },
+              "ruleId": "zizmor/artipacked"
+            }
+          ],
+          "tool": {
+            "driver": {
+              "downloadUri": "https://github.com/zizmorcore/zizmor",
+              "informationUri": "https://docs.zizmor.sh",
+              "name": "zizmor",
+              "rules": [
+                {
+                  "help": {
+                    "markdown": "`artipacked`: credential persistence through GitHub Actions artifacts\n\nDocs: <https://docs.zizmor.sh/audits/#artipacked>",
+                    "text": "credential persistence through GitHub Actions artifacts"
+                  },
+                  "helpUri": "https://docs.zizmor.sh/audits/#artipacked",
+                  "id": "zizmor/artipacked",
+                  "name": "artipacked",
+                  "properties": {
+                    "tags": [
+                      "security"
+                    ]
+                  }
+                }
+              ],
+              "semanticVersion": "1.24.1",
+              "version": "1.24.1"
+            }
+          }
+        }
+      ],
+      "version": "2.1.0"
+    }
   },
   "selected_files": [
     ".github/workflows/workflow.yml"

--- a/zizmor/tests/pass/sarif.json
+++ b/zizmor/tests/pass/sarif.json
@@ -7,14 +7,123 @@
       },
       "results": [
         {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "importance": "essential",
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "properties": {
+                              "symbolic": {
+                                "annotation": "does not set persist-credentials: false",
+                                "feature_kind": "Normal",
+                                "key": {
+                                  "Local": {
+                                    "given_path": ".github/workflows/workflow.yml",
+                                    "prefix": null
+                                  }
+                                },
+                                "kind": "Primary",
+                                "route": {
+                                  "route": [
+                                    {
+                                      "Key": "jobs"
+                                    },
+                                    {
+                                      "Key": "test"
+                                    },
+                                    {
+                                      "Key": "steps"
+                                    },
+                                    {
+                                      "Index": 0
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "message": {
+                          "text": "does not set persist-credentials: false"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": ".github/workflows/workflow.yml"
+                          },
+                          "region": {
+                            "endColumn": 1,
+                            "endLine": 10,
+                            "snippet": {
+                              "text": "uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd\n"
+                            },
+                            "sourceLanguage": "yaml",
+                            "startColumn": 9,
+                            "startLine": 9
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "kind": "fail",
           "level": "warning",
           "locations": [
             {
+              "logicalLocations": [
+                {
+                  "properties": {
+                    "symbolic": {
+                      "annotation": "does not set persist-credentials: false",
+                      "feature_kind": "Normal",
+                      "key": {
+                        "Local": {
+                          "given_path": ".github/workflows/workflow.yml",
+                          "prefix": null
+                        }
+                      },
+                      "kind": "Primary",
+                      "route": {
+                        "route": [
+                          {
+                            "Key": "jobs"
+                          },
+                          {
+                            "Key": "test"
+                          },
+                          {
+                            "Key": "steps"
+                          },
+                          {
+                            "Index": 0
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              ],
+              "message": {
+                "text": "does not set persist-credentials: false"
+              },
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": ".github/workflows/workflow.yml"
                 },
                 "region": {
+                  "endColumn": 1,
+                  "endLine": 10,
+                  "snippet": {
+                    "text": "uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd\n"
+                  },
+                  "sourceLanguage": "yaml",
                   "startColumn": 9,
                   "startLine": 9
                 }
@@ -25,9 +134,12 @@
             "text": "credential persistence through GitHub Actions artifacts"
           },
           "properties": {
-            "linter_name": "zizmor"
+            "linter_name": "zizmor",
+            "zizmor/confidence": "Low",
+            "zizmor/persona": "Regular",
+            "zizmor/severity": "Medium"
           },
-          "ruleId": "artipacked"
+          "ruleId": "zizmor/artipacked"
         }
       ],
       "tool": {
@@ -36,10 +148,17 @@
           "name": "linter-service/zizmor",
           "rules": [
             {
-              "id": "artipacked",
+              "help": {
+                "markdown": "`artipacked`: credential persistence through GitHub Actions artifacts\n\nDocs: <https://docs.zizmor.sh/audits/#artipacked>",
+                "text": "credential persistence through GitHub Actions artifacts"
+              },
+              "helpUri": "https://docs.zizmor.sh/audits/#artipacked",
+              "id": "zizmor/artipacked",
               "name": "artipacked",
-              "shortDescription": {
-                "text": "artipacked"
+              "properties": {
+                "tags": [
+                  "security"
+                ]
               }
             }
           ]

--- a/zizmor/zizmor.test.js
+++ b/zizmor/zizmor.test.js
@@ -1,0 +1,241 @@
+const test = require("node:test");
+const { execFileSync, spawnSync } = require("node:child_process");
+const {
+	assert,
+	cleanupTempRepo,
+	fs,
+	makeTempRepo,
+	path,
+	writeExecutable,
+	writeFile,
+} = require("../.github/scripts/cargo-linter-test-lib.js");
+
+const runPath = path.join(__dirname, "run.sh");
+const bashPath = execFileSync("bash", ["-lc", "command -v bash"], {
+	encoding: "utf8",
+}).trim();
+
+function linkCommand(context, name) {
+	const targetPath = path.join(context.binDir, name);
+	if (fs.existsSync(targetPath)) {
+		return;
+	}
+
+	const sourcePath = execFileSync("bash", ["-lc", `command -v ${name}`], {
+		encoding: "utf8",
+	}).trim();
+	fs.symlinkSync(sourcePath, targetPath);
+}
+
+function createNodeOnlyEnv(context, extraEnv = {}) {
+	fs.rmSync(path.join(context.binDir, "python3"), { force: true });
+	fs.rmSync(path.join(context.binDir, "python"), { force: true });
+	for (const tool of ["bash", "cat", "dirname", "node", "rm"]) {
+		linkCommand(context, tool);
+	}
+
+	return {
+		...process.env,
+		...extraEnv,
+		PATH: context.binDir,
+		RUNNER_TEMP: context.runnerTemp,
+	};
+}
+
+function createZizmorStub(context) {
+	writeExecutable(
+		path.join(context.binDir, "zizmor"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+use_sarif=0
+for arg in "$@"; do
+  case "$arg" in
+    --format=sarif)
+      use_sarif=1
+      ;;
+  esac
+done
+if [ "$use_sarif" -eq 1 ]; then
+  case "\${ZIZMOR_STUB_MODE:-success}" in
+    success)
+      cat <<'EOF'
+{"$schema":"https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json","version":"2.1.0","runs":[{"tool":{"driver":{"name":"zizmor","version":"1.24.1","rules":[{"id":"zizmor/unpinned-uses","name":"unpinned-uses","helpUri":"https://docs.zizmor.sh/audits/#unpinned-uses"}]}},"results":[{"ruleId":"zizmor/unpinned-uses","level":"error","message":{"text":"unpinned action reference"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":".github/workflows/ci.yml"},"region":{"startLine":5,"startColumn":9}}}]}]}]}
+EOF
+      exit 0
+      ;;
+    success_with_stderr)
+      cat <<'EOF'
+{"$schema":"https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json","version":"2.1.0","runs":[{"tool":{"driver":{"name":"zizmor","version":"1.24.1","rules":[{"id":"zizmor/unpinned-uses","name":"unpinned-uses","helpUri":"https://docs.zizmor.sh/audits/#unpinned-uses"}]}},"results":[{"ruleId":"zizmor/unpinned-uses","level":"error","message":{"text":"unpinned action reference"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":".github/workflows/ci.yml"},"region":{"startLine":5,"startColumn":9}}}]}]}]}
+EOF
+      printf 'zizmor emitted SARIF with a warning on stderr\n' >&2
+      exit 0
+      ;;
+    empty)
+      printf 'zizmor failed to produce output\\n' >&2
+      exit 2
+      ;;
+    no_results)
+      cat <<'EOF'
+{"$schema":"https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json","version":"2.1.0","runs":[{"tool":{"driver":{"name":"zizmor","version":"1.24.1","rules":[]}},"results":[]}]}
+EOF
+      exit 0
+      ;;
+    malformed)
+      printf '{not valid json\n'
+      printf 'zizmor produced malformed SARIF\n' >&2
+      exit 0
+      ;;
+  esac
+fi
+printf 'unexpected invocation\\n' >&2
+exit 99
+`,
+	);
+}
+
+test("zizmor/run.sh emits SARIF result with findings", () => {
+	const context = makeTempRepo("zizmor-run-sarif-");
+
+	createZizmorStub(context);
+	writeFile(
+		path.join(context.repoDir, ".github/workflows/ci.yml"),
+		"name: ci\non: push\njobs: {}\n",
+	);
+
+	try {
+		const output = execFileSync(
+			bashPath,
+			[runPath, ".github/workflows/ci.yml"],
+			{
+				cwd: context.repoDir,
+				encoding: "utf8",
+				env: createNodeOnlyEnv(context),
+			},
+		);
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 1);
+		assert.ok(result.sarif, "result should have sarif key");
+		assert.equal(
+			result.sarif.runs[0].results[0].ruleId,
+			"zizmor/unpinned-uses",
+		);
+		assert.equal(
+			result.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			".github/workflows/ci.yml",
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("zizmor/run.sh sets exit_code=0 when no findings", () => {
+	const context = makeTempRepo("zizmor-run-no-findings-");
+
+	createZizmorStub(context);
+	writeFile(
+		path.join(context.repoDir, ".github/workflows/ci.yml"),
+		"name: ci\non: push\njobs: {}\n",
+	);
+
+	try {
+		const output = execFileSync(
+			bashPath,
+			[runPath, ".github/workflows/ci.yml"],
+			{
+				cwd: context.repoDir,
+				encoding: "utf8",
+				env: createNodeOnlyEnv(context, { ZIZMOR_STUB_MODE: "no_results" }),
+			},
+		);
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 0);
+		assert.ok(result.sarif, "result should have sarif key");
+		assert.equal(result.sarif.runs[0].results.length, 0);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("zizmor/run.sh fails when native SARIF output is missing", () => {
+	const context = makeTempRepo("zizmor-run-missing-sarif-");
+
+	createZizmorStub(context);
+	writeFile(
+		path.join(context.repoDir, ".github/workflows/ci.yml"),
+		"name: ci\non: push\njobs: {}\n",
+	);
+
+	try {
+		const result = spawnSync(bashPath, [runPath, ".github/workflows/ci.yml"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createNodeOnlyEnv(context, { ZIZMOR_STUB_MODE: "empty" }),
+		});
+
+		assert.equal(result.status, 1);
+		assert.match(
+			result.stderr,
+			/zizmor native SARIF output was empty or missing/u,
+		);
+		assert.equal(result.stdout, "");
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("zizmor/run.sh forwards stderr when SARIF output is available", () => {
+	const context = makeTempRepo("zizmor-run-stderr-");
+
+	createZizmorStub(context);
+	writeFile(
+		path.join(context.repoDir, ".github/workflows/ci.yml"),
+		"name: ci\non: push\njobs: {}\n",
+	);
+
+	try {
+		const result = spawnSync(bashPath, [runPath, ".github/workflows/ci.yml"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createNodeOnlyEnv(context, {
+				ZIZMOR_STUB_MODE: "success_with_stderr",
+			}),
+		});
+
+		assert.equal(result.status, 0);
+		assert.match(
+			result.stderr,
+			/zizmor emitted SARIF with a warning on stderr/u,
+		);
+		assert.equal(JSON.parse(result.stdout).exit_code, 1);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("zizmor/run.sh surfaces tool stderr before failing malformed SARIF", () => {
+	const context = makeTempRepo("zizmor-run-malformed-sarif-");
+
+	createZizmorStub(context);
+	writeFile(
+		path.join(context.repoDir, ".github/workflows/ci.yml"),
+		"name: ci\non: push\njobs: {}\n",
+	);
+
+	try {
+		const result = spawnSync(bashPath, [runPath, ".github/workflows/ci.yml"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createNodeOnlyEnv(context, { ZIZMOR_STUB_MODE: "malformed" }),
+		});
+
+		assert.notEqual(result.status, 0);
+		assert.match(result.stderr, /zizmor produced malformed SARIF/u);
+		assert.match(result.stderr, /SyntaxError/u);
+		assert.equal(result.stdout, "");
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});


### PR DESCRIPTION
## Summary
- switch `zizmor/run.sh` from plain output capture to native `--format=sarif` output embedded in the shared JSON result shape
- move zizmor's SARIF findings-to-exit-code normalization into a shared linter-library helper so `run.sh` stays minimal
- add shared helper coverage and keep zizmor fixture expectations unchanged