### PR TITLE
Fix repository-dispatch SARIF permissions for public repositories

### DIFF
--- a/.github/scripts/repository-dispatch-workflow.test.js
+++ b/.github/scripts/repository-dispatch-workflow.test.js
@@ -38,3 +38,155 @@ test("publish-results is gated by a safe boolean output", () => {
 		"skip-reason may be omitted from job outputs when GitHub masks it as a possible secret",
 	);
 });
+
+test("PR comment token does not request security-events permission", () => {
+	const workflow = readWorkflow();
+	const steps = workflow.jobs["publish-results"].steps;
+	const prTokenStep = steps.find((s) => s.id === "get_pr_token");
+
+	assert.ok(prTokenStep, "get_pr_token step must exist");
+	assert.equal(
+		prTokenStep.with["permission-pull-requests"],
+		"write",
+		"PR token must request pull-requests: write",
+	);
+	assert.equal(
+		prTokenStep.with["permission-security-events"],
+		undefined,
+		"PR token must not request security-events permission",
+	);
+	assert.equal(
+		prTokenStep["continue-on-error"],
+		undefined,
+		"PR token step must not suppress errors",
+	);
+});
+
+test("SARIF token is a separate step with continue-on-error", () => {
+	const workflow = readWorkflow();
+	const steps = workflow.jobs["publish-results"].steps;
+	const sarifTokenStep = steps.find((s) => s.id === "get_sarif_token");
+
+	assert.ok(sarifTokenStep, "get_sarif_token step must exist");
+	assert.equal(
+		sarifTokenStep.if,
+		`${expressionPrefix}always() }}`,
+		"SARIF token step must run even when earlier publication steps fail",
+	);
+	assert.equal(
+		sarifTokenStep.with["permission-security-events"],
+		"write",
+		"SARIF token must request security-events: write",
+	);
+	assert.equal(
+		sarifTokenStep.with["permission-pull-requests"],
+		undefined,
+		"SARIF token must not request pull-requests permission",
+	);
+	assert.equal(
+		sarifTokenStep["continue-on-error"],
+		true,
+		"SARIF token step must have continue-on-error: true",
+	);
+});
+
+test("SARIF upload uses SARIF token and only runs when token was obtained", () => {
+	const workflow = readWorkflow();
+	const steps = workflow.jobs["publish-results"].steps;
+	const uploadStep = steps.find((s) => s.id === "upload_sarif");
+
+	assert.ok(uploadStep, "upload_sarif step must exist");
+	assert.match(
+		uploadStep.if,
+		/steps\.get_sarif_token\.outcome == 'success'/u,
+		"upload_sarif must be gated on get_sarif_token outcome",
+	);
+	assert.match(
+		uploadStep.with["github-token"],
+		/steps\.get_sarif_token\.outputs\.token/u,
+		"upload_sarif must use the SARIF token, not the PR comment token",
+	);
+	assert.doesNotMatch(
+		uploadStep.with["github-token"],
+		/get_pr_token/u,
+		"upload_sarif must not use the PR comment token",
+	);
+});
+
+test("PR comment step uses PR token", () => {
+	const workflow = readWorkflow();
+	const steps = workflow.jobs["publish-results"].steps;
+	const commentStep = steps.find(
+		(s) => s.name === "Upsert combined PR comment",
+	);
+
+	assert.ok(commentStep, "Upsert combined PR comment step must exist");
+	assert.match(
+		commentStep.with["github-token"],
+		/steps\.get_pr_token\.outputs\.token/u,
+		"PR comment step must use the PR token",
+	);
+	assert.doesNotMatch(
+		commentStep.with["github-token"],
+		/get_sarif_token/u,
+		"PR comment step must not use the SARIF token",
+	);
+});
+
+test("deselected SARIF failure step also triggers when upload is skipped", () => {
+	const workflow = readWorkflow();
+	const steps = workflow.jobs["publish-results"].steps;
+	const failStep = steps.find(
+		(s) => s.name === "Fail workflow when deselected SARIF upload fails",
+	);
+
+	assert.ok(failStep, "deselected SARIF failure step must exist");
+	assert.match(
+		failStep.if,
+		/steps\.upload_sarif\.outcome == 'failure'/u,
+		"must still trigger on upload failure",
+	);
+	assert.match(
+		failStep.if,
+		/steps\.upload_sarif\.outcome == 'skipped'/u,
+		"must also trigger when upload was skipped due to missing token",
+	);
+	assert.match(
+		failStep.run,
+		/could not be completed/u,
+		"must use wording that also fits skipped uploads",
+	);
+});
+
+test("deselected SARIF permission skips are diagnosed explicitly", () => {
+	const workflow = readWorkflow();
+	const steps = workflow.jobs["publish-results"].steps;
+	const diagnosticStep = steps.find(
+		(s) => s.name === "Diagnose deselected SARIF permission errors",
+	);
+
+	assert.ok(
+		diagnosticStep,
+		"Diagnose deselected SARIF permission errors step must exist",
+	);
+	assert.match(
+		diagnosticStep.if,
+		/steps\.upload_sarif\.outcome == 'skipped'/u,
+		"diagnostic step must only run when SARIF upload was skipped",
+	);
+	assert.match(
+		diagnosticStep.if,
+		/steps\.get_sarif_token\.outcome == 'failure'/u,
+		"diagnostic step must point at SARIF token acquisition failures",
+	);
+	assert.match(
+		diagnosticStep.run,
+		/::error::/u,
+		"diagnostic step must emit a workflow error annotation",
+	);
+	assert.doesNotMatch(
+		diagnosticStep.run,
+		/>&2/u,
+		"workflow command annotations must be written to stdout",
+	);
+});

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -758,6 +758,16 @@ jobs:
           app-id: ${{ secrets.CHECKER_APP_ID }}
           owner: ${{ steps.decode_repository_context.outputs.pr-owner }}
           permission-pull-requests: write
+          private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
+          repositories: ${{ steps.decode_repository_context.outputs.pr-repo }}
+      - name: Get PR repository SARIF token
+        id: get_sarif_token
+        if: ${{ always() }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.CHECKER_APP_ID }}
+          owner: ${{ steps.decode_repository_context.outputs.pr-owner }}
           permission-security-events: write
           private-key: ${{ secrets.CHECKER_PRIVATE_KEY }}
           repositories: ${{ steps.decode_repository_context.outputs.pr-repo }}
@@ -870,7 +880,7 @@ jobs:
             await upsertPullRequestComment({ github, env: process.env });
       - name: Upload SARIF artifacts
         id: upload_sarif
-        if: ${{ always() }}
+        if: ${{ always() && steps.get_sarif_token.outcome == 'success' }}
         continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
@@ -882,7 +892,7 @@ jobs:
           SARIF_REPO: ${{ steps.decode_repository_context.outputs.pr-repo }}
           SARIF_ROOT: ${{ runner.temp }}/linter-sarif-upload
         with:
-          github-token: ${{ steps.get_pr_token.outputs.token }}
+          github-token: ${{ steps.get_sarif_token.outputs.token }}
           script: |
             const uploadSarif = require(
               `${process.env.LINTER_SERVICE_PATH}/.github/scripts/upload-sarif.js`,
@@ -892,6 +902,7 @@ jobs:
         id: prepare_final_summary
         if: ${{ always() && needs.detect-targets.outputs.selected-linters-json != '[]' }}
         env:
+          GET_SARIF_TOKEN_OUTCOME: ${{ steps.get_sarif_token.outcome }}
           OVERALL_CONCLUSION: ${{ steps.prepare_report.outcome == 'success' && steps.prepare_report.outputs.overall_conclusion || 'failure' }}
           OVERALL_STATUS: ${{ steps.prepare_report.outcome == 'success' && steps.prepare_report.outputs.overall_status || 'failure' }}
           OVERALL_SUMMARY: ${{ steps.prepare_report.outcome == 'success' && steps.prepare_report.outputs.overall_summary || 'The linter-service workflow failed to generate a combined report.' }}
@@ -901,6 +912,7 @@ jobs:
           import os
           from pathlib import Path
 
+          get_sarif_token_outcome = os.environ.get("GET_SARIF_TOKEN_OUTCOME", "")
           overall_conclusion = os.environ["OVERALL_CONCLUSION"]
           overall_status = os.environ["OVERALL_STATUS"]
           overall_summary = os.environ["OVERALL_SUMMARY"]
@@ -919,6 +931,10 @@ jobs:
 
           if upload_sarif_outcome == "failure":
               summary = f"{overall_summary} Warning: SARIF upload failed; see the workflow logs."
+              if conclusion == "success":
+                  title = "linter-service completed with warnings"
+          elif upload_sarif_outcome == "skipped" and get_sarif_token_outcome == "failure":
+              summary = f"{overall_summary} Warning: SARIF upload skipped; security-events permission could not be obtained."
               if conclusion == "success":
                   title = "linter-service completed with warnings"
 
@@ -964,8 +980,12 @@ jobs:
         run: |
           echo "$SUMMARY" >&2
           exit 1
-      - name: Fail workflow when deselected SARIF upload fails
-        if: ${{ needs.detect-targets.outputs.selected-linters-json == '[]' && steps.upload_sarif.outcome == 'failure' }}
+      - name: Diagnose deselected SARIF permission errors
+        if: ${{ needs.detect-targets.outputs.selected-linters-json == '[]' && steps.upload_sarif.outcome == 'skipped' && steps.get_sarif_token.outcome == 'failure' }}
         run: |
-          echo "SARIF upload failed while clearing deselected linter results. See the workflow logs." >&2
+          echo "::error::Cannot clear deselected SARIF results because the GitHub App could not obtain security-events: write on this repository."
+      - name: Fail workflow when deselected SARIF upload fails
+        if: ${{ needs.detect-targets.outputs.selected-linters-json == '[]' && (steps.upload_sarif.outcome == 'failure' || steps.upload_sarif.outcome == 'skipped') }}
+        run: |
+          echo "SARIF upload could not be completed while clearing deselected linter results. See the workflow logs." >&2
           exit 1

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: disable
+  document-start: disable
+  line-length: disable
+  truthy:
+    check-keys: false


### PR DESCRIPTION
## Summary
- split the repository-dispatch PR comment and SARIF GitHub App tokens
- make SARIF token acquisition non-blocking so missing security-events permission degrades to a warning instead of blocking result publication
- add regression tests and a repo-root .yamllint config that matches the repo's existing yamllint defaults

## Validation
- shared Node tests from `.github/workflows/ci.yml`
- `npm --prefix worker run check`
- `yamllint .github/workflows/repository-dispatch.yml .yamllint`