### PR TITLE
fix(cargo-coupling): stabilize fixture verification

### DIFF
--- a/cargo-coupling/cargo-coupling-result.js
+++ b/cargo-coupling/cargo-coupling-result.js
@@ -112,8 +112,12 @@ function normalizeCargoCouplingJsonOutput(jsonOutput) {
 		return jsonOutput;
 	}
 
-	return {
-		...jsonOutput,
+	const normalized = {
+		...(Object.hasOwn(jsonOutput, "summary")
+			? {
+					summary: normalizeCargoCouplingSummary(jsonOutput.summary),
+				}
+			: {}),
 		...(Array.isArray(jsonOutput.circular_dependencies)
 			? {
 					circular_dependencies: [...jsonOutput.circular_dependencies]
@@ -130,7 +134,9 @@ function normalizeCargoCouplingJsonOutput(jsonOutput) {
 			: {}),
 		...(Array.isArray(jsonOutput.issues)
 			? {
-					issues: [...jsonOutput.issues].sort(compareCargoCouplingIssues),
+					issues: [...jsonOutput.issues]
+						.map((issue) => normalizeCargoCouplingIssue(issue))
+						.sort(compareCargoCouplingIssues),
 				}
 			: {}),
 		...(Array.isArray(jsonOutput.modules)
@@ -141,6 +147,8 @@ function normalizeCargoCouplingJsonOutput(jsonOutput) {
 				}
 			: {}),
 	};
+
+	return normalized;
 }
 
 function canonicalizeCargoCouplingCycle(cycle) {
@@ -175,17 +183,114 @@ function normalizeCargoCouplingHotspot(hotspot) {
 	}
 
 	return {
-		...hotspot,
 		...(Object.hasOwn(hotspot, "file_path")
 			? {
 					file_path: normalizeCargoCouplingPath(hotspot.file_path),
 				}
 			: {}),
-		...(Array.isArray(hotspot.issues)
+		...(Object.hasOwn(hotspot, "in_cycle")
 			? {
-					issues: [...hotspot.issues].sort(compareCargoCouplingHotspotIssues),
+					in_cycle: hotspot.in_cycle,
 				}
 			: {}),
+		...(Object.hasOwn(hotspot, "module")
+			? {
+					module: hotspot.module,
+				}
+			: {}),
+		...(Object.hasOwn(hotspot, "score")
+			? {
+					score: hotspot.score,
+				}
+			: {}),
+		...(Object.hasOwn(hotspot, "suggestion")
+			? {
+					suggestion: hotspot.suggestion,
+				}
+			: {}),
+		...(Array.isArray(hotspot.issues)
+			? {
+					issues: [...hotspot.issues]
+						.map((issue) => normalizeCargoCouplingHotspotIssue(issue))
+						.sort(compareCargoCouplingHotspotIssues),
+				}
+			: {}),
+	};
+}
+
+function normalizeCargoCouplingSummary(summary) {
+	if (!summary || typeof summary !== "object" || Array.isArray(summary)) {
+		return summary;
+	}
+
+	return {
+		...(Object.hasOwn(summary, "critical_issues")
+			? { critical_issues: summary.critical_issues }
+			: {}),
+		...(Object.hasOwn(summary, "external_couplings")
+			? { external_couplings: summary.external_couplings }
+			: {}),
+		...(Object.hasOwn(summary, "health_grade")
+			? { health_grade: summary.health_grade }
+			: {}),
+		...(Object.hasOwn(summary, "health_score")
+			? { health_score: summary.health_score }
+			: {}),
+		...(Object.hasOwn(summary, "high_issues")
+			? { high_issues: summary.high_issues }
+			: {}),
+		...(Object.hasOwn(summary, "internal_couplings")
+			? { internal_couplings: summary.internal_couplings }
+			: {}),
+		...(Object.hasOwn(summary, "medium_issues")
+			? { medium_issues: summary.medium_issues }
+			: {}),
+		...(Object.hasOwn(summary, "total_couplings")
+			? { total_couplings: summary.total_couplings }
+			: {}),
+		...(Object.hasOwn(summary, "total_modules")
+			? { total_modules: summary.total_modules }
+			: {}),
+	};
+}
+
+function normalizeCargoCouplingIssue(issue) {
+	if (!issue || typeof issue !== "object" || Array.isArray(issue)) {
+		return issue;
+	}
+
+	return {
+		...(Object.hasOwn(issue, "balance_score")
+			? { balance_score: issue.balance_score }
+			: {}),
+		...(Object.hasOwn(issue, "description")
+			? { description: issue.description }
+			: {}),
+		...(Object.hasOwn(issue, "issue_type")
+			? { issue_type: issue.issue_type }
+			: {}),
+		...(Object.hasOwn(issue, "severity") ? { severity: issue.severity } : {}),
+		...(Object.hasOwn(issue, "source") ? { source: issue.source } : {}),
+		...(Object.hasOwn(issue, "suggestion")
+			? { suggestion: issue.suggestion }
+			: {}),
+		...(Object.hasOwn(issue, "target") ? { target: issue.target } : {}),
+	};
+}
+
+function normalizeCargoCouplingHotspotIssue(issue) {
+	if (!issue || typeof issue !== "object" || Array.isArray(issue)) {
+		return issue;
+	}
+
+	return {
+		...(Object.hasOwn(issue, "description")
+			? { description: issue.description }
+			: {}),
+		...(Object.hasOwn(issue, "issue_type")
+			? { issue_type: issue.issue_type }
+			: {}),
+		...(Object.hasOwn(issue, "severity") ? { severity: issue.severity } : {}),
 	};
 }
 
@@ -195,12 +300,22 @@ function normalizeCargoCouplingModule(module) {
 	}
 
 	return {
-		...module,
+		...(Object.hasOwn(module, "balance_score")
+			? { balance_score: module.balance_score }
+			: {}),
+		...(Object.hasOwn(module, "couplings_in")
+			? { couplings_in: module.couplings_in }
+			: {}),
+		...(Object.hasOwn(module, "couplings_out")
+			? { couplings_out: module.couplings_out }
+			: {}),
 		...(Object.hasOwn(module, "file_path")
 			? {
 					file_path: normalizeCargoCouplingPath(module.file_path),
 				}
 			: {}),
+		...(Object.hasOwn(module, "in_cycle") ? { in_cycle: module.in_cycle } : {}),
+		...(Object.hasOwn(module, "name") ? { name: module.name } : {}),
 	};
 }
 

--- a/cargo-coupling/cargo-coupling-result.test.js
+++ b/cargo-coupling/cargo-coupling-result.test.js
@@ -204,16 +204,21 @@ test("buildCargoCouplingResult normalizes unstable cargo-coupling ordering and /
 				stderr:
 					"Analyzing project at 'src'...\nAnalysis complete: 3 files, 3 modules\n",
 				stdout: JSON.stringify({
+					extra_top_level_field: {
+						version: "0.3.3",
+					},
 					circular_dependencies: [
 						["fixture-fail::query", "fixture-fail::handler"],
 					],
 					hotspots: [
 						{
+							diagnostics: ["ignore me"],
 							file_path: "/work/src/query.rs",
 							in_cycle: true,
 							issues: [
 								{
 									description: "Part of a circular dependency cycle",
+									extra: true,
 									issue_type: "CircularDependency",
 									severity: "Critical",
 								},
@@ -231,6 +236,7 @@ test("buildCargoCouplingResult normalizes unstable cargo-coupling ordering and /
 									description: "Part of a circular dependency cycle",
 									issue_type: "CircularDependency",
 									severity: "Critical",
+									version: "new",
 								},
 							],
 							module: "fixture-fail::handler",
@@ -239,7 +245,22 @@ test("buildCargoCouplingResult normalizes unstable cargo-coupling ordering and /
 								"Break circular dependency by extracting shared types or inverting with traits",
 						},
 					],
-					issues: [],
+					issues: [
+						{
+							balance_score: 0.24,
+							description:
+								"Intrusive coupling across a distant module boundary",
+							issue_type: "Global Complexity",
+							metadata: {
+								threshold: "new",
+							},
+							severity: "Critical",
+							source: "fixture-fail::handler",
+							suggestion:
+								"Break the direct dependency by introducing an abstraction.",
+							target: "fixture-fail::query",
+						},
+					],
 					modules: [
 						{
 							balance_score: 1,
@@ -247,6 +268,7 @@ test("buildCargoCouplingResult normalizes unstable cargo-coupling ordering and /
 							couplings_out: 0,
 							file_path: "/work/src/query.rs",
 							in_cycle: false,
+							item_count: 3,
 							name: "query",
 						},
 						{
@@ -273,7 +295,11 @@ test("buildCargoCouplingResult normalizes unstable cargo-coupling ordering and /
 						health_score: 0.75,
 						high_issues: 0,
 						internal_couplings: 2,
+						low_issues: 4,
 						medium_issues: 0,
+						subdomains: {
+							core: 1,
+						},
 						total_couplings: 2,
 						total_modules: 3,
 					},
@@ -303,6 +329,33 @@ test("buildCargoCouplingResult normalizes unstable cargo-coupling ordering and /
 			(entry) => entry.file_path,
 		),
 		["src/handler.rs", "src/query.rs"],
+	);
+	assert.deepEqual(result.cargo_coupling_runs[0].json_output.issues, [
+		{
+			balance_score: 0.24,
+			description: "Intrusive coupling across a distant module boundary",
+			issue_type: "Global Complexity",
+			severity: "Critical",
+			source: "fixture-fail::handler",
+			suggestion: "Break the direct dependency by introducing an abstraction.",
+			target: "fixture-fail::query",
+		},
+	]);
+	assert.equal(
+		"extra_top_level_field" in result.cargo_coupling_runs[0].json_output,
+		false,
+	);
+	assert.equal(
+		"low_issues" in result.cargo_coupling_runs[0].json_output.summary,
+		false,
+	);
+	assert.equal(
+		"item_count" in result.cargo_coupling_runs[0].json_output.modules[0],
+		false,
+	);
+	assert.equal(
+		"diagnostics" in result.cargo_coupling_runs[0].json_output.hotspots[0],
+		false,
 	);
 	assert.match(
 		result.details,

--- a/cargo-coupling/cargo-coupling.test.js
+++ b/cargo-coupling/cargo-coupling.test.js
@@ -16,6 +16,25 @@ const {
 const installPath = path.join(__dirname, "install.sh");
 const commonPath = path.join(__dirname, "common.sh");
 const runPath = path.join(__dirname, "run.sh");
+const cargoCouplingVersion = readInstallAssignment("cargo_coupling_version");
+const cargoCouplingSemver = cargoCouplingVersion.replace(/^v/u, "");
+
+function readInstallAssignment(variableName) {
+	const source = fs.readFileSync(installPath, "utf8");
+	const match = source.match(
+		new RegExp(`^${variableName}="([^"\\n]+)"$`, "mu"),
+	);
+
+	if (!match) {
+		throw new Error(`failed to read ${variableName} from ${installPath}`);
+	}
+
+	return match[1];
+}
+
+function escapeRegExp(value) {
+	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
 
 function createCargoStub(binDir) {
 	writeExecutable(
@@ -438,7 +457,7 @@ function createCargoCouplingSourceArchive(context) {
 		path.join(archiveRoot, "Cargo.toml"),
 		`[package]
 name = "cargo-coupling"
-version = "0.3.2"
+version = "${cargoCouplingSemver}"
 edition = "2021"
 `,
 	);
@@ -570,15 +589,24 @@ test("cargo-coupling install builds the pinned local container image when missin
 
 		assert.match(
 			fs.readFileSync(tooling.dockerImageInspectLog, "utf8"),
-			/localhost\/linter-service-cargo-coupling:0\.3\.2-[a-f0-9]{12}/,
+			new RegExp(
+				`localhost/linter-service-cargo-coupling:${escapeRegExp(cargoCouplingSemver)}-[a-f0-9]{12}`,
+				"u",
+			),
 		);
 		assert.match(
 			fs.readFileSync(tooling.curlLog, "utf8"),
-			/github\.com\/nwiizo\/cargo-coupling\/archive\/refs\/tags\/v0\.3\.2\.tar\.gz/,
+			new RegExp(
+				`github\\.com/nwiizo/cargo-coupling/archive/refs/tags/${escapeRegExp(cargoCouplingVersion)}\\.tar\\.gz`,
+				"u",
+			),
 		);
 		assert.match(
 			fs.readFileSync(tooling.dockerBuildLog, "utf8"),
-			/--tag localhost\/linter-service-cargo-coupling:0\.3\.2-[a-f0-9]{12}/,
+			new RegExp(
+				`--tag localhost/linter-service-cargo-coupling:${escapeRegExp(cargoCouplingSemver)}-[a-f0-9]{12}`,
+				"u",
+			),
 		);
 		assert.match(
 			fs.readFileSync(tooling.dockerBuildLog, "utf8"),
@@ -593,7 +621,7 @@ test("cargo-coupling install builds the pinned local container image when missin
 test("cargo-coupling image ref changes when build inputs change", () => {
 	const defaultEnv = {
 		...process.env,
-		CARGO_COUPLING_VERSION: "v0.3.2",
+		CARGO_COUPLING_VERSION: cargoCouplingVersion,
 		CARGO_COUPLING_SOURCE_ARCHIVE_SHA256:
 			"1111111111111111111111111111111111111111111111111111111111111111",
 	};
@@ -624,7 +652,10 @@ test("cargo-coupling image ref changes when build inputs change", () => {
 	assert.notEqual(defaultImageRef, alternateImageRef);
 	assert.match(
 		defaultImageRef,
-		/^localhost\/linter-service-cargo-coupling:0\.3\.2-[a-f0-9]{12}$/u,
+		new RegExp(
+			`^localhost/linter-service-cargo-coupling:${escapeRegExp(cargoCouplingSemver)}-[a-f0-9]{12}$`,
+			"u",
+		),
 	);
 });
 

--- a/cargo-coupling/install.sh
+++ b/cargo-coupling/install.sh
@@ -55,7 +55,7 @@ verify_source_archive_sha256() {
 trap cleanup_build_root EXIT
 
 curl -fsSL "$source_url" -o "$archive_path"
-# verify_source_archive_sha256 "$archive_path"
+verify_source_archive_sha256 "$archive_path"
 tar -xzf "$archive_path" -C "$source_dir" --strip-components=1
 cp "$script_dir/Dockerfile.full" "$dockerfile_path"
 


### PR DESCRIPTION
## Summary
- narrow cargo-coupling fixture normalization to stable downstream-consumed JSON fields so upstream version-added fields do not break deep-equal snapshot checks
- add regression coverage for extra upstream JSON fields and make cargo-coupling install tests derive their version expectations from install.sh
- restore cargo-coupling source archive checksum verification during install

## Testing
- node --test cargo-coupling/cargo-coupling-result.test.js cargo-coupling/cargo-coupling.test.js .github/scripts/run-fixture-tests.test.js