### PR TITLE
fix: emit SARIF-backed actionlint results

### DIFF
--- a/.github/linter-service.yaml
+++ b/.github/linter-service.yaml
@@ -11,6 +11,8 @@ linters:
       - typescript
   textlint:
     disabled: false
+    exclude_paths:
+      - "actionlint/sarif_template.txt"
     preset_packages:
       - "textlint-rule-preset-ja-technical-writing@12.0.2"
       - "@textlint-ja/textlint-rule-preset-ai-writing@1.6.1"

--- a/.github/scripts/linter-service-config.test.js
+++ b/.github/scripts/linter-service-config.test.js
@@ -186,6 +186,26 @@ test("prefers YAML over JSON when both config files exist", () => {
 	}
 });
 
+test("repository config excludes the vendored actionlint SARIF template from textlint", () => {
+	const config = loadLinterServiceConfig({
+		repositoryPath: path.join(__dirname, "..", ".."),
+	});
+
+	assert.equal(config.exists, true);
+	assert.equal(
+		isPathExcluded(config, "textlint", "actionlint/sarif_template.txt"),
+		true,
+	);
+	assert.equal(
+		isPathExcluded(
+			config,
+			"textlint",
+			"actionlint/render-linter-sarif.test.js",
+		),
+		false,
+	);
+});
+
 test("loads global and per-linter exclude globs with directory normalization", () => {
 	const context = makeTempRepo();
 	writeLinterServiceConfig(context.repoDir, {

--- a/actionlint/actionlint.test.js
+++ b/actionlint/actionlint.test.js
@@ -22,6 +22,7 @@ const linterLibraryPath = path.join(
 const bashPath = execFileSync("bash", ["-lc", "command -v bash"], {
 	encoding: "utf8",
 }).trim();
+const expressionSnippet = "run: echo $" + "{{ bad";
 
 function linkCommand(context, name) {
 	const targetPath = path.join(context.binDir, name);
@@ -86,7 +87,7 @@ const SARIF_WITH_RESULTS = JSON.stringify({
 									startLine: 5,
 									startColumn: 9,
 									endColumn: 9,
-									snippet: { text: "run: echo ${{ bad" },
+									snippet: { text: expressionSnippet },
 								},
 							},
 						},

--- a/actionlint/actionlint.test.js
+++ b/actionlint/actionlint.test.js
@@ -1,0 +1,344 @@
+const test = require("node:test");
+const { execFileSync, spawnSync } = require("node:child_process");
+const {
+	assert,
+	cleanupTempRepo,
+	fs,
+	makeTempRepo,
+	path,
+	writeExecutable,
+	writeFile,
+} = require("../.github/scripts/cargo-linter-test-lib.js");
+
+const runPath = path.join(__dirname, "run.sh");
+const commonPath = path.join(__dirname, "common.sh");
+const linterLibraryPath = path.join(
+	__dirname,
+	"..",
+	".github",
+	"scripts",
+	"linter-library.sh",
+);
+const bashPath = execFileSync("bash", ["-lc", "command -v bash"], {
+	encoding: "utf8",
+}).trim();
+
+function linkCommand(context, name) {
+	const targetPath = path.join(context.binDir, name);
+	if (fs.existsSync(targetPath)) {
+		return;
+	}
+
+	const sourcePath = execFileSync("bash", ["-lc", `command -v ${name}`], {
+		encoding: "utf8",
+	}).trim();
+	fs.symlinkSync(sourcePath, targetPath);
+}
+
+function createNodeOnlyEnv(context, extraEnv = {}) {
+	fs.rmSync(path.join(context.binDir, "python3"), { force: true });
+	fs.rmSync(path.join(context.binDir, "python"), { force: true });
+	for (const tool of ["bash", "cat", "dirname", "node", "rm"]) {
+		linkCommand(context, tool);
+	}
+
+	return {
+		...process.env,
+		...extraEnv,
+		PATH: context.binDir,
+		RUNNER_TEMP: context.runnerTemp,
+	};
+}
+
+// Minimal well-formed SARIF with one result
+const SARIF_WITH_RESULTS = JSON.stringify({
+	$schema:
+		"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+	version: "2.1.0",
+	runs: [
+		{
+			tool: {
+				driver: {
+					name: "GitHub Actions lint",
+					version: "1.7.12",
+					informationUri: "https://github.com/rhysd/actionlint",
+					rules: [
+						{
+							id: "expression",
+							name: "Expression",
+							defaultConfiguration: { level: "error" },
+						},
+					],
+				},
+			},
+			results: [
+				{
+					ruleId: "expression",
+					message: { text: "got unexpected character" },
+					locations: [
+						{
+							physicalLocation: {
+								artifactLocation: {
+									uri: ".github/workflows/ci.yml",
+									uriBaseId: "%SRCROOT%",
+								},
+								region: {
+									startLine: 5,
+									startColumn: 9,
+									endColumn: 9,
+									snippet: { text: "run: echo ${{ bad" },
+								},
+							},
+						},
+					],
+				},
+			],
+		},
+	],
+});
+
+// Minimal well-formed SARIF with no results
+const SARIF_NO_RESULTS = JSON.stringify({
+	$schema:
+		"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+	version: "2.1.0",
+	runs: [
+		{
+			tool: {
+				driver: {
+					name: "GitHub Actions lint",
+					version: "1.7.12",
+					informationUri: "https://github.com/rhysd/actionlint",
+					rules: [],
+				},
+			},
+			results: [],
+		},
+	],
+});
+
+function createActionlintStub(context) {
+	writeExecutable(
+		path.join(context.binDir, "actionlint"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+case "\${ACTIONLINT_STUB_MODE:-success}" in
+  success)
+    printf '%s\\n' '${SARIF_WITH_RESULTS.replace(/'/g, "'\\''")}'
+    exit 1
+    ;;
+  success_with_stderr)
+    printf '%s\\n' '${SARIF_WITH_RESULTS.replace(/'/g, "'\\''")}'
+    printf 'actionlint emitted SARIF with a warning on stderr\\n' >&2
+    exit 1
+    ;;
+  no_results)
+    printf '%s\\n' '${SARIF_NO_RESULTS.replace(/'/g, "'\\''")}'
+    exit 0
+    ;;
+  empty)
+    printf 'actionlint failed to produce output\\n' >&2
+    exit 3
+    ;;
+  malformed)
+    printf '{not valid json\\n'
+    printf 'actionlint produced malformed SARIF\\n' >&2
+    exit 1
+    ;;
+esac
+`,
+	);
+}
+
+function createRunScriptWithoutTemplate(context) {
+	const tempRoot = path.join(context.tempDir, "actionlint-script-root");
+	const tempActionlintDir = path.join(tempRoot, "actionlint");
+	const tempGithubScriptsDir = path.join(tempRoot, ".github", "scripts");
+	const tempRunPath = path.join(tempActionlintDir, "run.sh");
+	const tempCommonPath = path.join(tempActionlintDir, "common.sh");
+	const tempLibraryPath = path.join(tempGithubScriptsDir, "linter-library.sh");
+
+	fs.mkdirSync(tempActionlintDir, { recursive: true });
+	fs.mkdirSync(tempGithubScriptsDir, { recursive: true });
+	fs.copyFileSync(runPath, tempRunPath);
+	fs.copyFileSync(commonPath, tempCommonPath);
+	fs.copyFileSync(linterLibraryPath, tempLibraryPath);
+	fs.chmodSync(tempRunPath, 0o755);
+
+	return tempRunPath;
+}
+
+test("actionlint/run.sh emits SARIF result with findings", () => {
+	const context = makeTempRepo("actionlint-run-sarif-");
+
+	createActionlintStub(context);
+	writeFile(
+		path.join(context.repoDir, ".github/workflows/ci.yml"),
+		"name: ci\non: push\njobs: {}\n",
+	);
+
+	try {
+		const output = execFileSync(
+			bashPath,
+			[runPath, ".github/workflows/ci.yml"],
+			{
+				cwd: context.repoDir,
+				encoding: "utf8",
+				env: createNodeOnlyEnv(context),
+			},
+		);
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 1);
+		assert.ok(result.sarif, "result should have sarif key");
+		assert.equal(result.sarif.runs[0].results[0].ruleId, "expression");
+		assert.equal(
+			result.sarif.runs[0].results[0].locations[0].physicalLocation
+				.artifactLocation.uri,
+			".github/workflows/ci.yml",
+		);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("actionlint/run.sh sets exit_code=0 when no findings", () => {
+	const context = makeTempRepo("actionlint-run-no-findings-");
+
+	createActionlintStub(context);
+	writeFile(
+		path.join(context.repoDir, ".github/workflows/ci.yml"),
+		"name: ci\non: push\njobs: {}\n",
+	);
+
+	try {
+		const output = execFileSync(
+			bashPath,
+			[runPath, ".github/workflows/ci.yml"],
+			{
+				cwd: context.repoDir,
+				encoding: "utf8",
+				env: createNodeOnlyEnv(context, {
+					ACTIONLINT_STUB_MODE: "no_results",
+				}),
+			},
+		);
+		const result = JSON.parse(output);
+
+		assert.equal(result.exit_code, 0);
+		assert.ok(result.sarif, "result should have sarif key");
+		assert.equal(result.sarif.runs[0].results.length, 0);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("actionlint/run.sh fails when native SARIF output is missing", () => {
+	const context = makeTempRepo("actionlint-run-missing-sarif-");
+
+	createActionlintStub(context);
+	writeFile(
+		path.join(context.repoDir, ".github/workflows/ci.yml"),
+		"name: ci\non: push\njobs: {}\n",
+	);
+
+	try {
+		const result = spawnSync(bashPath, [runPath, ".github/workflows/ci.yml"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createNodeOnlyEnv(context, { ACTIONLINT_STUB_MODE: "empty" }),
+		});
+
+		assert.equal(result.status, 1);
+		assert.match(
+			result.stderr,
+			/actionlint native SARIF output was empty or missing/u,
+		);
+		assert.equal(result.stdout, "");
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("actionlint/run.sh forwards stderr when SARIF output is available", () => {
+	const context = makeTempRepo("actionlint-run-stderr-");
+
+	createActionlintStub(context);
+	writeFile(
+		path.join(context.repoDir, ".github/workflows/ci.yml"),
+		"name: ci\non: push\njobs: {}\n",
+	);
+
+	try {
+		const result = spawnSync(bashPath, [runPath, ".github/workflows/ci.yml"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createNodeOnlyEnv(context, {
+				ACTIONLINT_STUB_MODE: "success_with_stderr",
+			}),
+		});
+
+		assert.equal(result.status, 0);
+		assert.match(
+			result.stderr,
+			/actionlint emitted SARIF with a warning on stderr/u,
+		);
+		assert.equal(JSON.parse(result.stdout).exit_code, 1);
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("actionlint/run.sh fails fast when SARIF template is missing", () => {
+	const context = makeTempRepo("actionlint-run-missing-template-");
+
+	createActionlintStub(context);
+	writeFile(
+		path.join(context.repoDir, ".github/workflows/ci.yml"),
+		"name: ci\non: push\njobs: {}\n",
+	);
+
+	try {
+		const isolatedRunPath = createRunScriptWithoutTemplate(context);
+		const result = spawnSync(
+			bashPath,
+			[isolatedRunPath, ".github/workflows/ci.yml"],
+			{
+				cwd: context.repoDir,
+				encoding: "utf8",
+				env: createNodeOnlyEnv(context),
+			},
+		);
+
+		assert.notEqual(result.status, 0);
+		assert.match(result.stderr, /sarif_template\.txt/u);
+		assert.equal(result.stdout, "");
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});
+
+test("actionlint/run.sh surfaces tool stderr before failing malformed SARIF", () => {
+	const context = makeTempRepo("actionlint-run-malformed-sarif-");
+
+	createActionlintStub(context);
+	writeFile(
+		path.join(context.repoDir, ".github/workflows/ci.yml"),
+		"name: ci\non: push\njobs: {}\n",
+	);
+
+	try {
+		const result = spawnSync(bashPath, [runPath, ".github/workflows/ci.yml"], {
+			cwd: context.repoDir,
+			encoding: "utf8",
+			env: createNodeOnlyEnv(context, { ACTIONLINT_STUB_MODE: "malformed" }),
+		});
+
+		assert.notEqual(result.status, 0);
+		assert.match(result.stderr, /actionlint produced malformed SARIF/u);
+		assert.match(result.stderr, /SyntaxError/u);
+		assert.equal(result.stdout, "");
+	} finally {
+		cleanupTempRepo(context.tempDir);
+	}
+});

--- a/actionlint/render-linter-sarif.test.js
+++ b/actionlint/render-linter-sarif.test.js
@@ -11,7 +11,69 @@ const { runFromEnv } = require("../.github/scripts/render-linter-sarif.js");
 
 const configPath = path.join(__dirname, "..", "linters.json");
 
-test("emits SARIF for actionlint workflow diagnostics", () => {
+// Native SARIF as emitted by `actionlint -format "$(cat sarif_template.txt)"`
+const nativeSarif = {
+	$schema:
+		"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+	version: "2.1.0",
+	runs: [
+		{
+			tool: {
+				driver: {
+					name: "GitHub Actions lint",
+					version: "1.7.12",
+					informationUri: "https://github.com/rhysd/actionlint",
+					rules: [
+						{
+							id: "expression",
+							name: "Expression",
+							defaultConfiguration: { level: "error" },
+							properties: {
+								description:
+									"Syntax and semantics checks for expressions embedded with ${{ }} syntax",
+								queryURI:
+									"https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+							},
+							fullDescription: {
+								text: "Syntax and semantics checks for expressions embedded with ${{ }} syntax",
+							},
+							helpUri:
+								"https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+						},
+					],
+				},
+			},
+			results: [
+				{
+					ruleId: "expression",
+					message: {
+						text: "got unexpected character '\"' while lexing expression",
+					},
+					locations: [
+						{
+							physicalLocation: {
+								artifactLocation: {
+									uri: ".github/workflows/ci.yml",
+									uriBaseId: "%SRCROOT%",
+								},
+								region: {
+									startLine: 7,
+									startColumn: 35,
+									endColumn: 35,
+									snippet: {
+										text: '      - run: echo "${{ github.ref "\n                                  ^',
+									},
+								},
+							},
+						},
+					],
+				},
+			],
+		},
+	],
+};
+
+test("prefers embedded actionlint SARIF when available", () => {
 	const context = makeTempRepo("render-linter-sarif-actionlint-");
 
 	writeFile(
@@ -25,9 +87,8 @@ test("emits SARIF for actionlint workflow diagnostics", () => {
 	writeFile(
 		path.join(context.runnerTemp, "linter-result.json"),
 		JSON.stringify({
-			details:
-				'.github/workflows/ci.yml:12:5: unexpected key "permissions" for "workflow"',
 			exit_code: 1,
+			sarif: nativeSarif,
 		}),
 	);
 
@@ -47,6 +108,7 @@ test("emits SARIF for actionlint workflow diagnostics", () => {
 
 		assert.equal(report.produced, true);
 		assert.equal(report.sarif.runs[0].results.length, 1);
+		assert.equal(report.sarif.runs[0].results[0].ruleId, "expression");
 		assert.equal(
 			report.sarif.runs[0].results[0].locations[0].physicalLocation
 				.artifactLocation.uri,
@@ -55,17 +117,19 @@ test("emits SARIF for actionlint workflow diagnostics", () => {
 		assert.equal(
 			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
 				.startLine,
-			12,
+			7,
 		);
 		assert.equal(
 			report.sarif.runs[0].results[0].locations[0].physicalLocation.region
 				.startColumn,
-			5,
+			35,
 		);
 		assert.match(
 			report.sarif.runs[0].results[0].message.text,
-			/unexpected key "permissions"/,
+			/got unexpected character/,
 		);
+		// Rules are sourced from native SARIF
+		assert.equal(report.sarif.runs[0].tool.driver.rules[0].id, "expression");
 	} finally {
 		cleanupTempRepo(context.tempDir);
 	}

--- a/actionlint/render-linter-sarif.test.js
+++ b/actionlint/render-linter-sarif.test.js
@@ -10,6 +10,13 @@ const {
 const { runFromEnv } = require("../.github/scripts/render-linter-sarif.js");
 
 const configPath = path.join(__dirname, "..", "linters.json");
+const expressionDescription =
+	"Syntax and semantics checks for expressions embedded with $" +
+	"{{ }} syntax";
+const expressionSnippet =
+	'      - run: echo "' +
+	"$" +
+	'{{ github.ref "\n                                  ^';
 
 // Native SARIF as emitted by `actionlint -format "$(cat sarif_template.txt)"`
 const nativeSarif = {
@@ -29,13 +36,12 @@ const nativeSarif = {
 							name: "Expression",
 							defaultConfiguration: { level: "error" },
 							properties: {
-								description:
-									"Syntax and semantics checks for expressions embedded with ${{ }} syntax",
+								description: expressionDescription,
 								queryURI:
 									"https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
 							},
 							fullDescription: {
-								text: "Syntax and semantics checks for expressions embedded with ${{ }} syntax",
+								text: expressionDescription,
 							},
 							helpUri:
 								"https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
@@ -61,7 +67,7 @@ const nativeSarif = {
 									startColumn: 35,
 									endColumn: 35,
 									snippet: {
-										text: '      - run: echo "${{ github.ref "\n                                  ^',
+										text: expressionSnippet,
 									},
 								},
 							},

--- a/actionlint/run.sh
+++ b/actionlint/run.sh
@@ -7,5 +7,27 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "$script_dir/common.sh"
 
 : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
-output_file="$RUNNER_TEMP/linter-output.txt"
-linter_lib::run_and_emit_json "$output_file" actionlint "$@"
+native_sarif_file="$RUNNER_TEMP/actionlint-native.sarif"
+stderr_file="$RUNNER_TEMP/actionlint-stderr.log"
+sarif_format=$(cat "$script_dir/sarif_template.txt")
+rm -f "$native_sarif_file" "$stderr_file"
+
+set +e
+actionlint -format "$sarif_format" "$@" >"$native_sarif_file" 2>"$stderr_file"
+exit_code=$?
+set -e
+
+if [ ! -s "$native_sarif_file" ]; then
+  echo "actionlint native SARIF output was empty or missing" >&2
+  if [ -s "$stderr_file" ]; then
+    cat "$stderr_file" >&2
+  fi
+  exit 1
+fi
+
+if [ -s "$stderr_file" ]; then
+  cat "$stderr_file" >&2
+fi
+rm -f "$stderr_file"
+
+linter_lib::emit_json_result_with_sarif "$exit_code" "$native_sarif_file"

--- a/actionlint/sarif_template.txt
+++ b/actionlint/sarif_template.txt
@@ -1,0 +1,66 @@
+{
+    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+    "version": "2.1.0",
+    "runs": [
+        {
+            "tool": {
+                "driver": {
+                    "name": "GitHub Actions lint",
+                    "version": {{ getVersion | json }},
+                    "informationUri": "https://github.com/rhysd/actionlint",
+                    "rules": [
+                        {{$first := true}}
+                        {{range $ := allKinds }}
+                            {{if $first}}{{$first = false}}{{else}},{{end}}
+                            {
+                                "id": {{json $.Name}},
+                                "name": {{$.Name | toPascalCase | json}},
+                                "defaultConfiguration": {
+                                    "level": "error"
+                                },
+                                "properties": {
+                                    "description": {{json $.Description}},
+                                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                                },
+                                "fullDescription": {
+                                    "text": {{json $.Description}}
+                                },
+                                "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                            }
+                        {{end}}
+                    ]
+                }
+            },
+            "results": [
+                {{$first := true}}
+                {{range $ := .}}
+                    {{if $first}}{{$first = false}}{{else}},{{end}}
+                    {
+                        "ruleId": {{json $.Kind}},
+                        "message": {
+                            "text": {{json $.Message}}
+                        },
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "artifactLocation": {
+                                        "uri": {{json $.Filepath}},
+                                        "uriBaseId": "%SRCROOT%"
+                                    },
+                                    "region": {
+                                        "startLine": {{$.Line}},
+                                        "startColumn": {{$.Column}},
+                                        "endColumn": {{$.EndColumn}},
+                                        "snippet": {
+                                            "text": {{json $.Snippet}}
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                {{end}}
+            ]
+        }
+    ]
+}

--- a/actionlint/tests/fail/result.json
+++ b/actionlint/tests/fail/result.json
@@ -1,8 +1,377 @@
 {
   "checked_projects": [],
   "result": {
-    "details": ".github/workflows/workflow.yml:7:9: shellcheck reported issue in this script: SC1009:info:1:7: The mentioned syntax error was in this parameter expansion [shellcheck]\n  |\n7 |       - run: echo \"${{ github.ref \"\n  |         ^~~~\n.github/workflows/workflow.yml:7:9: shellcheck reported issue in this script: SC1072:error:2:1: Expected end of double quoted string. Fix any mentioned problems and try again [shellcheck]\n  |\n7 |       - run: echo \"${{ github.ref \"\n  |         ^~~~\n.github/workflows/workflow.yml:7:9: shellcheck reported issue in this script: SC1073:error:1:22: Couldn't parse this double quoted string. Fix to allow more checks [shellcheck]\n  |\n7 |       - run: echo \"${{ github.ref \"\n  |         ^~~~\n.github/workflows/workflow.yml:7:35: got unexpected character '\"' while lexing expression, expecting 'a'..'z', 'A'..'Z', '_', '0'..'9', ''', '}', '(', ')', '[', ']', '.', '!', '<', '>', '=', '&', '|', '*', ',', ' '. do you mean string literals? only single quotes are available for string delimiter [expression]\n  |\n7 |       - run: echo \"${{ github.ref \"\n  |                                   ^",
-    "exit_code": 1
+    "exit_code": 1,
+    "sarif": {
+      "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+      "runs": [
+        {
+          "results": [
+            {
+              "locations": [
+                {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": ".github/workflows/workflow.yml",
+                      "uriBaseId": "%SRCROOT%"
+                    },
+                    "region": {
+                      "endColumn": 12,
+                      "snippet": {
+                        "text": "      - run: echo \"${{ github.ref \"\n        ^~~~"
+                      },
+                      "startColumn": 9,
+                      "startLine": 7
+                    }
+                  }
+                }
+              ],
+              "message": {
+                "text": "shellcheck reported issue in this script: SC1009:info:1:7: The mentioned syntax error was in this parameter expansion"
+              },
+              "ruleId": "shellcheck"
+            },
+            {
+              "locations": [
+                {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": ".github/workflows/workflow.yml",
+                      "uriBaseId": "%SRCROOT%"
+                    },
+                    "region": {
+                      "endColumn": 12,
+                      "snippet": {
+                        "text": "      - run: echo \"${{ github.ref \"\n        ^~~~"
+                      },
+                      "startColumn": 9,
+                      "startLine": 7
+                    }
+                  }
+                }
+              ],
+              "message": {
+                "text": "shellcheck reported issue in this script: SC1072:error:2:1: Expected end of double quoted string. Fix any mentioned problems and try again"
+              },
+              "ruleId": "shellcheck"
+            },
+            {
+              "locations": [
+                {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": ".github/workflows/workflow.yml",
+                      "uriBaseId": "%SRCROOT%"
+                    },
+                    "region": {
+                      "endColumn": 12,
+                      "snippet": {
+                        "text": "      - run: echo \"${{ github.ref \"\n        ^~~~"
+                      },
+                      "startColumn": 9,
+                      "startLine": 7
+                    }
+                  }
+                }
+              ],
+              "message": {
+                "text": "shellcheck reported issue in this script: SC1073:error:1:22: Couldn't parse this double quoted string. Fix to allow more checks"
+              },
+              "ruleId": "shellcheck"
+            },
+            {
+              "locations": [
+                {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": ".github/workflows/workflow.yml",
+                      "uriBaseId": "%SRCROOT%"
+                    },
+                    "region": {
+                      "endColumn": 35,
+                      "snippet": {
+                        "text": "      - run: echo \"${{ github.ref \"\n                                  ^"
+                      },
+                      "startColumn": 35,
+                      "startLine": 7
+                    }
+                  }
+                }
+              ],
+              "message": {
+                "text": "got unexpected character '\"' while lexing expression, expecting 'a'..'z', 'A'..'Z', '_', '0'..'9', ''', '}', '(', ')', '[', ']', '.', '!', '<', '>', '=', '&', '|', '*', ',', ' '. do you mean string literals? only single quotes are available for string delimiter"
+              },
+              "ruleId": "expression"
+            }
+          ],
+          "tool": {
+            "driver": {
+              "informationUri": "https://github.com/rhysd/actionlint",
+              "name": "GitHub Actions lint",
+              "rules": [
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for popular actions released on GitHub, local actions, and action calls at \"uses:\""
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "action",
+                  "name": "Action",
+                  "properties": {
+                    "description": "Checks for popular actions released on GitHub, local actions, and action calls at \"uses:\"",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for credentials in \"services:\" configuration"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "credentials",
+                  "name": "Credentials",
+                  "properties": {
+                    "description": "Checks for credentials in \"services:\" configuration",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for deprecated \"set-output\", \"save-state\", \"set-env\", and \"add-path\" commands at \"run:\""
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "deprecated-commands",
+                  "name": "DeprecatedCommands",
+                  "properties": {
+                    "description": "Checks for deprecated \"set-output\", \"save-state\", \"set-env\", and \"add-path\" commands at \"run:\"",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for environment variables configuration at \"env:\""
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "env-var",
+                  "name": "EnvVar",
+                  "properties": {
+                    "description": "Checks for environment variables configuration at \"env:\"",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for workflow trigger events at \"on:\""
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "events",
+                  "name": "Events",
+                  "properties": {
+                    "description": "Checks for workflow trigger events at \"on:\"",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Syntax and semantics checks for expressions embedded with ${{ }} syntax"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "expression",
+                  "name": "Expression",
+                  "properties": {
+                    "description": "Syntax and semantics checks for expressions embedded with ${{ }} syntax",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for glob syntax used in branch names, tags, and paths"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "glob",
+                  "name": "Glob",
+                  "properties": {
+                    "description": "Checks for glob syntax used in branch names, tags, and paths",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for duplication and naming convention of job/step IDs"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "id",
+                  "name": "Id",
+                  "properties": {
+                    "description": "Checks for duplication and naming convention of job/step IDs",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for if: conditions which are always true/false"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "if-cond",
+                  "name": "IfCond",
+                  "properties": {
+                    "description": "Checks for if: conditions which are always true/false",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for job IDs in \"needs:\". Undefined IDs and cyclic dependencies are checked"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "job-needs",
+                  "name": "JobNeeds",
+                  "properties": {
+                    "description": "Checks for job IDs in \"needs:\". Undefined IDs and cyclic dependencies are checked",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for matrix combinations in \"matrix:\""
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "matrix",
+                  "name": "Matrix",
+                  "properties": {
+                    "description": "Checks for matrix combinations in \"matrix:\"",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for permissions configuration in \"permissions:\". Permission names and permission scopes are checked"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "permissions",
+                  "name": "Permissions",
+                  "properties": {
+                    "description": "Checks for permissions configuration in \"permissions:\". Permission names and permission scopes are checked",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for GitHub-hosted and preset self-hosted runner labels in \"runs-on:\""
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "runner-label",
+                  "name": "RunnerLabel",
+                  "properties": {
+                    "description": "Checks for GitHub-hosted and preset self-hosted runner labels in \"runs-on:\"",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for shell names used for scripts in \"run:\""
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "shell-name",
+                  "name": "ShellName",
+                  "properties": {
+                    "description": "Checks for shell names used for scripts in \"run:\"",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for shell script sources in \"run:\" using shellcheck"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "shellcheck",
+                  "name": "Shellcheck",
+                  "properties": {
+                    "description": "Checks for shell script sources in \"run:\" using shellcheck",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for GitHub Actions workflow syntax"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "syntax-check",
+                  "name": "SyntaxCheck",
+                  "properties": {
+                    "description": "Checks for GitHub Actions workflow syntax",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for reusable workflow calls. Inputs and outputs of called reusable workflow are checked"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "workflow-call",
+                  "name": "WorkflowCall",
+                  "properties": {
+                    "description": "Checks for reusable workflow calls. Inputs and outputs of called reusable workflow are checked",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                }
+              ],
+              "version": "1.7.12"
+            }
+          }
+        }
+      ],
+      "version": "2.1.0"
+    }
   },
   "selected_files": [
     ".github/workflows/workflow.yml"

--- a/actionlint/tests/fail/sarif.json
+++ b/actionlint/tests/fail/sarif.json
@@ -7,14 +7,18 @@
       },
       "results": [
         {
-          "level": "warning",
           "locations": [
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": ".github/workflows/workflow.yml"
+                  "uri": ".github/workflows/workflow.yml",
+                  "uriBaseId": "%SRCROOT%"
                 },
                 "region": {
+                  "endColumn": 35,
+                  "snippet": {
+                    "text": "      - run: echo \"${{ github.ref \"\n                                  ^"
+                  },
                   "startColumn": 35,
                   "startLine": 7
                 }
@@ -22,22 +26,26 @@
             }
           ],
           "message": {
-            "text": "got unexpected character '\"' while lexing expression, expecting 'a'..'z', 'A'..'Z', '_', '0'..'9', ''', '}', '(', ')', '[', ']', '.', '!', '<', '>', '=', '&', '|', '*', ',', ' '. do you mean string literals? only single quotes are available for string delimiter [expression]"
+            "text": "got unexpected character '\"' while lexing expression, expecting 'a'..'z', 'A'..'Z', '_', '0'..'9', ''', '}', '(', ')', '[', ']', '.', '!', '<', '>', '=', '&', '|', '*', ',', ' '. do you mean string literals? only single quotes are available for string delimiter"
           },
           "properties": {
             "linter_name": "actionlint"
           },
-          "ruleId": "actionlint/diagnostic"
+          "ruleId": "expression"
         },
         {
-          "level": "error",
           "locations": [
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": ".github/workflows/workflow.yml"
+                  "uri": ".github/workflows/workflow.yml",
+                  "uriBaseId": "%SRCROOT%"
                 },
                 "region": {
+                  "endColumn": 12,
+                  "snippet": {
+                    "text": "      - run: echo \"${{ github.ref \"\n        ^~~~"
+                  },
                   "startColumn": 9,
                   "startLine": 7
                 }
@@ -45,22 +53,26 @@
             }
           ],
           "message": {
-            "text": "shellcheck reported issue in this script: SC1009:info:1:7: The mentioned syntax error was in this parameter expansion [shellcheck]"
+            "text": "shellcheck reported issue in this script: SC1009:info:1:7: The mentioned syntax error was in this parameter expansion"
           },
           "properties": {
             "linter_name": "actionlint"
           },
-          "ruleId": "SC1009"
+          "ruleId": "shellcheck"
         },
         {
-          "level": "error",
           "locations": [
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": ".github/workflows/workflow.yml"
+                  "uri": ".github/workflows/workflow.yml",
+                  "uriBaseId": "%SRCROOT%"
                 },
                 "region": {
+                  "endColumn": 12,
+                  "snippet": {
+                    "text": "      - run: echo \"${{ github.ref \"\n        ^~~~"
+                  },
                   "startColumn": 9,
                   "startLine": 7
                 }
@@ -68,22 +80,26 @@
             }
           ],
           "message": {
-            "text": "shellcheck reported issue in this script: SC1072:error:2:1: Expected end of double quoted string. Fix any mentioned problems and try again [shellcheck]"
+            "text": "shellcheck reported issue in this script: SC1072:error:2:1: Expected end of double quoted string. Fix any mentioned problems and try again"
           },
           "properties": {
             "linter_name": "actionlint"
           },
-          "ruleId": "SC1072"
+          "ruleId": "shellcheck"
         },
         {
-          "level": "error",
           "locations": [
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": ".github/workflows/workflow.yml"
+                  "uri": ".github/workflows/workflow.yml",
+                  "uriBaseId": "%SRCROOT%"
                 },
                 "region": {
+                  "endColumn": 12,
+                  "snippet": {
+                    "text": "      - run: echo \"${{ github.ref \"\n        ^~~~"
+                  },
                   "startColumn": 9,
                   "startLine": 7
                 }
@@ -91,12 +107,12 @@
             }
           ],
           "message": {
-            "text": "shellcheck reported issue in this script: SC1073:error:1:22: Couldn't parse this double quoted string. Fix to allow more checks [shellcheck]"
+            "text": "shellcheck reported issue in this script: SC1073:error:1:22: Couldn't parse this double quoted string. Fix to allow more checks"
           },
           "properties": {
             "linter_name": "actionlint"
           },
-          "ruleId": "SC1073"
+          "ruleId": "shellcheck"
         }
       ],
       "tool": {
@@ -105,31 +121,258 @@
           "name": "linter-service/actionlint",
           "rules": [
             {
-              "id": "actionlint/diagnostic",
-              "name": "actionlint/diagnostic",
-              "shortDescription": {
-                "text": "actionlint/diagnostic"
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "Checks for popular actions released on GitHub, local actions, and action calls at \"uses:\""
+              },
+              "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+              "id": "action",
+              "name": "Action",
+              "properties": {
+                "description": "Checks for popular actions released on GitHub, local actions, and action calls at \"uses:\"",
+                "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
               }
             },
             {
-              "id": "SC1009",
-              "name": "SC1009",
-              "shortDescription": {
-                "text": "SC1009"
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "Checks for credentials in \"services:\" configuration"
+              },
+              "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+              "id": "credentials",
+              "name": "Credentials",
+              "properties": {
+                "description": "Checks for credentials in \"services:\" configuration",
+                "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
               }
             },
             {
-              "id": "SC1072",
-              "name": "SC1072",
-              "shortDescription": {
-                "text": "SC1072"
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "Checks for deprecated \"set-output\", \"save-state\", \"set-env\", and \"add-path\" commands at \"run:\""
+              },
+              "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+              "id": "deprecated-commands",
+              "name": "DeprecatedCommands",
+              "properties": {
+                "description": "Checks for deprecated \"set-output\", \"save-state\", \"set-env\", and \"add-path\" commands at \"run:\"",
+                "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
               }
             },
             {
-              "id": "SC1073",
-              "name": "SC1073",
-              "shortDescription": {
-                "text": "SC1073"
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "Checks for environment variables configuration at \"env:\""
+              },
+              "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+              "id": "env-var",
+              "name": "EnvVar",
+              "properties": {
+                "description": "Checks for environment variables configuration at \"env:\"",
+                "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "Checks for workflow trigger events at \"on:\""
+              },
+              "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+              "id": "events",
+              "name": "Events",
+              "properties": {
+                "description": "Checks for workflow trigger events at \"on:\"",
+                "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "Syntax and semantics checks for expressions embedded with ${{ }} syntax"
+              },
+              "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+              "id": "expression",
+              "name": "Expression",
+              "properties": {
+                "description": "Syntax and semantics checks for expressions embedded with ${{ }} syntax",
+                "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "Checks for glob syntax used in branch names, tags, and paths"
+              },
+              "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+              "id": "glob",
+              "name": "Glob",
+              "properties": {
+                "description": "Checks for glob syntax used in branch names, tags, and paths",
+                "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "Checks for duplication and naming convention of job/step IDs"
+              },
+              "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+              "id": "id",
+              "name": "Id",
+              "properties": {
+                "description": "Checks for duplication and naming convention of job/step IDs",
+                "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "Checks for if: conditions which are always true/false"
+              },
+              "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+              "id": "if-cond",
+              "name": "IfCond",
+              "properties": {
+                "description": "Checks for if: conditions which are always true/false",
+                "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "Checks for job IDs in \"needs:\". Undefined IDs and cyclic dependencies are checked"
+              },
+              "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+              "id": "job-needs",
+              "name": "JobNeeds",
+              "properties": {
+                "description": "Checks for job IDs in \"needs:\". Undefined IDs and cyclic dependencies are checked",
+                "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "Checks for matrix combinations in \"matrix:\""
+              },
+              "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+              "id": "matrix",
+              "name": "Matrix",
+              "properties": {
+                "description": "Checks for matrix combinations in \"matrix:\"",
+                "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "Checks for permissions configuration in \"permissions:\". Permission names and permission scopes are checked"
+              },
+              "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+              "id": "permissions",
+              "name": "Permissions",
+              "properties": {
+                "description": "Checks for permissions configuration in \"permissions:\". Permission names and permission scopes are checked",
+                "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "Checks for GitHub-hosted and preset self-hosted runner labels in \"runs-on:\""
+              },
+              "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+              "id": "runner-label",
+              "name": "RunnerLabel",
+              "properties": {
+                "description": "Checks for GitHub-hosted and preset self-hosted runner labels in \"runs-on:\"",
+                "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "Checks for shell names used for scripts in \"run:\""
+              },
+              "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+              "id": "shell-name",
+              "name": "ShellName",
+              "properties": {
+                "description": "Checks for shell names used for scripts in \"run:\"",
+                "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "Checks for shell script sources in \"run:\" using shellcheck"
+              },
+              "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+              "id": "shellcheck",
+              "name": "Shellcheck",
+              "properties": {
+                "description": "Checks for shell script sources in \"run:\" using shellcheck",
+                "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "Checks for GitHub Actions workflow syntax"
+              },
+              "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+              "id": "syntax-check",
+              "name": "SyntaxCheck",
+              "properties": {
+                "description": "Checks for GitHub Actions workflow syntax",
+                "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "Checks for reusable workflow calls. Inputs and outputs of called reusable workflow are checked"
+              },
+              "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+              "id": "workflow-call",
+              "name": "WorkflowCall",
+              "properties": {
+                "description": "Checks for reusable workflow calls. Inputs and outputs of called reusable workflow are checked",
+                "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
               }
             }
           ]

--- a/actionlint/tests/pass/result.json
+++ b/actionlint/tests/pass/result.json
@@ -1,8 +1,280 @@
 {
   "checked_projects": [],
   "result": {
-    "details": "",
-    "exit_code": 0
+    "exit_code": 0,
+    "sarif": {
+      "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+      "runs": [
+        {
+          "results": [],
+          "tool": {
+            "driver": {
+              "informationUri": "https://github.com/rhysd/actionlint",
+              "name": "GitHub Actions lint",
+              "rules": [
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for popular actions released on GitHub, local actions, and action calls at \"uses:\""
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "action",
+                  "name": "Action",
+                  "properties": {
+                    "description": "Checks for popular actions released on GitHub, local actions, and action calls at \"uses:\"",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for credentials in \"services:\" configuration"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "credentials",
+                  "name": "Credentials",
+                  "properties": {
+                    "description": "Checks for credentials in \"services:\" configuration",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for deprecated \"set-output\", \"save-state\", \"set-env\", and \"add-path\" commands at \"run:\""
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "deprecated-commands",
+                  "name": "DeprecatedCommands",
+                  "properties": {
+                    "description": "Checks for deprecated \"set-output\", \"save-state\", \"set-env\", and \"add-path\" commands at \"run:\"",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for environment variables configuration at \"env:\""
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "env-var",
+                  "name": "EnvVar",
+                  "properties": {
+                    "description": "Checks for environment variables configuration at \"env:\"",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for workflow trigger events at \"on:\""
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "events",
+                  "name": "Events",
+                  "properties": {
+                    "description": "Checks for workflow trigger events at \"on:\"",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Syntax and semantics checks for expressions embedded with ${{ }} syntax"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "expression",
+                  "name": "Expression",
+                  "properties": {
+                    "description": "Syntax and semantics checks for expressions embedded with ${{ }} syntax",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for glob syntax used in branch names, tags, and paths"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "glob",
+                  "name": "Glob",
+                  "properties": {
+                    "description": "Checks for glob syntax used in branch names, tags, and paths",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for duplication and naming convention of job/step IDs"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "id",
+                  "name": "Id",
+                  "properties": {
+                    "description": "Checks for duplication and naming convention of job/step IDs",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for if: conditions which are always true/false"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "if-cond",
+                  "name": "IfCond",
+                  "properties": {
+                    "description": "Checks for if: conditions which are always true/false",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for job IDs in \"needs:\". Undefined IDs and cyclic dependencies are checked"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "job-needs",
+                  "name": "JobNeeds",
+                  "properties": {
+                    "description": "Checks for job IDs in \"needs:\". Undefined IDs and cyclic dependencies are checked",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for matrix combinations in \"matrix:\""
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "matrix",
+                  "name": "Matrix",
+                  "properties": {
+                    "description": "Checks for matrix combinations in \"matrix:\"",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for permissions configuration in \"permissions:\". Permission names and permission scopes are checked"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "permissions",
+                  "name": "Permissions",
+                  "properties": {
+                    "description": "Checks for permissions configuration in \"permissions:\". Permission names and permission scopes are checked",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for GitHub-hosted and preset self-hosted runner labels in \"runs-on:\""
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "runner-label",
+                  "name": "RunnerLabel",
+                  "properties": {
+                    "description": "Checks for GitHub-hosted and preset self-hosted runner labels in \"runs-on:\"",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for shell names used for scripts in \"run:\""
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "shell-name",
+                  "name": "ShellName",
+                  "properties": {
+                    "description": "Checks for shell names used for scripts in \"run:\"",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for shell script sources in \"run:\" using shellcheck"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "shellcheck",
+                  "name": "Shellcheck",
+                  "properties": {
+                    "description": "Checks for shell script sources in \"run:\" using shellcheck",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for GitHub Actions workflow syntax"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "syntax-check",
+                  "name": "SyntaxCheck",
+                  "properties": {
+                    "description": "Checks for GitHub Actions workflow syntax",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                },
+                {
+                  "defaultConfiguration": {
+                    "level": "error"
+                  },
+                  "fullDescription": {
+                    "text": "Checks for reusable workflow calls. Inputs and outputs of called reusable workflow are checked"
+                  },
+                  "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+                  "id": "workflow-call",
+                  "name": "WorkflowCall",
+                  "properties": {
+                    "description": "Checks for reusable workflow calls. Inputs and outputs of called reusable workflow are checked",
+                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                  }
+                }
+              ],
+              "version": "1.7.12"
+            }
+          }
+        }
+      ],
+      "version": "2.1.0"
+    }
   },
   "selected_files": [
     ".github/workflows/workflow.yml"


### PR DESCRIPTION
## Summary
- switch `actionlint/run.sh` from plain output capture to native SARIF output using the upstream SARIF template
- emit `{ exit_code, sarif }` through the shared SARIF result flow and keep actionlint's native exit semantics
- add direct actionlint run tests and refresh actionlint SARIF fixture expectations